### PR TITLE
fix: auto-discover Node's static OpenSSL binary for SSL capture (#42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,9 +120,14 @@ This logic is in `run_trace()` in `collector/src/main.rs` (around line 485).
 - **`ssl`** — Raw SSL events only. Passes extra args directly to sslsniff after `--`.
 - **`process`** — Process events only.
 
+## SSL Binary Auto-Discovery (record/trace)
+
+In `run_trace()`, when SSL is enabled and `--binary-path` is absent, the binary is auto-discovered from `--comm`: `resolve_binary_path(comm)` resolves the binary, and it is adopted **only if `binary_embeds_ssl()` returns true** (the binary contains the `SSL_write` symbol-name string). This fixes `record -c node` (Node statically links OpenSSL — no system `libssl.so` to hook) while leaving dynamically-linked runtimes like Python on sslsniff's system-libssl + comm-filter path. `exec` resolves unconditionally (it targets one known program); `record`/`trace` gate on `binary_embeds_ssl()` to avoid over-capturing for Python.
+
 ## Common Issues
 
-- **No SSL capture from Claude/Bun**: Must use `--binary-path` pointing to the actual binary. BoringSSL is statically linked and stripped.
+- **No SSL capture from Claude/Bun**: Must use `--binary-path` pointing to the actual binary (or use `exec`). BoringSSL is statically linked and stripped.
+- **No SSL capture from Node.js / Gemini CLI**: All Node.js statically links OpenSSL. `record -c node` now auto-discovers the Node binary; `exec -- gemini` also works. An HTTP/HTTPS proxy does not affect capture (TLS still happens in-process at `SSL_*`).
 - **`--comm` filter drops all SSL events**: SSL runs on "HTTP Client" thread, not the process name thread. Fixed: `--comm` is auto-skipped for sslsniff when `--binary-path` is set.
 - **eBPF permission errors**: Requires `sudo` or `CAP_BPF` + `CAP_SYS_ADMIN`.
 - **Port 7395 conflict**: Default web server port. Change with `--server-port`.

--- a/README.md
+++ b/README.md
@@ -267,16 +267,32 @@ sudo ./agentsight record -c "python" --server-port 8080 --log-file /tmp/agent.lo
 
 #### Monitoring Node.js AI Tools (Gemini CLI, etc.)
 
-For Node.js applications installed via NVM that statically link OpenSSL, use
-`--binary-path` to point to the actual Node.js binary:
+> **Important**: Node.js (both NVM and system installs) **statically links
+> OpenSSL into the `node` binary** — there is no system `libssl.so` to hook.
+> SSL capture therefore requires pointing sslsniff at the `node` binary itself.
+
+The easiest way is `exec`, which discovers the `node` binary automatically:
 
 ```bash
-# Monitor Gemini CLI or other Node.js AI tools
-sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/node
-
-# Or with system Node.js (uses dynamic libssl, no --binary-path needed)
-sudo ./agentsight record -c node
+# Gemini CLI runs on Node — exec finds the right binary and traces it
+sudo ./agentsight exec -- gemini
 ```
+
+With `record`, AgentSight now auto-discovers the Node binary from `-c node`
+(it detects that Node embeds OpenSSL and attaches to the binary instead of a
+system library), so this just works without `--binary-path`:
+
+```bash
+# Monitor Gemini CLI or other Node.js AI tools — binary auto-discovered
+sudo ./agentsight record -c node
+
+# Pin the binary explicitly if auto-discovery picks the wrong Node install
+sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/node
+```
+
+> **Behind an HTTP/HTTPS proxy?** Traffic is still TLS-encrypted inside the
+> Node process (the proxy only tunnels it), so AgentSight captures it the same
+> way — at the `SSL_read`/`SSL_write` calls before encryption.
 
 #### Advanced Monitoring
 
@@ -370,8 +386,8 @@ A: Yes, use combined monitoring modes for concurrent multi-agent observation wit
 **Q: How do I filter sensitive data?**  
 A: Built-in analyzers can remove authentication headers and filter specific content patterns.
 
