### PR TITLE
feat: export OpenTelemetry GenAI (gen_ai.*) spans via OTLP/HTTP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ eBPF Programs (kernel) → JSON stdout → Rust Runners → Analyzer Chain → O
 - **`bpf/`** — C eBPF programs. `sslsniff` hooks SSL_read/SSL_write via uprobes; `process` tracks process lifecycle via tracepoints. Both emit JSON to stdout.
 - **`collector/src/framework/`** — Rust streaming framework:
   - `runners/` — Execute eBPF binaries and parse their JSON output into event streams (SslRunner, ProcessRunner, SystemRunner, FakeRunner)
-  - `analyzers/` — Pluggable stream processors: ChunkMerger, SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, FileLogger, AuthHeaderRemover
+  - `analyzers/` — Pluggable stream processors: ChunkMerger, SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, FileLogger, AuthHeaderRemover, OtelExporter (maps LLM HTTP pairs to OpenTelemetry `gen_ai.*` spans, exported via OTLP/HTTP JSON; enabled by `trace --otel`, see `docs/otel.md`)
   - `core/events.rs` — Standardized `Event` struct with JSON payloads
   - `binary_extractor.rs` — Extracts embedded eBPF binaries to temp files at runtime
 - **`collector/src/main.rs`** — CLI entry point. Subcommands: `ssl`, `process`, `trace` (most flexible), `record` (optimized defaults)

