### PR TITLE
ci: enforce clippy (-D warnings) + run C unit tests under AddressSanitizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+        components: clippy
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -56,10 +57,24 @@ jobs:
         cd collector
         cargo build --verbose
 
+    - name: Run clippy (deny warnings)
+      run: |
+        cd collector
+        cargo clippy --all-targets -- -D warnings
+
     - name: Run Rust tests
       run: |
         cd collector
         cargo test --verbose
+
+    # Rebuild the C unit tests under AddressSanitizer and run them. Done last and
+    # after `make clean` so the ASan objects don't replace the BPF binaries that
+    # the Rust collector build embeds above.
+    - name: Run C unit tests with AddressSanitizer
+      run: |
+        cd bpf
+        make clean
+        make ASAN=1 test
 
   docker:
     name: Build and Push Docker Image

--- a/collector/src/framework/analyzers/file_logger.rs
+++ b/collector/src/framework/analyzers/file_logger.rs
@@ -136,11 +136,10 @@ impl FileLogger {
                 let old_path = format!("{}.{}", file_path, i);
                 let new_path = format!("{}.{}", file_path, i + 1);
                 
-                if std::path::Path::new(&old_path).exists() {
-                    if let Err(e) = std::fs::rename(&old_path, &new_path) {
+                if std::path::Path::new(&old_path).exists()
+                    && let Err(e) = std::fs::rename(&old_path, &new_path) {
                         eprintln!("FileLogger: Failed to rotate {} to {}: {}", old_path, new_path, e);
                     }
-                }
             }
             
             // Move current file to .1
@@ -166,11 +165,10 @@ impl FileLogger {
             
             // Cleanup old files beyond max_files limit
             let cleanup_path = format!("{}.{}", file_path, config.max_files + 1);
-            if std::path::Path::new(&cleanup_path).exists() {
-                if let Err(e) = std::fs::remove_file(&cleanup_path) {
+            if std::path::Path::new(&cleanup_path).exists()
+                && let Err(e) = std::fs::remove_file(&cleanup_path) {
                     eprintln!("FileLogger: Failed to cleanup old log file {}: {}", cleanup_path, e);
                 }
-            }
         }
     }
 }
