### PR TITLE
feat: out-of-the-box monitoring for containerized agents (OpenClaw)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,19 @@ This logic is in `run_trace()` in `collector/src/main.rs` (around line 485).
 
 In `run_trace()`, when SSL is enabled and `--binary-path` is absent, the binary is auto-discovered from `--comm`: `resolve_binary_path(comm)` resolves the binary, and it is adopted **only if `binary_embeds_ssl()` returns true** (the binary contains the `SSL_write` symbol-name string). This fixes `record -c node` (Node statically links OpenSSL — no system `libssl.so` to hook) while leaving dynamically-linked runtimes like Python on sslsniff's system-libssl + comm-filter path. `exec` resolves unconditionally (it targets one known program); `record`/`trace` gate on `binary_embeds_ssl()` to avoid over-capturing for Python.
 
+## Containerized Agents: `docker://` Binary Path
+
+`--binary-path docker://<name|id>` (or `docker:<name|id>`) targets an agent
+running in a Docker container. `resolve_container_binary_path()` in
+`collector/src/main.rs` runs `docker inspect --format '{{.State.Pid}}'` to get
+the container's init PID, then `find_ssl_pid_in_tree()` walks the descendant
+process tree (via `/proc/<pid>/task/<pid>/children`) and returns the first
+process whose `/proc/<pid>/exe` embeds SSL. This is needed because the init PID
+is often a wrapper like `tini` (OpenClaw runs `tini -s -- node openclaw.mjs
+gateway`) that contains no SSL code. The scheme is translated in `run_trace()`
+(covers `record`/`trace`) and `run_raw_ssl()` (covers `ssl`). See
+`docs/openclaw.md`. `parse_container_ref()` has unit tests in `main.rs`.
+
 ## Common Issues
 
 - **No SSL capture from Claude/Bun**: Must use `--binary-path` pointing to the actual binary (or use `exec`). BoringSSL is statically linked and stripped.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ sudo ./agentsight record -c "node"
 sudo ./agentsight record -c "python"
 # For Node.js apps with NVM (statically-linked OpenSSL)
 sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/node
+# For an agent running in a Docker container (e.g. OpenClaw) — see docs/openclaw.md
+sudo ./agentsight record -c node --binary-path docker://openclaw
 ```
 
 Visit [http://127.0.0.1:7395](http://127.0.0.1:7395) to view the recorded data.
@@ -293,6 +295,25 @@ sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/
 > **Behind an HTTP/HTTPS proxy?** Traffic is still TLS-encrypted inside the
 > Node process (the proxy only tunnels it), so AgentSight captures it the same
 > way — at the `SSL_read`/`SSL_write` calls before encryption.
+
+#### Monitoring Agents in Docker Containers (OpenClaw, etc.)
+
+For an agent running inside a Docker container, pass the container to
+`--binary-path` with the `docker://` scheme. AgentSight resolves the container's
+process tree and attaches sslsniff to the right binary automatically:
+
+```bash
+# OpenClaw is a Node.js agent that runs in a container — works out of the box
+sudo ./agentsight record -c node --binary-path docker://openclaw
+
+# Accepts a container name or ID; supported by record / trace / ssl
+sudo ./agentsight trace --binary-path docker://openclaw --server
+```
+
+`docker inspect` reports the container's *init* process (often `tini`), which
+has no SSL code. AgentSight walks the descendant process tree and attaches to the
+first process whose binary actually embeds SSL (the `node` process). See
+[docs/openclaw.md](docs/openclaw.md) for the full walkthrough.
 
 #### Advanced Monitoring
 

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -384,6 +384,14 @@ async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bo
     // Set up event broadcasting for server if enabled
     let (event_sender, _event_receiver) = broadcast::channel(1000);
 
