### PR TITLE
Add missing SPDX license headers to 3 test files

### DIFF
--- a/bpf/tests/test_integration.py
+++ b/bpf/tests/test_integration.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 eunomia-bpf org.
 """
 Integration tests for the process_new eBPF tracer.
 

--- a/docs/mcp-test/test_mcp_cli.py
+++ b/docs/mcp-test/test_mcp_cli.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 eunomia-bpf org.
 """Minimal MCP client that exercises the test server over stdio or HTTP."""
 
 from __future__ import annotations

--- a/docs/mcp-test/test_mcp_server.py
+++ b/docs/mcp-test/test_mcp_server.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 eunomia-bpf org.
 """Minimal MCP test server supporting stdio and HTTP transports."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Added `SPDX-License-Identifier: MIT` and copyright headers to 3 Python test files that were missing them:
  - `docs/mcp-test/test_mcp_cli.py`
  - `docs/mcp-test/test_mcp_server.py`
  - `bpf/tests/test_integration.py`

All other source files in the repo already have proper SPDX headers. This ensures complete license compliance across the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)