-**Q: Why doesn't AgentSight capture traffic from Claude Code or NVM Node.js?**
-A: These applications statically link their SSL library (BoringSSL for Claude/Bun, OpenSSL for NVM Node.js) instead of using system `libssl.so`. Use `--binary-path` to point to the actual binary so AgentSight can auto-detect SSL functions via byte-pattern matching. See the "Monitoring Claude Code" and "Monitoring Node.js AI Tools" sections for examples.
+**Q: Why doesn't AgentSight capture traffic from Claude Code, Node.js, or Gemini CLI?**
+A: These applications statically link their SSL library (BoringSSL for Claude/Bun, OpenSSL for **all** Node.js — both NVM and system installs) into their own binary instead of using system `libssl.so`, so there's nothing for sslsniff to hook by default. AgentSight handles this for you: `exec` always discovers the binary, and `record -c node` now auto-discovers the Node binary too. For Claude, pass `--binary-path` (or use `exec`). See the "Zero-Config: exec" and "Monitoring Node.js AI Tools" sections.
 
 **Q: Why does `--comm claude` not capture SSL traffic?**
 A: Claude Code's SSL traffic runs on an internal "HTTP Client" thread, not the main "claude" thread. The `--comm` filter in sslsniff matches thread name (from `bpf_get_current_comm()`), not process name. When using `--binary-path`, the collector automatically skips the `--comm` filter for SSL monitoring.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -257,15 +257,29 @@ sudo ./agentsight record -c "python" --server-port 8080 --log-file /tmp/agent.lo
 
 #### 监控 Node.js AI 工具（Gemini CLI 等）
 
-对于通过 NVM 安装的静态链接 OpenSSL 的 Node.js 应用，使用 `--binary-path` 指向实际的 Node.js 二进制文件：
+> **重要**：Node.js（NVM 和系统安装都一样）**将 OpenSSL 静态链接进了 `node` 二进制**——
+> 没有系统 `libssl.so` 可供 hook。因此 SSL 捕获需要让 sslsniff 指向 `node` 二进制本身。
+
+最简单的方式是 `exec`，它会自动发现 `node` 二进制：
 
 ```bash
-# 监控 Gemini CLI 或其他 Node.js AI 工具
-sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/node
-
-# 或使用系统 Node.js（使用动态 libssl，无需 --binary-path）
-sudo ./agentsight record -c node
+# Gemini CLI 基于 Node 运行 —— exec 会找到正确的二进制并追踪它
+sudo ./agentsight exec -- gemini
 ```
+
+使用 `record` 时，AgentSight 现在会从 `-c node` 自动发现 Node 二进制
+（检测到 Node 内嵌了 OpenSSL，于是附加到二进制而非系统库），因此无需 `--binary-path` 即可工作：
+
+```bash
+# 监控 Gemini CLI 或其他 Node.js AI 工具 —— 二进制自动发现
+sudo ./agentsight record -c node
+
+# 若自动发现选错了 Node 安装，可显式指定二进制
+sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/node
+```
+
+> **使用 HTTP/HTTPS 代理？** 流量在 Node 进程内仍是 TLS 加密的（代理只是隧道转发），
+> 因此 AgentSight 的捕获方式不变——在加密之前的 `SSL_read`/`SSL_write` 调用处捕获。
 
 #### 高级监控
 
@@ -353,8 +367,8 @@ sudo ./bpf/process -c python
 **问：如何过滤敏感数据？**
 答：内置 Analyzer 可以移除认证头信息并过滤特定内容模式。
 
