### PR TITLE
refactor: cut dead code — gate test-only items behind cfg(test), delete the rest

### DIFF
--- a/collector/src/framework/analyzers/file_logger.rs
+++ b/collector/src/framework/analyzers/file_logger.rs
@@ -93,7 +93,7 @@ impl FileLogger {
     }
 
     /// Create a new FileLogger with custom options (for backward compatibility)
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new_with_options<P: AsRef<Path>>(
         file_path: P,
         _pretty_print: bool,  // Ignored - we always use raw JSON

--- a/collector/src/framework/analyzers/sse_processor.rs
+++ b/collector/src/framework/analyzers/sse_processor.rs
@@ -52,7 +52,7 @@ pub struct SSEEvent {
 
 impl SSEProcessor {
     /// Create a new SSEProcessor with default timeout (30 seconds)
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new() -> Self {
         Self::new_with_timeout(30_000)
     }

--- a/collector/src/framework/core/events.rs
+++ b/collector/src/framework/core/events.rs
@@ -16,7 +16,7 @@ pub struct Event {
 
 impl Event {
     /// Create a new event with current timestamp
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new(source: String, pid: u32, comm: String, data: serde_json::Value) -> Self {
         Self {
             timestamp: std::time::SystemTime::now()
@@ -58,14 +58,8 @@ impl Event {
         serde_json::to_string(self)
     }
 
-    /// Serialize this event to pretty-printed JSON
-    #[allow(dead_code)]
-    pub fn to_json_pretty(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string_pretty(self)
-    }
-
     /// Deserialize an event from JSON string
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(json)
     }

--- a/collector/src/framework/mod.rs
+++ b/collector/src/framework/mod.rs
@@ -11,7 +11,10 @@ pub mod binary_extractor;
 #[allow(unused_imports)]
 pub use core::Event;
 #[allow(unused_imports)]
-pub use runners::{Runner, SslRunner, StdioRunner, ProcessRunner, FakeRunner, EventStream, RunnerError};
+pub use runners::{Runner, SslRunner, StdioRunner, ProcessRunner, EventStream, RunnerError};
+#[cfg(test)]
+#[allow(unused_imports)]
+pub use runners::FakeRunner;
 #[allow(unused_imports)]
 pub use analyzers::{Analyzer, OutputAnalyzer};
 #[allow(unused_imports)]

--- a/collector/src/framework/runners/fake.rs
+++ b/collector/src/framework/runners/fake.rs
@@ -28,14 +28,12 @@ impl FakeRunner {
     }
 
     /// Set custom event count (this will generate 2x events - request + response pairs)
-    #[allow(dead_code)]
     pub fn event_count(mut self, count: usize) -> Self {
         self.event_count = count;
         self
     }
     
     /// Set delay between events in milliseconds  
-    #[allow(dead_code)]
     pub fn delay_ms(mut self, delay: u64) -> Self {
         self.delay_ms = delay;
         self
@@ -43,7 +41,6 @@ impl FakeRunner {
 
 
     /// Add an analyzer to the chain
-    #[allow(dead_code)]
     pub fn add_analyzer(mut self, analyzer: Box<dyn Analyzer>) -> Self {
         self.analyzers.push(analyzer);
         self

--- a/collector/src/framework/runners/mod.rs
+++ b/collector/src/framework/runners/mod.rs
@@ -32,37 +32,27 @@ pub trait Runner: Send + Sync {
     fn id(&self) -> String;
 }
 
-/// Configuration for SSL/TLS monitoring
-#[derive(Debug, Clone)]
-#[derive(Default)]
+/// Configuration for SSL/TLS monitoring (only exercised by builder/tests).
+#[cfg(test)]
+#[derive(Debug, Clone, Default)]
 pub struct SslConfig {
-    #[allow(dead_code)]
     pub tls_version: Option<String>,
 }
 
-
-/// Configuration for process monitoring
-#[derive(Debug, Clone)]
-#[derive(Default)]
+/// Configuration for process monitoring (only exercised by builder/tests).
+#[cfg(test)]
+#[derive(Debug, Clone, Default)]
 pub struct ProcessConfig {
-    #[allow(dead_code)]
     pub pid: Option<u32>,
-    #[allow(dead_code)]
-    pub memory_threshold: Option<u64>,
 }
 
 
 /// Configuration for stdio payload monitoring
-#[derive(Debug, Clone)]
-#[derive(Default)]
+#[derive(Debug, Clone, Default)]
 pub struct StdioConfig {
-    #[allow(dead_code)]
     pub pid: Option<u32>,
-    #[allow(dead_code)]
     pub uid: Option<u32>,
-    #[allow(dead_code)]
     pub all_fds: bool,
-    #[allow(dead_code)]
     pub max_bytes: Option<u32>,
 }
 
@@ -70,7 +60,8 @@ pub struct StdioConfig {
 pub mod common;
 pub mod ssl;
 pub mod process;
-pub mod fake; // Add fake runner for testing
+#[cfg(test)]
+pub mod fake; // Test-only fake runner (compiled only for tests)
 pub mod agent; // Add agent runner for flexible composition
 pub mod stdio;
 pub mod system; // Add system runner for CPU and memory monitoring
@@ -78,6 +69,7 @@ pub mod system; // Add system runner for CPU and memory monitoring
 pub use ssl::SslRunner;
 pub use stdio::StdioRunner;
 pub use process::ProcessRunner;
-pub use fake::FakeRunner; // Export FakeRunner
+#[cfg(test)]
+pub use fake::FakeRunner; // Export FakeRunner (tests only)
 pub use agent::AgentRunner; // Export AgentRunner
 pub use system::SystemRunner; // Export SystemRunner

--- a/collector/src/framework/runners/process.rs
+++ b/collector/src/framework/runners/process.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use super::{Runner, ProcessConfig, EventStream, RunnerError};
+use super::{Runner, EventStream, RunnerError};
+#[cfg(test)]
+use super::ProcessConfig;
 use super::common::{BinaryExecutor, AnalyzerProcessor};
 use crate::framework::core::Event;
 use crate::framework::analyzers::Analyzer;
@@ -11,6 +13,8 @@ use futures::stream::StreamExt;
 
 /// Runner for collecting process/system events
 pub struct ProcessRunner {
+    // Config is only exercised by the builder/tests; excluded from prod builds.
+    #[cfg(test)]
     config: ProcessConfig,
     analyzers: Vec<Box<dyn Analyzer>>,
     executor: BinaryExecutor,
@@ -22,6 +26,7 @@ impl ProcessRunner {
     pub fn from_binary_extractor(binary_path: impl AsRef<Path>) -> Self {
         let path_str = binary_path.as_ref().to_string_lossy().to_string();
         Self {
+            #[cfg(test)]
             config: ProcessConfig::default(),
             analyzers: Vec::new(),
             executor: BinaryExecutor::new(path_str).with_runner_name("Process".to_string()),
@@ -43,16 +48,9 @@ impl ProcessRunner {
     }
 
     /// Set the PID to monitor
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn pid(mut self, pid: u32) -> Self {
         self.config.pid = Some(pid);
-        self
-    }
-
-    /// Set the memory threshold for filtering
-    #[allow(dead_code)]
-    pub fn memory_threshold(mut self, threshold: u64) -> Self {
-        self.config.memory_threshold = Some(threshold);
         self
     }
 }

--- a/collector/src/framework/runners/ssl.rs
+++ b/collector/src/framework/runners/ssl.rs
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use super::{Runner, SslConfig, EventStream, RunnerError};
+use super::{Runner, EventStream, RunnerError};
+#[cfg(test)]
+use super::SslConfig;
 use super::common::{BinaryExecutor, AnalyzerProcessor};
 use crate::framework::core::Event;
 use crate::framework::analyzers::Analyzer;
@@ -11,6 +13,8 @@ use futures::stream::StreamExt;
 
 /// Runner for collecting SSL/TLS events
 pub struct SslRunner {
+    // Config is only exercised by the builder/tests; excluded from prod builds.
+    #[cfg(test)]
     config: SslConfig,
     analyzers: Vec<Box<dyn Analyzer>>,
     executor: BinaryExecutor,
@@ -22,6 +26,7 @@ impl SslRunner {
     pub fn from_binary_extractor(binary_path: impl AsRef<Path>) -> Self {
         let path_str = binary_path.as_ref().to_string_lossy().to_string();
         Self {
+            #[cfg(test)]
             config: SslConfig::default(),
             analyzers: Vec::new(),
             executor: BinaryExecutor::new(path_str).with_runner_name("SSL".to_string()),
@@ -43,7 +48,7 @@ impl SslRunner {
     }
 
     /// Set the TLS version filter
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn tls_version(mut self, version: String) -> Self {
         self.config.tls_version = Some(version);
         self

--- a/collector/src/framework/runners/stdio.rs
+++ b/collector/src/framework/runners/stdio.rs
@@ -41,28 +41,28 @@ impl StdioRunner {
     }
 
     /// Set the PID to monitor
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn pid(mut self, pid: u32) -> Self {
         self.config.pid = Some(pid);
         self
     }
 
     /// Set the UID to monitor
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn uid(mut self, uid: u32) -> Self {
         self.config.uid = Some(uid);
         self
     }
 
     /// Capture all file descriptors instead of only 0/1/2
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn all_fds(mut self, enabled: bool) -> Self {
         self.config.all_fds = enabled;
         self
     }
 
     /// Limit captured payload bytes per event
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn max_bytes(mut self, max_bytes: u32) -> Self {
         self.config.max_bytes = Some(max_bytes);
         self


### PR DESCRIPTION
Follow-up to the codebase-quality review. I'd earlier waved off the 26 `#[allow(dead_code)]` as "intentional API" — that was an unverified assumption. Stripping them and rebuilding surfaced **15 real dead-code warnings**, which split cleanly into two kinds, handled individually instead of masked:

## Deleted (dead even in the test build)
- `Event::to_json_pretty`
- `ProcessRunner::memory_threshold` (builder method + `ProcessConfig` field)

## Moved to `#[cfg(test)]` (excluded from the production binary, not just un-warned)
- **`FakeRunner`** — the whole `fake` module + its re-exports were `pub` in production but only ever constructed by tests. ~650 LOC of test fixture no longer compiled into the shipped binary. *(This is the "if it's only used by tests, it should be in test" point.)*
- `Event::new` / `Event::from_json`, `SSEProcessor::new`, `FileLogger::new_with_options`
- The `SslRunner`/`ProcessRunner` `config` fields + `SslConfig`/`ProcessConfig` structs + their builder setters (`tls_version`, `pid`): written/read **only by tests**, never wired into production.

## Dropped redundant allows
`StdioConfig`'s field allows — those fields *are* read in production (stdio.rs:74-83), so the attributes were noise.

## Result
- `#[allow(dead_code)]`: **26 → 3**. The remaining three are the `Runner::name`/`id` and `Analyzer::name` trait methods, where `#[cfg(test)]` would force every impl to match — left intentionally.
- Production binary no longer carries the test scaffolding.

## Verification
- `cargo build` + `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 101 + 3 pass.
- Release binary `process` capture smoke-tested (107k events, no errors) — prod behavior unchanged, as expected since the gated `config` was never read in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)