+    // Translate a `docker://<container>` binary path to the host /proc/<pid>/exe
+    // of the container's SSL-embedding process (see resolve_container_binary_path).
+    let container_resolved: Option<String> = match binary_path.and_then(parse_container_ref) {
+        Some(reference) => Some(resolve_container_binary_path(reference).map_err(RunnerError::from)?),
+        None => None,
+    };
+    let binary_path = container_resolved.as_deref().or(binary_path);
+
     // Build arguments list with binary_path if provided
     let mut final_args = Vec::new();
     if let Some(path) = binary_path {
@@ -808,6 +816,18 @@ async fn run_trace(
     // system libssl.so to hook. Only adopt the resolved binary if it actually
     // embeds SSL, so dynamically-linked runtimes like Python are left to
     // sslsniff's system-libssl path with comm filtering intact.
+    // A `--binary-path docker://<container>` (or `docker:<container>`) reference
+    // is translated to the host-side /proc/<host-pid>/exe of the container's
+    // main process. This is the out-of-the-box path for containerized agents
+    // such as OpenClaw, which is Node.js with a statically-linked OpenSSL — so
+    // there is no in-container libssl.so to scan, and sslsniff must attach its
+    // uprobe directly to the node binary via /proc/<pid>/exe.
+    let container_resolved: Option<String> = match binary_path.and_then(parse_container_ref) {
+        Some(reference) => Some(resolve_container_binary_path(reference).map_err(RunnerError::from)?),
+        None => None,
+    };
+    let binary_path = container_resolved.as_deref().or(binary_path);
+
     let auto_resolved: Option<String> = if ssl_enabled && binary_path.is_none() {
         comm.filter(|c| !c.contains(','))
             .and_then(|c| resolve_binary_path(c).ok())
@@ -1018,6 +1038,90 @@ fn binary_embeds_ssl(path: &str) -> bool {
         }
     }
     false
+}
+
+/// Strip a `docker://<ref>` or `docker:<ref>` scheme from a `--binary-path`
+/// value, returning the container reference (name or id). Returns `None` for
+/// ordinary filesystem paths, which are passed through to sslsniff unchanged.
+fn parse_container_ref(binary_path: &str) -> Option<&str> {
+    binary_path
+        .strip_prefix("docker://")
+        .or_else(|| binary_path.strip_prefix("docker:"))
+        .filter(|r| !r.is_empty())
+}
+
+/// Resolve a Docker container reference to the host path of the executable
+/// that sslsniff should attach its SSL uprobe to (`/proc/<host-pid>/exe`).
+///
+/// This works for containerized runtimes that statically link their TLS
+/// library (Node.js / OpenClaw), where there is no in-container `libssl.so`
+/// to scan for. The host PID comes from `docker inspect`, so this requires the
+/// Docker CLI and (typically) root to read the target's `/proc` entries.
+///
+/// `docker inspect .State.Pid` returns the container's *init* process, which is
+/// often a wrapper such as `tini` (OpenClaw's image uses `tini -s -- node …`).
+/// That wrapper does not embed SSL, so we walk its descendant process tree and
+/// pick the first process whose `/proc/<pid>/exe` actually embeds SSL (the
+/// `node` process). If none is found we fall back to the init PID's executable.
+fn resolve_container_binary_path(reference: &str) -> Result<String, String> {
+    let output = std::process::Command::new("docker")
+        .args(["inspect", "--format", "{{.State.Pid}}", reference])
+        .output()
+        .map_err(|e| format!(
+            "failed to run `docker inspect` for container '{}': {} (is the Docker CLI installed and on $PATH?)",
+            reference, e
+        ))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("`docker inspect {}` failed: {}", reference, stderr.trim()));
+    }
+
+    let init_pid: u32 = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse()
+        .map_err(|_| format!("could not determine host PID for container '{}'", reference))?;
+
+    if init_pid == 0 {
+        return Err(format!("container '{}' is not running (host PID 0)", reference));
+    }
+
+    let target_pid = find_ssl_pid_in_tree(init_pid).unwrap_or(init_pid);
+    let exe = format!("/proc/{}/exe", target_pid);
+    if target_pid == init_pid {
+        println!("✓ Resolved container '{}' to host PID {} → {}", reference, target_pid, exe);
+    } else {
+        println!("✓ Resolved container '{}' (init PID {}) to SSL-embedding host PID {} → {}",
+                 reference, init_pid, target_pid, exe);
+    }
+    Ok(exe)
+}
+
+/// Breadth-first search the descendant process tree rooted at `root_pid` for the
+/// first process whose `/proc/<pid>/exe` statically embeds SSL. Returns that
+/// PID, or `None` if no descendant (including the root) embeds SSL.
+///
+/// Children are read from `/proc/<pid>/task/<pid>/children`, which lists the
+/// immediate child PIDs of a process. Requires permission to read those entries
+/// (root in practice for containerized processes).
+fn find_ssl_pid_in_tree(root_pid: u32) -> Option<u32> {
+    let mut queue = std::collections::VecDeque::from([root_pid]);
+    let mut seen = std::collections::HashSet::new();
+    while let Some(pid) = queue.pop_front() {
+        if !seen.insert(pid) {
+            continue;
+        }
+        if binary_embeds_ssl(&format!("/proc/{}/exe", pid)) {
+            return Some(pid);
+        }
+        let children_path = format!("/proc/{}/task/{}/children", pid, pid);
+        if let Ok(children) = std::fs::read_to_string(&children_path) {
+            for child in children.split_whitespace().filter_map(|s| s.parse::<u32>().ok()) {
+                queue.push_back(child);
+            }
+        }
+    }
+    None
 }
 
 /// Launch a target command and automatically trace it with eBPF.