@@ -194,14 +192,12 @@ impl Analyzer for FileLogger {
                 *count += 1;
                 
                 // Check rotation at intervals
-                if *count % config.size_check_interval == 0 {
-                    if let Ok(metadata) = std::fs::metadata(&file_path) {
-                        if metadata.len() > config.max_file_size {
+                if (*count).is_multiple_of(config.size_check_interval)
+                    && let Ok(metadata) = std::fs::metadata(&file_path)
+                        && metadata.len() > config.max_file_size {
                             // Perform rotation
                             Self::perform_rotation(&file_handle, &file_path, config);
                         }
-                    }
-                }
             }
             
             // Log the event to file
@@ -211,12 +207,11 @@ impl Analyzer for FileLogger {
                     Ok(json_str) => {
                         // Parse and fix data field if it contains binary
                         if let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(&json_str) {
-                            if let Some(data_obj) = parsed.get_mut("data") {
-                                if let Some(data_field) = data_obj.get_mut("data") {
+                            if let Some(data_obj) = parsed.get_mut("data")
+                                && let Some(data_field) = data_obj.get_mut("data") {
                                     let data_str = Self::data_to_string(data_field);
                                     *data_field = serde_json::Value::String(data_str);
                                 }
-                            }
                             serde_json::to_string(&parsed).unwrap_or(json_str)
                         } else {
                             json_str

--- a/collector/src/framework/analyzers/http_filter.rs
+++ b/collector/src/framework/analyzers/http_filter.rs
@@ -27,13 +27,12 @@ pub fn print_global_http_filter_metrics() {
 
 /// Update global metrics with current filter metrics
 fn update_global_metrics(total: u64, filtered: u64, passed: u64) {
-    if let Some(metrics_ref) = HTTP_FILTER_GLOBAL_METRICS.get() {
-        if let Ok(mut metrics) = metrics_ref.lock() {
+    if let Some(metrics_ref) = HTTP_FILTER_GLOBAL_METRICS.get()
+        && let Ok(mut metrics) = metrics_ref.lock() {
             metrics.total_events_processed = total;
             metrics.filtered_events_count = filtered;
             metrics.passed_events_count = passed;
         }
-    }
 }
 
 /// HTTP Filter Analyzer that filters HTTP parser events based on configurable expressions
@@ -151,7 +150,7 @@ impl FilterExpression {
         
         if or_parts.len() > 1 {
             let conditions: Vec<FilterNode> = or_parts.into_iter()
-                .map(|part| Self::parse_and_expression(part))
+                .map(Self::parse_and_expression)
                 .collect();
             FilterNode::Or(conditions)
         } else {
@@ -165,7 +164,7 @@ impl FilterExpression {
         
         if and_parts.len() > 1 {
             let conditions: Vec<FilterNode> = and_parts.into_iter()
-                .map(|part| Self::parse_condition(part))
+                .map(Self::parse_condition)
                 .collect();
             FilterNode::And(conditions)
         } else {
@@ -298,7 +297,8 @@ impl FilterExpression {
                 match operator {
                     "prefix" => path.starts_with(value),
                     "contains" => path.contains(value),
-                    "exact" | _ => path == value,
+                    // "exact" and any unknown operator default to exact match
+                    _ => path == value,
                 }
             }
             "path_prefix" | "path_starts_with" => {
@@ -397,9 +397,7 @@ impl Analyzer for HTTPFilter {
                 total_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 
                 // Check if this is an HTTP parser event and should be filtered
-                let should_filter = if filters.is_empty() {
-                    false
-                } else if event.source != "http_parser" {
+                let should_filter = if filters.is_empty() || event.source != "http_parser" {
                     false
                 } else {
                     // Evaluate each filter expression

--- a/collector/src/framework/analyzers/http_parser.rs
+++ b/collector/src/framework/analyzers/http_parser.rs
@@ -226,12 +226,11 @@ impl HTTPParser {
         };
 
         // Only process if it's HTTP data AND can be parsed as a complete HTTP message
-        if Self::is_http_data(data_str) {
-            if let Some(parsed_message) = Self::parse_http_message(data_str) {
+        if Self::is_http_data(data_str)
+            && let Some(parsed_message) = Self::parse_http_message(data_str) {
                 let tid = ssl_data.get("tid").and_then(|v| v.as_u64()).unwrap_or(0);
                 return Some(Self::create_http_event(tid, parsed_message, &event, include_raw_data));
             }
-        }
 
         // If not parseable as HTTP, pass through original event
         Some(event)

--- a/collector/src/framework/analyzers/mod.rs
+++ b/collector/src/framework/analyzers/mod.rs
@@ -184,7 +184,7 @@ mod comprehensive_analyzer_chain_tests {
         println!("Total events: {}", events.len());
         
         // Verify events passed through all analyzers
-        assert!(events.len() > 0, "Should have events");
+        assert!(!events.is_empty(), "Should have events");
         
         // All remaining events should be SSL (due to filter)
         let non_ssl_events = events.iter().filter(|e| e.source != "ssl" && e.source != "sse_processor").count();

--- a/collector/src/framework/analyzers/otel_exporter.rs
+++ b/collector/src/framework/analyzers/otel_exporter.rs
@@ -233,11 +233,10 @@ fn build_otlp_payload(
         }
     }
 
-    if capture_content {
-        if let Some(msgs) = &req.input_messages {
+    if capture_content
+        && let Some(msgs) = &req.input_messages {
             attributes.push(attr_str("gen_ai.input.messages", msgs));
         }
-    }
 
     json!({
         "resourceSpans": [{

--- a/collector/src/framework/analyzers/output.rs
+++ b/collector/src/framework/analyzers/output.rs
@@ -40,12 +40,11 @@ impl Analyzer for OutputAnalyzer {
                 Ok(json_str) => {
                     // Parse and fix data field if it contains binary
                     if let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(&json_str) {
-                        if let Some(data_obj) = parsed.get_mut("data") {
-                            if let Some(data_field) = data_obj.get_mut("data") {
+                        if let Some(data_obj) = parsed.get_mut("data")
+                            && let Some(data_field) = data_obj.get_mut("data") {
                                 let data_str = Self::data_to_string(data_field);
                                 *data_field = serde_json::Value::String(data_str);
                             }
-                        }
                         serde_json::to_string(&parsed).unwrap_or(json_str)
                     } else {
                         json_str

--- a/collector/src/framework/analyzers/sse_processor.rs
+++ b/collector/src/framework/analyzers/sse_processor.rs
@@ -116,12 +116,12 @@ impl SSEProcessor {
             
             for line in block.split('\n') {
                 let line = line.trim();
-                if line.starts_with("event:") {
-                    event.event = Some(line[6..].trim().to_string());
-                } else if line.starts_with("data:") {
-                    data_lines.push(line[5..].trim());
-                } else if line.starts_with("id:") {
-                    event.id = Some(line[3..].trim().to_string());
+                if let Some(rest) = line.strip_prefix("event:") {
+                    event.event = Some(rest.trim().to_string());
+                } else if let Some(rest) = line.strip_prefix("data:") {
+                    data_lines.push(rest.trim());
+                } else if let Some(rest) = line.strip_prefix("id:") {
+                    event.id = Some(rest.trim().to_string());
                 }
             }
             
@@ -207,19 +207,14 @@ impl SSEProcessor {
     /// Extract message ID from SSE events - matches ssl_log_analyzer.py logic
     fn extract_message_id(events: &[SSEEvent]) -> Option<String> {
         for event in events {
-            if let Some(event_type) = &event.event {
-                if event_type == "message_start" {
-                    if let Some(parsed_data) = &event.parsed_data {
-                        if let Some(message) = parsed_data.get("message") {
-                            if let Some(id) = message.get("id") {
-                                if let Some(id_str) = id.as_str() {
+            if let Some(event_type) = &event.event
+                && event_type == "message_start"
+                    && let Some(parsed_data) = &event.parsed_data
+                        && let Some(message) = parsed_data.get("message")
+                            && let Some(id) = message.get("id")
+                                && let Some(id_str) = id.as_str() {
                                     return Some(id_str.to_string());
                                 }
-                            }
-                        }
-                    }
-                }
-            }
         }
         None
     }
@@ -246,10 +241,10 @@ impl SSEProcessor {
         
         // Fallback: check for very large buffer size as safety measure
         // Use much larger buffer limit to avoid cutting off long responses  
-        let size_timeout = accumulator.accumulated_text.len() > 50000 || 
-                          accumulator.accumulated_json.len() > 50000;
         
-        size_timeout
+        
+        accumulator.accumulated_text.len() > 50000 || 
+                          accumulator.accumulated_json.len() > 50000
     }
 
     /// Check if SSE stream contains meaningful content worth creating an event for
@@ -307,7 +302,7 @@ impl SSEProcessor {
                         accumulator.has_message_start = true;
                         // Extract message ID
                         if accumulator.message_id.is_none() {
-                            accumulator.message_id = Self::extract_message_id(&[event.clone()]);
+                            accumulator.message_id = Self::extract_message_id(std::slice::from_ref(event));
                         }
                         if debug {
                             eprintln!("[DEBUG]     Found message_start, has_message_start=true");
@@ -315,8 +310,8 @@ impl SSEProcessor {
                     }
                     "content_block_delta" => {
                         // Handle deltas - matches ssl_log_analyzer.py logic
-                        if let Some(parsed_data) = &event.parsed_data {
-                            if let Some(delta) = parsed_data.get("delta") {
+                        if let Some(parsed_data) = &event.parsed_data
+                            && let Some(delta) = parsed_data.get("delta") {
                                 let mut text = String::new();
                                 
                                 // Handle text delta
@@ -329,14 +324,13 @@ impl SSEProcessor {
                                     }
                                 }
                                 // Handle thinking delta
-                                else if delta.get("type").and_then(|v| v.as_str()) == Some("thinking_delta") {
-                                    if let Some(thinking_value) = delta.get("thinking").and_then(|v| v.as_str()) {
+                                else if delta.get("type").and_then(|v| v.as_str()) == Some("thinking_delta")
+                                    && let Some(thinking_value) = delta.get("thinking").and_then(|v| v.as_str()) {
                                         text = thinking_value.to_string();
                                         if debug {
                                             eprintln!("[DEBUG]     Extracted thinking_delta: '{}'", text);
                                         }
                                     }
-                                }
                                 
                                 if !text.is_empty() {
                                     chunk_text_parts.push(text.clone());
@@ -351,7 +345,6 @@ impl SSEProcessor {
                                     }
                                 }
                             }
-                        }
                     }
                     _ => {
                         if debug {

--- a/collector/src/framework/analyzers/sse_processor_tests.rs
+++ b/collector/src/framework/analyzers/sse_processor_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 eunomia-bpf org.
 
 #[cfg(test)]
+#[allow(clippy::module_inception)]
 mod sse_processor_tests {
     use super::super::sse_processor::SSEProcessor;
     use super::super::Analyzer;

--- a/collector/src/framework/analyzers/ssl_filter.rs
+++ b/collector/src/framework/analyzers/ssl_filter.rs
@@ -350,9 +350,7 @@ impl Analyzer for SSLFilter {
                 total_counter.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                 
                 // Check if this is an SSL event and should be filtered
-                let should_filter = if filters.is_empty() {
-                    false
-                } else if event.source != "ssl" {
+                let should_filter = if filters.is_empty() || event.source != "ssl" {
                     false
                 } else {
                     // Evaluate each filter expression

--- a/collector/src/framework/analyzers/timestamp_normalizer.rs
+++ b/collector/src/framework/analyzers/timestamp_normalizer.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-/// Timestamp Normalizer Analyzer
-///
-/// Converts all timestamps from nanoseconds since boot to milliseconds since UNIX epoch.
-/// This ensures timestamps are standardized for frontend consumption.
+//! Timestamp Normalizer Analyzer
+//!
+//! Converts all timestamps from nanoseconds since boot to milliseconds since UNIX epoch.
+//! This ensures timestamps are standardized for frontend consumption.
 
 use super::Analyzer;
 use crate::framework::core::Event;

--- a/collector/src/framework/binary_extractor.rs
+++ b/collector/src/framework/binary_extractor.rs
@@ -85,8 +85,7 @@ impl BinaryExtractor {
         }
 
         let _guard = self.stdiocap_init_lock.lock().map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
+            std::io::Error::other(
                 "stdiocap extraction lock poisoned",
             )
         })?;
@@ -108,8 +107,7 @@ impl BinaryExtractor {
         println!("Extracted stdiocap binary to: {}", stdiocap_path.display());
 
         self.stdiocap_path.set(stdiocap_path).map_err(|_| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
+            std::io::Error::other(
                 "stdiocap path initialized concurrently",
             )
         })?;

--- a/collector/src/framework/core/events.rs
+++ b/collector/src/framework/core/events.rs
@@ -50,7 +50,7 @@ impl Event {
     /// Get the event timestamp as a DateTime<Utc>
     pub fn datetime(&self) -> DateTime<Utc> {
         DateTime::from_timestamp_millis(self.timestamp as i64)
-            .unwrap_or_else(|| Utc::now())
+            .unwrap_or_else(Utc::now)
     }
 
     /// Convert to JSON string

--- a/collector/src/framework/core/timestamp.rs
+++ b/collector/src/framework/core/timestamp.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-/// Timestamp conversion utilities
-///
-/// All timestamps in the system are standardized to milliseconds since UNIX epoch
-/// for consistency and ease of use in the frontend.
+//! Timestamp conversion utilities
+//!
+//! All timestamps in the system are standardized to milliseconds since UNIX epoch
+//! for consistency and ease of use in the frontend.
 
 use std::fs;
 use std::sync::OnceLock;
@@ -22,28 +22,24 @@ pub fn get_boot_time_secs() -> i64 {
         // Try to read from /proc/stat (most reliable)
         if let Ok(content) = fs::read_to_string("/proc/stat") {
             for line in content.lines() {
-                if line.starts_with("btime ") {
-                    if let Some(btime_str) = line.split_whitespace().nth(1) {
-                        if let Ok(btime) = btime_str.parse::<i64>() {
+                if line.starts_with("btime ")
+                    && let Some(btime_str) = line.split_whitespace().nth(1)
+                        && let Ok(btime) = btime_str.parse::<i64>() {
                             return btime;
                         }
-                    }
-                }
             }
         }
 
         // Fallback: calculate from uptime
-        if let Ok(uptime_str) = fs::read_to_string("/proc/uptime") {
-            if let Some(uptime_secs_str) = uptime_str.split_whitespace().next() {
-                if let Ok(uptime_secs) = uptime_secs_str.parse::<f64>() {
+        if let Ok(uptime_str) = fs::read_to_string("/proc/uptime")
+            && let Some(uptime_secs_str) = uptime_str.split_whitespace().next()
+                && let Ok(uptime_secs) = uptime_secs_str.parse::<f64>() {
                     let now_secs = SystemTime::now()
                         .duration_since(UNIX_EPOCH)
                         .unwrap()
                         .as_secs() as i64;
                     return now_secs - uptime_secs as i64;
                 }
-            }
-        }
 
         // Last resort: return current time (will be incorrect but won't crash)
         SystemTime::now()
@@ -90,7 +86,7 @@ mod tests {
     #[test]
     fn test_boot_ns_to_epoch_ms_conversion() {
         // Test with a known timestamp: 1000 seconds after boot
-        let ns_since_boot = 1000_000_000_000u64; // 1000 seconds in nanoseconds
+        let ns_since_boot = 1_000_000_000_000u64; // 1000 seconds in nanoseconds
         let result_ms = boot_ns_to_epoch_ms(ns_since_boot);
 
         let boot_time = get_boot_time_secs();

--- a/collector/src/framework/runners/agent.rs
+++ b/collector/src/framework/runners/agent.rs
@@ -179,7 +179,7 @@ mod tests {
         
         // Check for events from different sources (SSL from FakeRunner, potentially processed by analyzers)
         let sources: std::collections::HashSet<_> = events.iter().map(|e| &e.source).collect();
-        assert!(sources.len() >= 1, "Should have events from at least one source");
+        assert!(!sources.is_empty(), "Should have events from at least one source");
     }
     
     #[tokio::test]

--- a/collector/src/framework/runners/common.rs
+++ b/collector/src/framework/runners/common.rs
@@ -63,20 +63,17 @@ impl BinaryExecutor {
         }
         
         let mut child = cmd.spawn()
-            .map_err(|e| Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other, 
+            .map_err(|e| Box::new(std::io::Error::other(
                 format!("Failed to start binary: {}", e)
             )) as RunnerError)?;
             
         let stdout = child.stdout.take()
-            .ok_or_else(|| Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other, 
+            .ok_or_else(|| Box::new(std::io::Error::other(
                 "Failed to get stdout"
             )) as RunnerError)?;
         
         let stderr = child.stderr.take()
-            .ok_or_else(|| Box::new(std::io::Error::new(
-                std::io::ErrorKind::Other, 
+            .ok_or_else(|| Box::new(std::io::Error::other(
                 "Failed to get stderr"
             )) as RunnerError)?;
         
@@ -229,8 +226,8 @@ impl BinaryExecutor {
                                     }
                                 }
                                 
-                                if valid_len > 0 {
-                                    if let Ok(valid_str) = std::str::from_utf8(&raw_bytes[0..valid_len]) {
+                                if valid_len > 0
+                                    && let Ok(valid_str) = std::str::from_utf8(&raw_bytes[0..valid_len]) {
                                         log::debug!("Recovered {} valid UTF-8 bytes before error", valid_len);
                                         // Try to parse the valid portion
                                         if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(valid_str.trim()) {
@@ -239,7 +236,6 @@ impl BinaryExecutor {
                                             continue;
                                         }
                                     }
-                                }
                             }
                             
                             // Log detailed error information

--- a/collector/src/framework/runners/fake.rs
+++ b/collector/src/framework/runners/fake.rs
@@ -503,7 +503,7 @@ mod tests {
                     max_events.fetch_max(current, Ordering::SeqCst);
                     
                     // Simulate processing and cleanup
-                    if current % 10 == 0 {
+                    if current.is_multiple_of(10) {
                         // Simulate periodic cleanup
                         event_count.store(0, Ordering::SeqCst);
                     }

--- a/collector/src/framework/runners/mod.rs
+++ b/collector/src/framework/runners/mod.rs
@@ -34,21 +34,16 @@ pub trait Runner: Send + Sync {
 
 /// Configuration for SSL/TLS monitoring
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct SslConfig {
     #[allow(dead_code)]
     pub tls_version: Option<String>,
 }
 
-impl Default for SslConfig {
-    fn default() -> Self {
-        Self {
-            tls_version: None,
-        }
-    }
-}
 
 /// Configuration for process monitoring
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct ProcessConfig {
     #[allow(dead_code)]
     pub pid: Option<u32>,
@@ -56,17 +51,10 @@ pub struct ProcessConfig {
     pub memory_threshold: Option<u64>,
 }
 
-impl Default for ProcessConfig {
-    fn default() -> Self {
-        Self {
-            pid: None,
-            memory_threshold: None,
-        }
-    }
-}
 
 /// Configuration for stdio payload monitoring
 #[derive(Debug, Clone)]
+#[derive(Default)]
 pub struct StdioConfig {
     #[allow(dead_code)]
     pub pid: Option<u32>,
@@ -78,16 +66,6 @@ pub struct StdioConfig {
     pub max_bytes: Option<u32>,
 }
 
-impl Default for StdioConfig {
-    fn default() -> Self {
-        Self {
-            pid: None,
-            uid: None,
-            all_fds: false,
-            max_bytes: None,
-        }
-    }
-}
 
 pub mod common;
 pub mod ssl;

--- a/collector/src/framework/runners/system.rs
+++ b/collector/src/framework/runners/system.rs
@@ -136,13 +136,11 @@ impl Runner for SystemRunner {
 /// Get nanoseconds since boot (matching bpf_ktime_get_ns() behavior)
 fn get_boot_time_ns() -> u64 {
     // Read /proc/uptime to get seconds since boot
-    if let Ok(uptime_str) = fs::read_to_string("/proc/uptime") {
-        if let Some(uptime_secs) = uptime_str.split_whitespace().next() {
-            if let Ok(secs) = uptime_secs.parse::<f64>() {
+    if let Ok(uptime_str) = fs::read_to_string("/proc/uptime")
+        && let Some(uptime_secs) = uptime_str.split_whitespace().next()
+            && let Ok(secs) = uptime_secs.parse::<f64>() {
                 return (secs * 1_000_000_000.0) as u64;
             }
-        }
-    }
     0
 }
 
@@ -237,15 +235,12 @@ fn find_pids_by_name(pattern: &str) -> Vec<u32> {
 
     if let Ok(entries) = fs::read_dir("/proc") {
         for entry in entries.flatten() {
-            if let Ok(file_name) = entry.file_name().into_string() {
-                if let Ok(pid) = file_name.parse::<u32>() {
-                    if let Ok(comm) = fs::read_to_string(format!("/proc/{}/comm", pid)) {
-                        if comm.trim().contains(pattern) {
+            if let Ok(file_name) = entry.file_name().into_string()
+                && let Ok(pid) = file_name.parse::<u32>()
+                    && let Ok(comm) = fs::read_to_string(format!("/proc/{}/comm", pid))
+                        && comm.trim().contains(pattern) {
                             matching_pids.push(pid);
                         }
-                    }
-                }
-            }
         }
     }
 
@@ -258,23 +253,19 @@ fn get_all_children(parent_pid: u32) -> Vec<u32> {
 
     if let Ok(entries) = fs::read_dir("/proc") {
         for entry in entries.flatten() {
-            if let Ok(file_name) = entry.file_name().into_string() {
-                if let Ok(pid) = file_name.parse::<u32>() {
-                    if let Ok(stat) = fs::read_to_string(format!("/proc/{}/stat", pid)) {
+            if let Ok(file_name) = entry.file_name().into_string()
+                && let Ok(pid) = file_name.parse::<u32>()
+                    && let Ok(stat) = fs::read_to_string(format!("/proc/{}/stat", pid)) {
                         // Extract PPID from stat file
                         let fields: Vec<&str> = stat.split_whitespace().collect();
-                        if fields.len() > 3 {
-                            if let Ok(ppid) = fields[3].parse::<u32>() {
-                                if ppid == parent_pid {
+                        if fields.len() > 3
+                            && let Ok(ppid) = fields[3].parse::<u32>()
+                                && ppid == parent_pid {
                                     children.push(pid);
                                     // Recursively get grandchildren
                                     children.extend(get_all_children(pid));
                                 }
-                            }
-                        }
                     }
-                }
-            }
         }
     }
 
@@ -333,16 +324,14 @@ fn collect_process_metrics(
 
     // Check thresholds for alerts
     let mut alert = false;
-    if let Some(cpu_threshold) = config.cpu_threshold {
-        if total_cpu_percent >= cpu_threshold {
+    if let Some(cpu_threshold) = config.cpu_threshold
+        && total_cpu_percent >= cpu_threshold {
             alert = true;
         }
-    }
-    if let Some(memory_threshold) = config.memory_threshold {
-        if total_rss_kb / 1024 >= memory_threshold {
+    if let Some(memory_threshold) = config.memory_threshold
+        && total_rss_kb / 1024 >= memory_threshold {
             alert = true;
         }
-    }
 
     // Build JSON payload
     let payload = json!({

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
+// The trace/record CLI handlers (run_trace, build_trace_agent, run_raw_ssl, …)
+// thread many positional arguments through. Collapsing them into a TraceConfig
+// struct is a tracked follow-up refactor; until then, allow the lint crate-wide.
+#![allow(clippy::too_many_arguments)]
+
 use clap::{Parser, Subcommand};
 use futures::stream::StreamExt;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -30,7 +35,7 @@ struct OtelConfig {
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 
 fn convert_runner_error(e: RunnerError) -> Box<dyn std::error::Error + Send + Sync> {
-    Box::new(std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+    Box::new(std::io::Error::other(e.to_string()))
 }
 
 async fn setup_signal_handler() {
@@ -396,7 +401,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
 
 /// Show raw SSL events as JSON with optional chunk merging and HTTP parsing
-async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bool, enable_http_parser: bool, include_raw_data: bool, http_filter_patterns: &Vec<String>, disable_auth_removal: bool, ssl_filter_patterns: &Vec<String>, quiet: bool, rotate_logs: bool, max_log_size: u64, enable_server: bool, server_port: u16, log_file: &str, binary_path: Option<&str>, args: &Vec<String>) -> Result<(), RunnerError> {
+async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bool, enable_http_parser: bool, include_raw_data: bool, http_filter_patterns: &[String], disable_auth_removal: bool, ssl_filter_patterns: &[String], quiet: bool, rotate_logs: bool, max_log_size: u64, enable_server: bool, server_port: u16, log_file: &str, binary_path: Option<&str>, args: &[String]) -> Result<(), RunnerError> {
     println!("Raw SSL Events");
     println!("{}", "=".repeat(60));
     
@@ -431,7 +436,7 @@ async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bo
 
     // Add SSL filter if patterns are provided
     if !ssl_filter_patterns.is_empty() {
-        ssl_runner = ssl_runner.add_analyzer(Box::new(SSLFilter::with_patterns(ssl_filter_patterns.clone())));
+        ssl_runner = ssl_runner.add_analyzer(Box::new(SSLFilter::with_patterns(ssl_filter_patterns.to_vec())));
     }
     
     // Add analyzers based on flags - when HTTP parser is enabled, always enable SSE merge first
@@ -448,7 +453,7 @@ async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bo
         
         // Add HTTP filter if patterns are provided
         if !http_filter_patterns.is_empty() {
-            ssl_runner = ssl_runner.add_analyzer(Box::new(HTTPFilter::with_patterns(http_filter_patterns.clone())));
+            ssl_runner = ssl_runner.add_analyzer(Box::new(HTTPFilter::with_patterns(http_filter_patterns.to_vec())));
         }
         
         // Add authorization header remover by default (unless disabled)
@@ -660,11 +665,10 @@ fn build_trace_agent(
         // because SSL traffic comes from "HTTP Client" thread (not the process name).
         // bpf_get_current_comm() returns thread name, so -c <process-name> would filter
         // out all SSL traffic. Instead, --binary-path alone provides sufficient targeting.
-        if binary_path.is_none() {
-            if let Some(comm_filter) = comm {
+        if binary_path.is_none()
+            && let Some(comm_filter) = comm {
                 ssl_args.extend(["-c".to_string(), comm_filter.to_string()]);
             }
-        }
         if ssl_handshake {
             ssl_args.push("--handshake".to_string());
         }
@@ -986,8 +990,8 @@ fn resolve_binary_path_inner(command: &str, depth: u8) -> Result<String, String>
 fn find_in_path(cmd: &str) -> Option<std::path::PathBuf> {
     let mut dirs: Vec<std::path::PathBuf> = Vec::new();
 
-    if let Some(user) = std::env::var_os("SUDO_USER") {
-        if let Some(home) = sudo_user_home(&user) {
+    if let Some(user) = std::env::var_os("SUDO_USER")
+        && let Some(home) = sudo_user_home(&user) {
             dirs.push(home.join(".local/bin"));
             dirs.push(home.join("bin"));
             // NVM keeps node under ~/.nvm/versions/node/<ver>/bin; pick the newest.
@@ -995,7 +999,6 @@ fn find_in_path(cmd: &str) -> Option<std::path::PathBuf> {
                 dirs.push(nvm_bin);
             }
         }
-    }
 
     if let Some(path) = std::env::var_os("PATH") {
         dirs.extend(std::env::split_paths(&path));
@@ -1003,11 +1006,10 @@ fn find_in_path(cmd: &str) -> Option<std::path::PathBuf> {
 
     for dir in dirs {
         let full = dir.join(cmd);
-        if let Ok(meta) = std::fs::metadata(&full) {
-            if meta.is_file() {
+        if let Ok(meta) = std::fs::metadata(&full)
+            && meta.is_file() {
                 return Some(full);
             }
-        }
     }
     None
 }

--- a/collector/tests/system_runner_test.rs
+++ b/collector/tests/system_runner_test.rs
@@ -93,15 +93,12 @@ fn test_process_discovery() {
     let mut found_processes = Vec::new();
     if let Ok(entries) = fs::read_dir("/proc") {
         for entry in entries.flatten() {
-            if let Ok(file_name) = entry.file_name().into_string() {
-                if let Ok(pid) = file_name.parse::<u32>() {
-                    if let Ok(comm) = fs::read_to_string(format!("/proc/{}/comm", pid)) {
-                        if comm.contains("test") || comm.contains("cargo") {
+            if let Ok(file_name) = entry.file_name().into_string()
+                && let Ok(pid) = file_name.parse::<u32>()
+                    && let Ok(comm) = fs::read_to_string(format!("/proc/{}/comm", pid))
+                        && (comm.contains("test") || comm.contains("cargo")) {
                             found_processes.push((pid, comm.trim().to_string()));
                         }
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds two quality gates to the CI `test` job and fixes the existing code so they pass:

1. **`cargo clippy --all-targets -- -D warnings`** — fails the build on any clippy warning.
2. **C unit tests under AddressSanitizer** — `make clean && make ASAN=1 test` (the Makefile already supports `ASAN=1`). Run last in the job so the ASan-instrumented objects don't replace the BPF binaries the Rust collector embeds.

`cargo fmt --check` is **intentionally deferred to a separate PR** — enabling it requires a repo-wide ~8k-line reformat that would pollute `git blame`, so it deserves its own dedicated commit.

## Clippy fixes

`clippy --fix` handled the mechanical bulk (83 → 0 warnings): collapsed nested `if let` into edition-2024 let-chains, redundant closures, derivable `impl`s, manual `is_multiple_of`, `io::Error::other`, etc. Manual fixes for: manual prefix-stripping → `strip_prefix`, identical `if` blocks, needless borrow, `&Vec<String>` → `&[String]`, inconsistent digit grouping, and `///` → `//!` module docs.

`clippy::too_many_arguments` is **allowed crate-wide** with a comment — the correct fix is collapsing the trace/record CLI plumbing into a `TraceConfig` struct, which is the next refactor PR (also addresses `main.rs` size, `unwrap()` hardening, dead code, and duplicate filter logic).

## Result

- Net **−47 lines**, no behavior changes.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 101 pass. `make ASAN=1 test`: 49 C tests pass, no ASan findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)