-**问：为什么 AgentSight 无法捕获 Claude Code 或 NVM Node.js 的流量？**
-答：这些应用静态链接了 SSL 库（Claude/Bun 使用 BoringSSL，NVM Node.js 使用 OpenSSL），而非使用系统 `libssl.so`。请使用 `--binary-path` 指向实际的二进制文件，AgentSight 将通过字节模式匹配自动检测 SSL 函数。详见"监控 Claude Code"和"监控 Node.js AI 工具"章节。
+**问：为什么 AgentSight 无法捕获 Claude Code、Node.js 或 Gemini CLI 的流量？**
+答：这些应用把 SSL 库静态链接进了自己的二进制（Claude/Bun 使用 BoringSSL，**所有** Node.js——NVM 和系统安装都是——使用 OpenSSL），而非使用系统 `libssl.so`，所以默认没有可供 sslsniff hook 的目标。AgentSight 已为你处理：`exec` 总会自动发现二进制，`record -c node` 现在也会自动发现 Node 二进制。对于 Claude，请传 `--binary-path`（或使用 `exec`）。详见"零配置：exec"和"监控 Node.js AI 工具"章节。
 
 **问：为什么 `--comm claude` 无法捕获 SSL 流量？**
 答：Claude Code 的 SSL 流量运行在内部 "HTTP Client" 线程上，而非主 "claude" 线程。sslsniff 中的 `--comm` 过滤器匹配的是线程名（来自 `bpf_get_current_comm()`），而非进程名。使用 `--binary-path` 时，collector 会自动跳过 SSL 监控的 `--comm` 过滤。

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -802,6 +802,26 @@ async fn run_trace(
     println!("Trace Monitoring");
     println!("{}", "=".repeat(60));
 
+    // When the user enabled SSL but didn't pin a --binary-path, try to discover
+    // one from --comm. This fixes the common "record -c node" case: Node (and
+    // gemini-cli, which runs on Node) statically links OpenSSL, so there is no
+    // system libssl.so to hook. Only adopt the resolved binary if it actually
+    // embeds SSL, so dynamically-linked runtimes like Python are left to
+    // sslsniff's system-libssl path with comm filtering intact.
+    let auto_resolved: Option<String> = if ssl_enabled && binary_path.is_none() {
+        comm.filter(|c| !c.contains(','))
+            .and_then(|c| resolve_binary_path(c).ok())
+            .filter(|p| binary_embeds_ssl(p))
+            .map(|p| {
+                println!("✓ Auto-discovered statically-linked SSL binary for --comm '{}': {}",
+                         comm.unwrap_or(""), p);
+                p
+            })
+    } else {
+        None
+    };
+    let binary_path = binary_path.or(auto_resolved.as_deref());
+
     // Set up event broadcasting for server if enabled
     let (event_sender, _event_receiver) = broadcast::channel(1000);
 
@@ -962,6 +982,42 @@ fn newest_nvm_bin(home: &std::path::Path) -> Option<std::path::PathBuf> {
         .collect();
     entries.sort();
     entries.last().map(|p| p.join("bin"))
+}
+
+/// Heuristic: does this ELF statically embed its own SSL implementation?
+///
+/// Node.js bundles OpenSSL directly into the `node` binary, so there is no
+/// system `libssl.so` for sslsniff to hook — it must attach to the binary
+/// itself. We detect this by scanning for the `SSL_write` symbol-name string
+/// in the file. Dynamically-linked runtimes like CPython call into a separate
+/// `libssl.so` (via `_ssl.so`) and do NOT contain this string, so they keep
+/// using sslsniff's system-libssl attachment with comm filtering intact.
+fn binary_embeds_ssl(path: &str) -> bool {
+    use std::io::Read;
+    const NEEDLE: &[u8] = b"SSL_write";
+    let mut f = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let mut buf = vec![0u8; 1 << 20]; // 1 MiB chunks
+    // Carry the tail of each chunk so a match spanning a boundary isn't missed.
+    let mut carry: Vec<u8> = Vec::new();
+    loop {
+        let n = match f.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => n,
+            Err(_) => return false,
+        };
+        carry.extend_from_slice(&buf[..n]);
+        if carry.windows(NEEDLE.len()).any(|w| w == NEEDLE) {
+            return true;
+        }
+        let keep = NEEDLE.len() - 1;
+        if carry.len() > keep {
+            carry.drain(..carry.len() - keep);
+        }
+    }
+    false
 }
 
 /// Launch a target command and automatically trace it with eBPF.


### PR DESCRIPTION
Fixes #42.

## Problem

`sudo ./agentsight record -c node` (e.g. tracing gemini-cli) captured only process/system events — **no SSL/HTTP traffic at all**.

**Root cause:** Node.js statically links OpenSSL *into the `node` binary*. There is no system `libssl.so` for sslsniff to hook, and without `--binary-path` nothing gets attached. The README even claimed "system Node.js uses dynamic libssl", which is incorrect — all Node builds (NVM and system) bundle OpenSSL. (The reporter's HTTP proxy is a red herring: TLS still happens in-process at `SSL_*`.)

## Fix

In `run_trace()`, when SSL is enabled and `--binary-path` is absent, auto-discover the binary from `--comm` via `resolve_binary_path()` — **but only adopt it if `binary_embeds_ssl()` detects the `SSL_write` symbol-name string in the file.**

This cleanly separates the two runtime classes without a hardcoded list:

| Runtime | Embeds `SSL_write`? | Result |
|---|---|---|
| Node (NVM + system) | ✅ yes (bundled OpenSSL) | `sslsniff --binary-path <node>` → **captures** |
| Python | ❌ no (uses `_ssl.so` → `libssl.so`) | `sslsniff -c python` → unchanged, **no regression** |
| Claude (BoringSSL, stripped) | ❌ no | unchanged — use `exec` or `--binary-path` (documented) |

`exec` keeps resolving unconditionally (it targets one known program); only the comm-based guess in `record`/`trace` is gated.

## Testing

- `trace -c node` → `sslsniff --binary-path .../node`; end-to-end an HTTPS GET to `api.github.com/zen` is captured (`"path":"/zen"`, `"host":"api.github.com"`). Before: nothing.
- `trace -c python` → `sslsniff -c python`, no `--binary-path` (verified no regression).
- `cargo test`: 91 + 3 pass; release build clean.

## Docs

Corrected the misleading dynamic-libssl claim in `README.md` / `README.zh-CN.md`, documented the proxy case and the `exec -- gemini` path, and noted auto-discovery behavior in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)