@@ -1269,4 +1373,35 @@ async fn start_web_server_if_enabled(
     tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
     Ok(Some(server_handle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_container_ref;
+
+    #[test]
+    fn parses_docker_double_slash_scheme() {
+        assert_eq!(parse_container_ref("docker://openclaw"), Some("openclaw"));
+        assert_eq!(parse_container_ref("docker://my-agent-1"), Some("my-agent-1"));
+    }
+
+    #[test]
+    fn parses_docker_colon_scheme() {
+        assert_eq!(parse_container_ref("docker:openclaw"), Some("openclaw"));
+        // A 64-char container id is a valid reference too.
+        assert_eq!(parse_container_ref("docker:abc123def456"), Some("abc123def456"));
+    }
+
+    #[test]
+    fn ignores_plain_filesystem_paths() {
+        assert_eq!(parse_container_ref("/proc/1234/exe"), None);
+        assert_eq!(parse_container_ref("/usr/bin/node"), None);
+        assert_eq!(parse_container_ref("~/.nvm/versions/node/v20.0.0/bin/node"), None);
+    }
+
+    #[test]
+    fn rejects_empty_container_reference() {
+        assert_eq!(parse_container_ref("docker://"), None);
+        assert_eq!(parse_container_ref("docker:"), None);
+    }
 }

--- a/docs/openclaw.md
+++ b/docs/openclaw.md
@@ -1,0 +1,121 @@
+# Monitoring OpenClaw with AgentSight
+
+[OpenClaw](https://github.com/openclaw/openclaw) is a self-hosted personal AI
+assistant that runs in Docker. It is built on **Node.js**, which **statically
+links OpenSSL** into the `node` binary — there is no system `libssl.so` to hook,
+so AgentSight must attach its SSL uprobe directly to the `node` executable.
+
+AgentSight does this for you out of the box: point `--binary-path` at the
+container with the `docker://` scheme and AgentSight resolves the right process
+automatically. No `docker inspect`, no manual PID lookup, no code changes inside
+OpenClaw.
+
+```bash
+# OpenClaw is running in a Docker container named "openclaw"
+sudo ./agentsight record -c node --binary-path docker://openclaw
+```
+
+Open <http://127.0.0.1:7395> to watch OpenClaw's LLM prompts, tool calls, and
+responses live — captured in plaintext at the kernel level.
+
+## Why `docker://`?
+
+`docker inspect --format '{{.State.Pid}}'` returns a container's **init**
+process. OpenClaw's image runs `tini -s -- node openclaw.mjs gateway`, so the
+init process is `tini`, which contains no SSL code. Attaching there would
+capture nothing.
+
+The `docker://<container>` scheme handles this: AgentSight looks up the init PID,
+then walks the descendant process tree and attaches to the first process whose
+executable actually embeds SSL (the `node` process). You see this in the log:
+
+```
+✓ Resolved container 'openclaw' (init PID 3176960) to SSL-embedding host PID 3177083 → /proc/3177083/exe
+```
+
+It accepts a container **name** or **ID**, and both `docker://name` and
+`docker:name` forms work. The scheme is supported by the `record`, `trace`, and
+`ssl` subcommands (anywhere `--binary-path` is accepted).
+
+## End-to-end walkthrough
+
+### 1. Start OpenClaw
+
+```bash
+docker run -d --name openclaw \
+  -e OPENAI_API_KEY=sk-... \
+  -e OPENCLAW_GATEWAY_TOKEN=your-token \
+  ghcr.io/openclaw/openclaw:latest \
+  node openclaw.mjs gateway
+```
+
+### 2. Attach AgentSight
+
+```bash
+sudo ./agentsight record -c node --binary-path docker://openclaw
+```
+
+`record` enables SSL + process + system monitoring and serves the web UI on port
+7395 with agent-tuned filters. For finer control use `trace`:
+
+```bash
+sudo ./agentsight trace --binary-path docker://openclaw --server
+```
+
+Or raw SSL events only:
+
+```bash
+sudo ./agentsight ssl --binary-path docker://openclaw --http-parser
+```
+
+### 3. Trigger agent activity and view captures
+
+Drive OpenClaw normally (via its channels, the gateway API, or `openclaw agent`).
+Every HTTPS call OpenClaw makes to an LLM provider is decrypted at `SSL_write` /
+`SSL_read` and surfaced in the UI. A captured request looks like:
+
+```
+POST /v1/responses HTTP/1.1
+  host: api.openai.com
+  authorization: Bearer sk-...        ← redacted by AuthHeaderRemover by default
+  {"model":"...","input":[
+    {"role":"developer","content":"You are a personal assistant ... ## Tooling ..."},
+    {"role":"user","content":"What is eBPF?"}
+  ]}
+```
+
+The full system prompt, tool definitions, and user message are all captured in
+plaintext — no instrumentation inside OpenClaw required.
+
+## How it works
+
+```
+OpenClaw container
+  tini (init, State.Pid)            ← docker inspect points here
+    └─ node openclaw.mjs gateway    ← AgentSight walks the tree and attaches here
+         │ HTTPS to LLM API (OpenAI / Anthropic / …)
+         ▼
+   sslsniff (eBPF uprobe on SSL_read/SSL_write via /proc/<pid>/exe)
+         │ decrypted plaintext
+         ▼
+   AgentSight analyzers → web UI / JSON log
+```
+
+## Troubleshooting
+
+| Symptom | Cause / Fix |
+|---------|-------------|
+| `container '<name>' is not running (host PID 0)` | The container is stopped. Start it and retry. |
+| `docker inspect ... failed` | Wrong container name/ID, or the Docker CLI isn't on `$PATH`. AgentSight runs `docker inspect` under the hood. |
+| No SSL events captured | Confirm the resolved PID is `node` (the log prints it). Plain HTTP is never captured — only TLS via `SSL_*`. |
+| Resolved to the init PID, not node | OpenClaw isn't running inside the container yet, or no descendant embeds SSL. Wait for the gateway to be `ready`, then retry. |
+
+## Notes
+
+- OpenClaw pins a recent Node.js (v22+) whose statically-linked OpenSSL is
+  detected by sslsniff's symbol lookup. This is the same mechanism that powers
+  `record -c node` for NVM-installed Node (see the main README).
+- The `--comm` filter is intentionally **not** passed to sslsniff when
+  `--binary-path` is set: SSL traffic runs on a worker thread whose name differs
+  from the process name, so a comm filter would drop all of it. `--binary-path`
+  alone provides sufficient targeting.


### PR DESCRIPTION
## Summary

Adds a `docker://<name|id>` (and `docker:<name|id>`) scheme to `--binary-path`, letting AgentSight monitor agents running in Docker containers with zero manual setup.

**OpenClaw** is the motivating case: it's a Node.js agent that statically links OpenSSL (no in-container `libssl.so` to scan), and its image runs `tini -s -- node openclaw.mjs gateway` — so `docker inspect`'s `.State.Pid` points at `tini` (no SSL code), not `node`.

```bash
# Before: manual host-PID lookup + /proc/<pid>/exe juggling
# Now:
sudo ./agentsight record -c node --binary-path docker://openclaw
```

## How it works

1. `resolve_container_binary_path()` runs `docker inspect --format '{{.State.Pid}}'` to get the container's init PID.
2. `find_ssl_pid_in_tree()` BFS-walks the descendant process tree (via `/proc/<pid>/task/<pid>/children`) and returns the first process whose `/proc/<pid>/exe` embeds SSL — i.e. the `node` process under `tini`.
3. The scheme is translated in `run_trace()` (covers `record`/`trace`) and `run_raw_ssl()` (covers `ssl`).

```
✓ Resolved container 'openclaw' (init PID 3176960) to SSL-embedding host PID 3177083 → /proc/3177083/exe
```

## Verification

Tested end-to-end against `ghcr.io/openclaw/openclaw:latest`:
- Resolution correctly skips `tini` and lands on the `node` process.
- sslsniff attaches and captures the container's outbound HTTPS requests in plaintext (verified with a real `GET https://api.github.com/zen` from inside the container).
- `record`, `trace`, and `ssl` paths all verified.

## Changes

- `collector/src/main.rs` — `parse_container_ref()`, `resolve_container_binary_path()`, `find_ssl_pid_in_tree()`; wired into `run_trace` and `run_raw_ssl`; unit tests for `parse_container_ref`.
- `docs/openclaw.md` — full OpenClaw + AgentSight walkthrough.
- `README.md` — `docker://` quick-start + usage subsection.
- `CLAUDE.md` — maintainer notes.

## Tests

- `cargo test`: 95 + 3 pass (4 new unit tests for `parse_container_ref`).
- Rust-only change; no eBPF/C or frontend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)