--- a/README.md
+++ b/README.md
@@ -325,6 +325,26 @@ sudo ./agentsight trace --ssl true --process true --server true
 sudo ./agentsight record -c "python" --server-port 8080 --log-file /tmp/agent.log
 ```
 
+#### Export to OpenTelemetry (GenAI semantic conventions)
+
+AgentSight can export captured LLM calls as OpenTelemetry **GenAI**
+(`gen_ai.*`) spans over OTLP/HTTP — standards-compliant agent telemetry for any
+agent, with zero in-process instrumentation. Send them to an OpenTelemetry
+Collector and on to Jaeger, Grafana Tempo, Datadog, Honeycomb, etc.
+
+```bash
+# Export gen_ai.* spans to a collector (defaults to http://localhost:4318)
+sudo ./agentsight trace --otel --otel-endpoint http://localhost:4318
+
+# Include prompt/completion content (opt-in; off by default for privacy)
+sudo ./agentsight trace --otel --otel-capture-content
+```
+
+Each LLM request/response pair becomes a `chat {model}` span with
+`gen_ai.provider.name`, `gen_ai.request.model`, `gen_ai.usage.{input,output}_tokens`,
+`gen_ai.response.finish_reasons`, and more. See [docs/otel.md](docs/otel.md) for
+collector setup and backend integration.
+
 #### Browser Plaintext Capture
 
 For browser-specific plaintext capture, use the standalone `browsertrace` BPF

--- a/collector/src/framework/analyzers/mod.rs
+++ b/collector/src/framework/analyzers/mod.rs
@@ -28,6 +28,7 @@ pub mod ssl_filter;
 pub mod event;
 pub mod common;
 pub mod timestamp_normalizer;
+pub mod otel_exporter;
 
 #[cfg(test)]
 mod sse_processor_tests;
@@ -40,6 +41,7 @@ pub use http_filter::{HTTPFilter, print_global_http_filter_metrics};
 pub use auth_header_remover::AuthHeaderRemover;
 pub use ssl_filter::{SSLFilter, print_global_ssl_filter_metrics};
 pub use timestamp_normalizer::TimestampNormalizer;
+pub use otel_exporter::OtelExporter;
 
 #[cfg(test)]
 mod comprehensive_analyzer_chain_tests {

--- a/collector/src/framework/analyzers/otel_exporter.rs
+++ b/collector/src/framework/analyzers/otel_exporter.rs
@@ -1,0 +1,521 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+//! OpenTelemetry GenAI exporter.
+//!
+//! Maps the LLM HTTP request/response pairs reconstructed by [`HTTPParser`] onto
+//! OpenTelemetry **GenAI semantic-convention** (`gen_ai.*`) spans and ships them
+//! to an OpenTelemetry Collector via **OTLP/HTTP (JSON)** — the standard wire
+//! format understood by the OTel Collector, Jaeger, Grafana Tempo, and the major
+//! observability vendors. Because AgentSight captures the traffic at the kernel
+//! (eBPF) level, this produces vendor-neutral GenAI telemetry for *any* agent
+//! binary with **zero in-process instrumentation**.
+//!
+//! Spec: <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+//!
+//! Each request/response pair becomes one `chat {model}` CLIENT span. Requests
+//! and responses are correlated by `(pid, tid)`; the span's start/end times come
+//! from the request and response event timestamps. Token usage, finish reasons,
+//! and (opt-in) message content are parsed from the JSON bodies, tolerating the
+//! OpenAI, OpenAI-Responses, and Anthropic payload shapes.
+//!
+//! [`HTTPParser`]: super::http_parser::HTTPParser
+
+use super::{Analyzer, AnalyzerError};
+use crate::framework::runners::EventStream;
+use async_trait::async_trait;
+use futures::stream::StreamExt;
+use http_body_util::{BodyExt, Full};
+use hyper::body::Bytes;
+use hyper_util::client::legacy::Client;
+use hyper_util::rt::TokioExecutor;
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Default OTLP/HTTP receiver endpoint (OpenTelemetry Collector).
+const DEFAULT_OTLP_ENDPOINT: &str = "http://localhost:4318";
+
+/// A request that is waiting for its matching response so a full span can be
+/// emitted. Keyed by `(pid, tid)` in the exporter's pending map.
+#[derive(Clone)]
+struct PendingRequest {
+    start_unix_nano: u128,
+    provider: String,
+    server_address: String,
+    model: Option<String>,
+    max_tokens: Option<i64>,
+    temperature: Option<f64>,
+    top_p: Option<f64>,
+    /// Opt-in: the request messages, captured only when content capture is on.
+    input_messages: Option<String>,
+}
+
+/// Exports GenAI spans for LLM HTTP exchanges via OTLP/HTTP (JSON).
+pub struct OtelExporter {
+    /// Full traces URL, e.g. `http://localhost:4318/v1/traces`.
+    traces_url: String,
+    /// `service.name` reported on the OTLP Resource.
+    service_name: String,
+    /// Whether to attach prompt/completion content (`gen_ai.{input,output}.messages`).
+    capture_content: bool,
+}
+
+impl OtelExporter {
+    /// Create an exporter. `endpoint` is the OTLP/HTTP base (e.g.
+    /// `http://collector:4318`); when `None`, `OTEL_EXPORTER_OTLP_ENDPOINT` is
+    /// honored, falling back to `http://localhost:4318`. A full traces endpoint
+    /// in `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence and is used as-is.
+    pub fn new(endpoint: Option<String>, capture_content: bool) -> Self {
+        let traces_url = if let Ok(full) = std::env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") {
+            full
+        } else {
+            let base = endpoint
+                .or_else(|| std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").ok())
+                .unwrap_or_else(|| DEFAULT_OTLP_ENDPOINT.to_string());
+            format!("{}/v1/traces", base.trim_end_matches('/'))
+        };
+
+        let service_name =
+            std::env::var("OTEL_SERVICE_NAME").unwrap_or_else(|_| "agentsight".to_string());
+
+        Self { traces_url, service_name, capture_content }
+    }
+}
+
+/// Map an LLM API host to a `gen_ai.provider.name` value (per the spec's
+/// well-known provider list). Falls back to the host for unknown OpenAI-compatible
+/// endpoints (e.g. self-hosted llama.cpp / vLLM), which keeps spans useful.
+fn provider_from_host(host: &str) -> String {
+    let h = host.to_ascii_lowercase();
+    if h.contains("openai.azure.com") {
+        "azure.ai.openai".to_string()
+    } else if h.contains("openai") {
+        "openai".to_string()
+    } else if h.contains("anthropic") {
+        "anthropic".to_string()
+    } else if h.contains("generativelanguage") || h.contains("googleapis") {
+        "gcp.gen_ai".to_string()
+    } else if h.contains("bedrock") {
+        "aws.bedrock".to_string()
+    } else {
+        host.to_string()
+    }
+}
+
+/// True if a request path targets a chat/completions-style LLM endpoint. Matches
+/// the OpenAI, OpenAI-Responses, Anthropic, and Gemini URL shapes.
+fn is_llm_path(path: &str) -> bool {
+    path.contains("/chat/completions")
+        || path.contains("/v1/messages")
+        || path.contains("/v1/responses")
+        || path.ends_with("/v1/completions")
+        || path.contains(":generateContent")
+        || path.contains(":streamGenerateContent")
+}
+
+/// Pull an integer token count from a usage object, tolerating both the
+/// OpenAI (`prompt_tokens`/`completion_tokens`) and Anthropic/Responses
+/// (`input_tokens`/`output_tokens`) field names.
+fn usage_int(usage: &Value, names: &[&str]) -> Option<i64> {
+    names.iter().find_map(|n| usage.get(*n).and_then(|v| v.as_i64()))
+}
+
+/// Extract finish/stop reasons from a response body across provider shapes.
+fn finish_reasons(body: &Value) -> Vec<String> {
+    // OpenAI chat/completions: choices[].finish_reason
+    if let Some(choices) = body.get("choices").and_then(|c| c.as_array()) {
+        let reasons: Vec<String> = choices
+            .iter()
+            .filter_map(|c| c.get("finish_reason").and_then(|r| r.as_str()).map(String::from))
+            .collect();
+        if !reasons.is_empty() {
+            return reasons;
+        }
+    }
+    // Anthropic messages: stop_reason
+    if let Some(stop) = body.get("stop_reason").and_then(|v| v.as_str()) {
+        return vec![stop.to_string()];
+    }
+    Vec::new()
+}
+
+/// Build an OTLP AnyValue JSON object for a string.
+fn av_str(s: &str) -> Value {
+    json!({ "stringValue": s })
+}
+
+/// Build an OTLP key/value attribute with a string value.
+fn attr_str(key: &str, s: &str) -> Value {
+    json!({ "key": key, "value": av_str(s) })
+}
+
+/// Build an OTLP key/value attribute with an int value (int64 is JSON-encoded as
+/// a string per the OTLP/JSON spec).
+fn attr_int(key: &str, n: i64) -> Value {
+    json!({ "key": key, "value": { "intValue": n.to_string() } })
+}
+
+/// Build an OTLP key/value attribute with a double value.
+fn attr_double(key: &str, n: f64) -> Value {
+    json!({ "key": key, "value": { "doubleValue": n } })
+}
+
+/// Build an OTLP key/value attribute holding an array of strings.
+fn attr_str_array(key: &str, items: &[String]) -> Value {
+    let values: Vec<Value> = items.iter().map(|s| av_str(s)).collect();
+    json!({ "key": key, "value": { "arrayValue": { "values": values } } })
+}
+
+/// Construct the OTLP/HTTP JSON `ExportTraceServiceRequest` body for a single
+/// span built from a request/response pair.
+fn build_otlp_payload(
+    service_name: &str,
+    trace_id: &str,
+    span_id: &str,
+    req: &PendingRequest,
+    end_unix_nano: u128,
+    status_code: Option<u16>,
+    response_body: Option<&Value>,
+    capture_content: bool,
+) -> Value {
+    let model_name = req.model.as_deref().unwrap_or("unknown");
+
+    let mut attributes = vec![
+        attr_str("gen_ai.operation.name", "chat"),
+        attr_str("gen_ai.provider.name", &req.provider),
+        attr_str("server.address", &req.server_address),
+    ];
+    if let Some(model) = &req.model {
+        attributes.push(attr_str("gen_ai.request.model", model));
+    }
+    if let Some(mt) = req.max_tokens {
+        attributes.push(attr_int("gen_ai.request.max_tokens", mt));
+    }
+    if let Some(t) = req.temperature {
+        attributes.push(attr_double("gen_ai.request.temperature", t));
+    }
+    if let Some(p) = req.top_p {
+        attributes.push(attr_double("gen_ai.request.top_p", p));
+    }
+
+    // Response-derived attributes.
+    let mut span_status = json!({ "code": 1 }); // STATUS_CODE_OK
+    if let Some(body) = response_body {
+        if let Some(rmodel) = body.get("model").and_then(|v| v.as_str()) {
+            attributes.push(attr_str("gen_ai.response.model", rmodel));
+        }
+        if let Some(id) = body.get("id").and_then(|v| v.as_str()) {
+            attributes.push(attr_str("gen_ai.response.id", id));
+        }
+        if let Some(usage) = body.get("usage") {
+            if let Some(input) = usage_int(usage, &["input_tokens", "prompt_tokens"]) {
+                attributes.push(attr_int("gen_ai.usage.input_tokens", input));
+            }
+            if let Some(output) = usage_int(usage, &["output_tokens", "completion_tokens"]) {
+                attributes.push(attr_int("gen_ai.usage.output_tokens", output));
+            }
+        }
+        let reasons = finish_reasons(body);
+        if !reasons.is_empty() {
+            attributes.push(attr_str_array("gen_ai.response.finish_reasons", &reasons));
+        }
+        if capture_content {
+            attributes.push(attr_str("gen_ai.output.messages", &body.to_string()));
+        }
+    }
+
+    // HTTP error status -> span ERROR.
+    if let Some(code) = status_code {
+        attributes.push(attr_int("http.response.status_code", code as i64));
+        if code >= 400 {
+            span_status = json!({ "code": 2, "message": format!("HTTP {}", code) });
+        }
+    }
+
+    if capture_content {
+        if let Some(msgs) = &req.input_messages {
+            attributes.push(attr_str("gen_ai.input.messages", msgs));
+        }
+    }
+
+    json!({
+        "resourceSpans": [{
+            "resource": {
+                "attributes": [ attr_str("service.name", service_name) ]
+            },
+            "scopeSpans": [{
+                "scope": { "name": "agentsight", "version": env!("CARGO_PKG_VERSION") },
+                "spans": [{
+                    "traceId": trace_id,
+                    "spanId": span_id,
+                    "name": format!("chat {}", model_name),
+                    "kind": 3, // SPAN_KIND_CLIENT
+                    "startTimeUnixNano": req.start_unix_nano.to_string(),
+                    "endTimeUnixNano": end_unix_nano.to_string(),
+                    "attributes": attributes,
+                    "status": span_status
+                }]
+            }]
+        }]
+    })
+}
+
+/// Generate a 32-hex-char trace id and 16-hex-char span id.
+fn new_ids() -> (String, String) {
+    let trace = uuid::Uuid::new_v4().simple().to_string(); // 32 hex chars
+    let span = uuid::Uuid::new_v4().simple().to_string()[..16].to_string();
+    (trace, span)
+}
+
+/// Parse a JSON body string into a `Value`, returning `None` if it isn't valid
+/// JSON (e.g. an SSE-streamed body that wasn't fully reassembled).
+fn parse_body(data: &Value) -> Option<Value> {
+    let body = data.get("body").and_then(|v| v.as_str())?;
+    serde_json::from_str(body).ok()
+}
+
+#[async_trait]
+impl Analyzer for OtelExporter {
+    async fn process(&mut self, stream: EventStream) -> Result<EventStream, AnalyzerError> {
+        let client: Arc<Client<_, Full<Bytes>>> =
+            Arc::new(Client::builder(TokioExecutor::new()).build_http());
+        let traces_url = self.traces_url.clone();
+        let service_name = self.service_name.clone();
+        let capture_content = self.capture_content;
+
+        log::info!("OtelExporter: exporting GenAI spans to {}", traces_url);
+
+        // Correlate requests with responses by (pid, tid). `.map` takes an
+        // FnMut, so this map persists across the whole stream.
+        let mut pending: HashMap<(u32, u64), PendingRequest> = HashMap::new();
+
+        let processed = stream.map(move |event| {
+            if event.source != "http_parser" {
+                return event;
+            }
+            let data = &event.data;
+            let tid = data.get("tid").and_then(|v| v.as_u64()).unwrap_or(0);
+            let key = (event.pid, tid);
+            let msg_type = data.get("message_type").and_then(|v| v.as_str()).unwrap_or("");
+            let unix_nano = (event.timestamp as u128) * 1_000_000; // ms -> ns
+
+            match msg_type {
+                "request" => {
+                    let host = data
+                        .get("headers")
+                        .and_then(|h| h.get("host"))
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let path = data.get("path").and_then(|v| v.as_str()).unwrap_or("");
+                    if is_llm_path(path) {
+                        let body = parse_body(data);
+                        let model = body
+                            .as_ref()
+                            .and_then(|b| b.get("model"))
+                            .and_then(|v| v.as_str())
+                            .map(String::from);
+                        let max_tokens = body
+                            .as_ref()
+                            .and_then(|b| b.get("max_tokens").or_else(|| b.get("max_output_tokens")))
+                            .and_then(|v| v.as_i64());
+                        let temperature = body
+                            .as_ref()
+                            .and_then(|b| b.get("temperature"))
+                            .and_then(|v| v.as_f64());
+                        let top_p = body
+                            .as_ref()
+                            .and_then(|b| b.get("top_p"))
+                            .and_then(|v| v.as_f64());
+                        let input_messages = if capture_content {
+                            body.as_ref().and_then(|b| {
+                                b.get("messages")
+                                    .or_else(|| b.get("input"))
+                                    .map(|m| m.to_string())
+                            })
+                        } else {
+                            None
+                        };
+                        pending.insert(
+                            key,
+                            PendingRequest {
+                                start_unix_nano: unix_nano,
+                                provider: provider_from_host(host),
+                                server_address: host.to_string(),
+                                model,
+                                max_tokens,
+                                temperature,
+                                top_p,
+                                input_messages,
+                            },
+                        );
+                    }
+                }
+                "response" => {
+                    if let Some(req) = pending.remove(&key) {
+                        let status_code =
+                            data.get("status_code").and_then(|v| v.as_u64()).map(|c| c as u16);
+                        let response_body = parse_body(data);
+                        let (trace_id, span_id) = new_ids();
+                        let payload = build_otlp_payload(
+                            &service_name,
+                            &trace_id,
+                            &span_id,
+                            &req,
+                            unix_nano,
+                            status_code,
+                            response_body.as_ref(),
+                            capture_content,
+                        );
+
+                        // Fire the OTLP POST without blocking the event stream.
+                        let client = client.clone();
+                        let url = traces_url.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = post_otlp(&client, &url, payload).await {
+                                log::warn!("OtelExporter: failed to export span: {}", e);
+                            }
+                        });
+                    }
+                }
+                _ => {}
+            }
+            event
+        });
+
+        Ok(Box::pin(processed))
+    }
+
+    fn name(&self) -> &str {
+        "OtelExporter"
+    }
+}
+
+/// POST an OTLP/HTTP JSON trace payload to the collector.
+async fn post_otlp(
+    client: &Client<hyper_util::client::legacy::connect::HttpConnector, Full<Bytes>>,
+    url: &str,
+    payload: Value,
+) -> Result<(), AnalyzerError> {
+    let body = serde_json::to_vec(&payload)?;
+    let req = hyper::Request::builder()
+        .method(hyper::Method::POST)
+        .uri(url)
+        .header(hyper::header::CONTENT_TYPE, "application/json")
+        .body(Full::new(Bytes::from(body)))?;
+
+    let resp = client.request(req).await?;
+    let status = resp.status();
+    if !status.is_success() {
+        let bytes = resp.into_body().collect().await?.to_bytes();
+        let text = String::from_utf8_lossy(&bytes);
+        return Err(format!("collector returned {}: {}", status, text.trim()).into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_llm_paths() {
+        assert!(is_llm_path("/v1/chat/completions"));
+        assert!(is_llm_path("/v1/messages"));
+        assert!(is_llm_path("/v1/responses"));
+        assert!(is_llm_path("/openai/deployments/gpt4/chat/completions"));
+        assert!(is_llm_path("/v1beta/models/gemini-pro:generateContent"));
+        assert!(!is_llm_path("/v1/rgstr"));
+        assert!(!is_llm_path("/health"));
+    }
+
+    #[test]
+    fn maps_providers() {
+        assert_eq!(provider_from_host("api.openai.com"), "openai");
+        assert_eq!(provider_from_host("api.anthropic.com"), "anthropic");
+        assert_eq!(provider_from_host("generativelanguage.googleapis.com"), "gcp.gen_ai");
+        assert_eq!(provider_from_host("my-resource.openai.azure.com"), "azure.ai.openai");
+        // Unknown OpenAI-compatible host falls back to the host itself.
+        assert_eq!(provider_from_host("localhost:8443"), "localhost:8443");
+    }
+
+    #[test]
+    fn parses_usage_both_shapes() {
+        let openai = json!({ "usage": { "prompt_tokens": 12, "completion_tokens": 7 } });
+        assert_eq!(usage_int(&openai["usage"], &["input_tokens", "prompt_tokens"]), Some(12));
+        assert_eq!(usage_int(&openai["usage"], &["output_tokens", "completion_tokens"]), Some(7));
+
+        let anthropic = json!({ "usage": { "input_tokens": 30, "output_tokens": 15 } });
+        assert_eq!(usage_int(&anthropic["usage"], &["input_tokens", "prompt_tokens"]), Some(30));
+    }
+
+    #[test]
+    fn extracts_finish_reasons() {
+        let openai = json!({ "choices": [{ "finish_reason": "stop" }] });
+        assert_eq!(finish_reasons(&openai), vec!["stop".to_string()]);
+        let anthropic = json!({ "stop_reason": "end_turn" });
+        assert_eq!(finish_reasons(&anthropic), vec!["end_turn".to_string()]);
+        let none = json!({ "foo": 1 });
+        assert!(finish_reasons(&none).is_empty());
+    }
+
+    #[test]
+    fn builds_payload_with_gen_ai_attributes() {
+        let req = PendingRequest {
+            start_unix_nano: 1_000_000_000,
+            provider: "openai".to_string(),
+            server_address: "api.openai.com".to_string(),
+            model: Some("gpt-4o".to_string()),
+            max_tokens: Some(256),
+            temperature: Some(0.7),
+            top_p: None,
+            input_messages: None,
+        };
+        let response = json!({
+            "model": "gpt-4o-2024",
+            "usage": { "prompt_tokens": 10, "completion_tokens": 5 },
+            "choices": [{ "finish_reason": "stop" }]
+        });
+        let payload = build_otlp_payload(
+            "agentsight", "0123456789abcdef0123456789abcdef", "0123456789abcdef",
+            &req, 2_000_000_000, Some(200), Some(&response), false,
+        );
+
+        let span = &payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["name"], "chat gpt-4o");
+        assert_eq!(span["kind"], 3);
+        assert_eq!(span["startTimeUnixNano"], "1000000000");
+        assert_eq!(span["endTimeUnixNano"], "2000000000");
+
+        let attrs = span["attributes"].as_array().unwrap();
+        let find = |k: &str| attrs.iter().find(|a| a["key"] == k).cloned();
+        assert_eq!(find("gen_ai.operation.name").unwrap()["value"]["stringValue"], "chat");
+        assert_eq!(find("gen_ai.provider.name").unwrap()["value"]["stringValue"], "openai");
+        assert_eq!(find("gen_ai.request.model").unwrap()["value"]["stringValue"], "gpt-4o");
+        assert_eq!(find("gen_ai.request.max_tokens").unwrap()["value"]["intValue"], "256");
+        assert_eq!(find("gen_ai.usage.input_tokens").unwrap()["value"]["intValue"], "10");
+        assert_eq!(find("gen_ai.usage.output_tokens").unwrap()["value"]["intValue"], "5");
+        assert_eq!(span["status"]["code"], 1);
+        // Content not captured by default.
+        assert!(find("gen_ai.input.messages").is_none());
+    }
+
+    #[test]
+    fn error_status_marks_span_error() {
+        let req = PendingRequest {
+            start_unix_nano: 1,
+            provider: "openai".to_string(),
+            server_address: "api.openai.com".to_string(),
+            model: Some("gpt-4o".to_string()),
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            input_messages: None,
+        };
+        let payload = build_otlp_payload(
+            "agentsight", "t", "s", &req, 2, Some(429), None, false,
+        );
+        let span = &payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0];
+        assert_eq!(span["status"]["code"], 2);
+    }
+}

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -13,10 +13,19 @@ mod server;
 use framework::{
     binary_extractor::BinaryExtractor,
     runners::{SslRunner, StdioRunner, ProcessRunner, AgentRunner, SystemRunner, RunnerError, Runner},
-    analyzers::{OutputAnalyzer, FileLogger, SSEProcessor, HTTPParser, HTTPFilter, AuthHeaderRemover, SSLFilter, TimestampNormalizer, print_global_http_filter_metrics, print_global_ssl_filter_metrics}
+    analyzers::{OutputAnalyzer, FileLogger, SSEProcessor, HTTPParser, HTTPFilter, AuthHeaderRemover, SSLFilter, TimestampNormalizer, OtelExporter, print_global_http_filter_metrics, print_global_ssl_filter_metrics}
 };
 
 use server::WebServer;
+
+/// Configuration for exporting GenAI spans to an OpenTelemetry Collector.
+#[derive(Clone)]
+struct OtelConfig {
+    /// OTLP/HTTP base endpoint; `None` falls back to env vars / localhost.
+    endpoint: Option<String>,
+    /// Opt-in: include prompt/completion content in spans.
+    capture_content: bool,
+}
 
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
@@ -222,6 +231,15 @@ enum Commands {
         /// Disable authorization header removal from HTTP traffic
         #[arg(long)]
         disable_auth_removal: bool,
+        /// Export GenAI spans to an OpenTelemetry Collector via OTLP/HTTP
+        #[arg(long)]
+        otel: bool,
+        /// OTLP/HTTP endpoint for --otel (default: $OTEL_EXPORTER_OTLP_ENDPOINT or http://localhost:4318)
+        #[arg(long)]
+        otel_endpoint: Option<String>,
+        /// Include prompt/completion content in exported GenAI spans (opt-in; off by default for privacy)
+        #[arg(long)]
+        otel_capture_content: bool,
         /// Path to the binary executable to monitor (e.g., ~/.nvm/versions/node/v20.0.0/bin/node)
         #[arg(long)]
         binary_path: Option<String>,
@@ -351,7 +369,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Commands::Ssl { sse_merge, http_parser, http_raw_data, http_filter, disable_auth_removal, ssl_filter, quiet, rotate_logs, max_log_size, server, server_port, log_file, binary_path, args } => run_raw_ssl(&binary_extractor, *sse_merge, *http_parser, *http_raw_data, http_filter, *disable_auth_removal, ssl_filter, *quiet, *rotate_logs, *max_log_size, *server, *server_port, log_file, binary_path.as_deref(), args).await.map_err(convert_runner_error)?,
         Commands::Process { quiet, rotate_logs, max_log_size, server, server_port, log_file, args } => run_raw_process(&binary_extractor, *quiet, *rotate_logs, *max_log_size, *server, *server_port, log_file, args).await.map_err(convert_runner_error)?,
         Commands::Stdio { pid, uid, comm, all_fds, max_bytes, quiet, rotate_logs, max_log_size, server, server_port, log_file } => run_raw_stdio(&binary_extractor, *pid, *uid, comm.as_deref(), *all_fds, *max_bytes, *quiet, *rotate_logs, *max_log_size, *server, *server_port, log_file).await.map_err(convert_runner_error)?,
-        Commands::Trace { ssl, ssl_uid, pid, comm, ssl_filter, ssl_handshake, ssl_http, ssl_raw_data, process, stdio, stdio_uid, stdio_comm, stdio_all_fds, stdio_max_bytes, duration, mode, system, system_interval, http_filter, disable_auth_removal, binary_path, log_file, quiet, rotate_logs, max_log_size, server, server_port } => run_trace(&binary_extractor, *ssl, *pid, *ssl_uid, comm.as_deref(), ssl_filter, *ssl_handshake, *ssl_http, *ssl_raw_data, *process, *stdio, *stdio_uid, stdio_comm.as_deref(), *stdio_all_fds, *stdio_max_bytes, *duration, *mode, *system, *system_interval, http_filter, *disable_auth_removal, binary_path.as_deref(), log_file, *quiet, *rotate_logs, *max_log_size, *server, *server_port).await.map_err(convert_runner_error)?,
+        Commands::Trace { ssl, ssl_uid, pid, comm, ssl_filter, ssl_handshake, ssl_http, ssl_raw_data, process, stdio, stdio_uid, stdio_comm, stdio_all_fds, stdio_max_bytes, duration, mode, system, system_interval, http_filter, disable_auth_removal, otel, otel_endpoint, otel_capture_content, binary_path, log_file, quiet, rotate_logs, max_log_size, server, server_port } => {
+            let otel_config = otel.then(|| OtelConfig { endpoint: otel_endpoint.clone(), capture_content: *otel_capture_content });
+            run_trace(&binary_extractor, *ssl, *pid, *ssl_uid, comm.as_deref(), ssl_filter, *ssl_handshake, *ssl_http, *ssl_raw_data, *process, *stdio, *stdio_uid, stdio_comm.as_deref(), *stdio_all_fds, *stdio_max_bytes, *duration, *mode, *system, *system_interval, http_filter, *disable_auth_removal, otel_config, binary_path.as_deref(), log_file, *quiet, *rotate_logs, *max_log_size, *server, *server_port).await.map_err(convert_runner_error)?
+        },
         Commands::Record { comm, binary_path, log_file, rotate_logs, max_log_size, server_port } => {
             // Predefined filter patterns optimized for agent monitoring
             let http_filter_patterns = vec![
@@ -362,7 +383,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             ];
 
             // Enable system monitoring by default for record command
-            run_trace(&binary_extractor, true, None, None, Some(comm), &ssl_filter_patterns, false, true, false, true, false, None, None, false, 8192, None, None, true, 2, &http_filter_patterns, false, binary_path.as_deref(), log_file, true, *rotate_logs, *max_log_size, true, *server_port).await.map_err(convert_runner_error)?
+            run_trace(&binary_extractor, true, None, None, Some(comm), &ssl_filter_patterns, false, true, false, true, false, None, None, false, 8192, None, None, true, 2, &http_filter_patterns, false, None, binary_path.as_deref(), log_file, true, *rotate_logs, *max_log_size, true, *server_port).await.map_err(convert_runner_error)?
         },
         Commands::Exec { binary_path, log_file, rotate_logs, max_log_size, no_server, server_port, command } => {
             run_exec(&binary_extractor, command, binary_path.as_deref(), log_file, *rotate_logs, *max_log_size, !*no_server, *server_port).await.map_err(convert_runner_error)?
@@ -614,6 +635,7 @@ fn build_trace_agent(
     system_interval: u64,
     http_filter: &[String],
     disable_auth_removal: bool,
+    otel: Option<OtelConfig>,
     binary_path: Option<&str>,
     log_file: &str,
     quiet: bool,
@@ -680,8 +702,18 @@ fn build_trace_agent(
             if !disable_auth_removal {
                 ssl_runner = ssl_runner.add_analyzer(Box::new(AuthHeaderRemover::new()));
             }
+
+            // Export GenAI spans to an OpenTelemetry Collector if requested.
+            // Placed last so it observes fully-parsed (and auth-scrubbed) events.
+            if let Some(otel_config) = &otel {
+                ssl_runner = ssl_runner.add_analyzer(Box::new(OtelExporter::new(
+                    otel_config.endpoint.clone(),
+                    otel_config.capture_content,
+                )));
+                println!("✓ OpenTelemetry GenAI export enabled");
+            }
         }
-        
+
         agent = agent.add_runner(Box::new(ssl_runner));
         let http_filter_info = if ssl_http && !http_filter.is_empty() { 
             format!(" with {} HTTP filter patterns", http_filter.len()) 
@@ -799,6 +831,7 @@ async fn run_trace(
     system_interval: u64,
     http_filter: &[String],
     disable_auth_removal: bool,
+    otel: Option<OtelConfig>,
     binary_path: Option<&str>,
     log_file: &str,
     quiet: bool,
@@ -849,7 +882,7 @@ async fn run_trace(
         binary_extractor, "trace", ssl_enabled, pid, ssl_uid, comm, ssl_filter,
         ssl_handshake, ssl_http, ssl_raw_data, process_enabled, stdio_enabled,
         stdio_uid, stdio_comm, stdio_all_fds, stdio_max_bytes, duration, mode,
-        system_enabled, system_interval, http_filter, disable_auth_removal,
+        system_enabled, system_interval, http_filter, disable_auth_removal, otel,
         binary_path, log_file, quiet, rotate_logs, max_log_size,
     )?;
 
@@ -1194,7 +1227,7 @@ async fn run_exec(
         /* ssl_raw_data */ false, /* process */ true, /* stdio */ false,
         None, None, false, 8192, None, None,
         /* system */ true, /* system_interval */ 2,
-        &http_filter_patterns, /* disable_auth_removal */ false,
+        &http_filter_patterns, /* disable_auth_removal */ false, /* otel */ None,
         binary_path.as_deref(), log_file,
         /* quiet */ true, rotate_logs, max_log_size,
     )?;

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -1,0 +1,128 @@
+# OpenTelemetry GenAI Export
+
+AgentSight can export the LLM calls it captures as **OpenTelemetry GenAI
+semantic-convention** (`gen_ai.*`) spans, sent to any OpenTelemetry Collector
+over **OTLP/HTTP**. Because AgentSight reconstructs the traffic from the kernel
+(eBPF) side, you get standards-compliant GenAI telemetry for **any agent** —
+including closed-source CLIs — with **zero in-process instrumentation**.
+
+Spec: <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+
+## Quick start
+
+Point AgentSight at a running collector with `--otel`:
+
+```bash
+sudo ./agentsight trace --otel --otel-endpoint http://localhost:4318
+```
+
+Each LLM request/response pair becomes a `chat {model}` CLIENT span. By default
+only metadata is exported; pass `--otel-capture-content` to also include the
+prompt/completion text (off by default for privacy).
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--otel` | off | Enable GenAI span export. |
+| `--otel-endpoint <URL>` | `$OTEL_EXPORTER_OTLP_ENDPOINT` or `http://localhost:4318` | OTLP/HTTP base endpoint. `/v1/traces` is appended. |
+| `--otel-capture-content` | off | Include `gen_ai.input.messages` / `gen_ai.output.messages`. |
+
+Standard OTel env vars are honored: `OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (used as-is if set), and `OTEL_SERVICE_NAME`
+(default `agentsight`).
+
+## Run a collector
+
+A minimal collector that prints received spans:
+
+```yaml
+# otel-collector-config.yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+exporters:
+  debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]
+```
+
+```bash
+docker run -d --name otelcol -p 4318:4318 \
+  -v $(pwd)/otel-collector-config.yaml:/etc/otelcol/config.yaml \
+  otel/opentelemetry-collector:latest
+```
+
+## Integrating with other tools
+
+Because the export is plain OTLP, anything in the OpenTelemetry ecosystem can be
+the backend — just change the collector's exporters:
+
+- **Jaeger** — Jaeger accepts OTLP natively (ports 4317/4318); point AgentSight
+  at Jaeger, or fan out from the collector with an `otlp` exporter.
+- **Grafana Tempo** — add an `otlp` exporter targeting Tempo.
+- **Vendors** (Datadog, Honeycomb, New Relic, …) — all consume the OTel GenAI
+  conventions; add the vendor exporter to the collector pipeline.
+
+Example collector pipeline forwarding to a vendor:
+
+```yaml
+exporters:
+  otlphttp/vendor:
+    endpoint: https://otlp.example-vendor.com
+    headers: { "api-key": "${VENDOR_API_KEY}" }
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlphttp/vendor]
+```
+
+## Emitted attributes
+
+Per the GenAI agent/model span conventions:
+
+| Attribute | Source |
+|-----------|--------|
+| `gen_ai.operation.name` | `chat` |
+| `gen_ai.provider.name` | derived from the API host (`openai`, `anthropic`, `gcp.gen_ai`, `azure.ai.openai`, …) |
+| `gen_ai.request.model` | request body `model` |
+| `gen_ai.request.max_tokens` / `temperature` / `top_p` | request body |
+| `gen_ai.response.model` / `gen_ai.response.id` | response body |
+| `gen_ai.usage.input_tokens` / `output_tokens` | response `usage` (OpenAI & Anthropic shapes) |
+| `gen_ai.response.finish_reasons` | `choices[].finish_reason` or `stop_reason` |
+| `http.response.status_code` | response status (≥400 marks the span ERROR) |
+| `server.address` | API host |
+| `gen_ai.input.messages` / `gen_ai.output.messages` | **opt-in** via `--otel-capture-content` |
+
+The span's start/end times come from the captured request and response
+timestamps, so latency is measured at the wire.
+
+## How it works
+
+```
+agent → SSL_write/SSL_read (captured by eBPF sslsniff)
+      → HTTPParser reconstructs request + response
+      → OtelExporter pairs them by (pid, tid), maps to gen_ai.* attributes
+      → POST OTLP/HTTP JSON to the collector's /v1/traces
+```
+
+Provider detection is host-based and falls back to the host name for
+OpenAI-compatible endpoints (self-hosted vLLM, llama.cpp, …), so those still
+produce useful spans. Streamed (SSE) responses whose body can't be reparsed as
+JSON still emit a span with the request attributes and HTTP status.
+
+## Notes & limitations
+
+- OTLP/**HTTP** only (the standard collector receiver). For a remote collector
+  behind TLS, run a local collector and let it forward upstream.
+- One span per request/response pair (`chat`); multi-agent workflow spans
+  (`invoke_agent`, `execute_tool`) are not yet emitted — see issue #47.
+- The GenAI conventions are still experimental; attribute names track the
+  current spec.


### PR DESCRIPTION
Closes #47.

## Summary

Adds an `OtelExporter` analyzer that maps the LLM HTTP request/response pairs reconstructed by `HTTPParser` onto OpenTelemetry **GenAI semantic-convention** (`gen_ai.*`) spans, exported to an OpenTelemetry Collector over **OTLP/HTTP (JSON)**.

Because AgentSight captures traffic at the eBPF level, this produces standards-compliant, vendor-neutral GenAI telemetry for **any agent** — including closed-source CLIs — with **zero in-process instrumentation**.

```bash
sudo ./agentsight trace --otel --otel-endpoint http://localhost:4318
sudo ./agentsight trace --otel --otel-capture-content   # include prompt/completion text (opt-in)
```

## What it emits

Each request/response pair (correlated by `pid`+`tid`) becomes one `chat {model}` CLIENT span:

- `gen_ai.operation.name`, `gen_ai.provider.name` (host-derived: openai / anthropic / gcp.gen_ai / azure.ai.openai / aws.bedrock, falling back to the host for OpenAI-compatible endpoints)
- `gen_ai.request.{model,max_tokens,temperature,top_p}`
- `gen_ai.response.{model,id}`, `gen_ai.usage.{input,output}_tokens` (OpenAI **and** Anthropic usage shapes), `gen_ai.response.finish_reasons`
- `http.response.status_code` (≥400 → span ERROR)
- `gen_ai.{input,output}.messages` — **opt-in** via `--otel-capture-content`

Span start/end times come from the captured request/response timestamps (wire latency). Honors `OTEL_EXPORTER_OTLP_ENDPOINT` / `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` / `OTEL_SERVICE_NAME`.

## Official integration, verified end-to-end

Tested against the official `otel/opentelemetry-collector`. The collector received:

```
Span #0
    Name           : chat gpt-4o-mini
    Kind           : Client
    Status code    : Error
    Status message : HTTP 401
Attributes:
     -> gen_ai.operation.name: Str(chat)
     -> gen_ai.provider.name: Str(openai)
     -> gen_ai.request.model: Str(gpt-4o-mini)
     -> gen_ai.request.max_tokens: Int(16)
     -> gen_ai.request.temperature: Double(0.5)
     -> http.response.status_code: Int(401)
     -> gen_ai.input.messages: Str([{"content":"...","role":"user"}])
```

Since the wire format is plain OTLP, the collector can fan out to Jaeger, Grafana Tempo, Datadog, Honeycomb, New Relic, etc. — documented in `docs/otel.md`.

## Implementation notes

- **No new dependencies** — reuses the existing `hyper` / `hyper-util` / `http-body-util` / `uuid` crates.
- The exporter is added last in the SSL analyzer chain, so it observes fully-parsed, auth-scrubbed events; it passes events through unchanged and fires OTLP POSTs on a spawned task (never blocks the stream).
- Wired via `trace --otel [--otel-endpoint] [--otel-capture-content]`; `OtelConfig` threaded through `run_trace` / `build_trace_agent`.

## Tests

- `cargo test`: 101 pass (6 new unit tests covering path detection, provider mapping, usage/finish-reason parsing across OpenAI & Anthropic shapes, OTLP payload shape, and error-status mapping).

## Follow-ups (not in this PR)

- Multi-agent workflow spans (`invoke_agent`, `execute_tool`) and request↔process-tree trace correlation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)