### PR TITLE
refactor: extract shared filter-metrics machinery (http/ssl)

### DIFF
--- a/collector/src/framework/analyzers/filter_metrics.rs
+++ b/collector/src/framework/analyzers/filter_metrics.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+//! Shared global-metrics machinery for the HTTP and SSL filter analyzers.
+//!
+//! Both filters publish cumulative `{total, filtered, passed}` counters to a
+//! process-global slot so they can be printed after the run. They differ only
+//! in *how* they publish: the HTTP filter overwrites the slot with its latest
+//! cumulative snapshot inline ([`set`]), while the SSL filter adds its totals
+//! once on `Drop` ([`add`]). Both semantics are preserved here.
+
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// Cumulative filter counters published for end-of-run reporting.
+#[derive(Default)]
+pub(crate) struct FilterCounts {
+    pub total: u64,
+    pub filtered: u64,
+    pub passed: u64,
+}
+
+/// A process-global metrics slot owned by each filter analyzer.
+pub(crate) type MetricsSlot = OnceLock<Arc<Mutex<FilterCounts>>>;
+
+fn counts(slot: &MetricsSlot) -> &Arc<Mutex<FilterCounts>> {
+    slot.get_or_init(|| Arc::new(Mutex::new(FilterCounts::default())))
+}
+
+/// Overwrite the published counts with the latest cumulative snapshot.
+pub(crate) fn set(slot: &MetricsSlot, total: u64, filtered: u64, passed: u64) {
+    if let Ok(mut m) = counts(slot).lock() {
+        m.total = total;
+        m.filtered = filtered;
+        m.passed = passed;
+    }
+}
+
+/// Add the given counts to the published totals.
+pub(crate) fn add(slot: &MetricsSlot, total: u64, filtered: u64, passed: u64) {
+    if let Ok(mut m) = counts(slot).lock() {
+        m.total += total;
+        m.filtered += filtered;
+        m.passed += passed;
+    }
+}
+
+/// Print the published counts under the given label (e.g. "HTTPFilter").
+pub(crate) fn print(label: &str, slot: &MetricsSlot) {
+    match slot.get().and_then(|r| r.lock().ok()) {
+        Some(m) => println!(
+            "[{} Global Metrics] Total: {}, Filtered: {}, Passed: {}",
+            label, m.total, m.filtered, m.passed
+        ),
+        None => println!("[{} Global Metrics] No metrics available", label),
+    }
+}

--- a/collector/src/framework/analyzers/http_filter.rs
+++ b/collector/src/framework/analyzers/http_filter.rs
@@ -6,33 +6,18 @@ use crate::framework::runners::EventStream;
 use async_trait::async_trait;
 use futures::stream::StreamExt;
 use serde_json::Value;
-use std::sync::{Arc, Mutex};
 
-// Global metrics storage for HTTP filter
-static HTTP_FILTER_GLOBAL_METRICS: std::sync::OnceLock<Arc<Mutex<FilterMetrics>>> = std::sync::OnceLock::new();
+// Global metrics storage for HTTP filter (shared machinery in filter_metrics).
+static HTTP_FILTER_GLOBAL_METRICS: super::filter_metrics::MetricsSlot = std::sync::OnceLock::new();
 
 /// Print global HTTP filter metrics
 pub fn print_global_http_filter_metrics() {
-    if let Some(metrics_ref) = HTTP_FILTER_GLOBAL_METRICS.get() {
-        if let Ok(metrics) = metrics_ref.lock() {
-            println!("[HTTPFilter Global Metrics] Total: {}, Filtered: {}, Passed: {}", 
-                     metrics.total_events_processed, 
-                     metrics.filtered_events_count, 
-                     metrics.passed_events_count);
-        }
-    } else {
-        println!("[HTTPFilter Global Metrics] No metrics available");
-    }
+    super::filter_metrics::print("HTTPFilter", &HTTP_FILTER_GLOBAL_METRICS);
 }
 
-/// Update global metrics with current filter metrics
+/// Publish the latest cumulative counts (HTTP filter overwrites inline per event).
 fn update_global_metrics(total: u64, filtered: u64, passed: u64) {
-    if let Some(metrics_ref) = HTTP_FILTER_GLOBAL_METRICS.get()
-        && let Ok(mut metrics) = metrics_ref.lock() {
-            metrics.total_events_processed = total;
-            metrics.filtered_events_count = filtered;
-            metrics.passed_events_count = passed;
-        }
+    super::filter_metrics::set(&HTTP_FILTER_GLOBAL_METRICS, total, filtered, passed);
 }
 
 /// HTTP Filter Analyzer that filters HTTP parser events based on configurable expressions
@@ -81,12 +66,8 @@ pub enum FilterNode {
 impl HTTPFilter {
     /// Create a new HTTP filter with no patterns (passes everything through)
     pub fn new() -> Self {
-        // Initialize global metrics if not already done
-        let _ = HTTP_FILTER_GLOBAL_METRICS.set(Arc::new(Mutex::new(FilterMetrics {
-            total_events_processed: 0,
-            filtered_events_count: 0,
-            passed_events_count: 0,
-        })));
+        // Initialize global metrics so a filter that never runs still prints zeros.
+        update_global_metrics(0, 0, 0);
 
         HTTPFilter {
             exclude_patterns: Vec::new(),
@@ -113,17 +94,6 @@ impl HTTPFilter {
 
 
 
-}
-
-/// Metrics for HTTP filtering
-#[derive(Debug, Clone)]
-pub struct FilterMetrics {
-    pub total_events_processed: u64,
-    pub filtered_events_count: u64,
-    pub passed_events_count: u64,
-}
-
-impl FilterMetrics {
 }
 
 impl FilterExpression {

--- a/collector/src/framework/analyzers/mod.rs
+++ b/collector/src/framework/analyzers/mod.rs
@@ -25,6 +25,7 @@ pub mod http_parser;
 pub mod http_filter;
 pub mod auth_header_remover;
 pub mod ssl_filter;
+mod filter_metrics;
 pub mod event;
 pub mod common;
 pub mod timestamp_normalizer;

--- a/collector/src/framework/analyzers/ssl_filter.rs
+++ b/collector/src/framework/analyzers/ssl_filter.rs
@@ -7,6 +7,19 @@ use async_trait::async_trait;
 use futures::stream::StreamExt;
 use serde_json::Value;
 
+// Global metrics storage for SSL filter (shared machinery in filter_metrics).
+static SSL_FILTER_GLOBAL_METRICS: super::filter_metrics::MetricsSlot = std::sync::OnceLock::new();
+
+/// Print global SSL filter metrics
+pub fn print_global_ssl_filter_metrics() {
+    super::filter_metrics::print("SSLFilter", &SSL_FILTER_GLOBAL_METRICS);
+}
+
+/// Accumulate this filter's totals into the global counts (called once on Drop).
+fn update_global_ssl_metrics(total: u64, filtered: u64, passed: u64) {
+    super::filter_metrics::add(&SSL_FILTER_GLOBAL_METRICS, total, filtered, passed);
+}
+
 /// SSL Filter Analyzer that filters SSL events based on configurable expressions
 /// Filters SSL events based on data content, function, latency, etc.
 pub struct SSLFilter {
@@ -537,45 +550,3 @@ mod tests {
     }
 }
 
-// Global metrics storage for SSL filter
-use std::sync::{Arc, Mutex, OnceLock};
-
-#[derive(Debug, Clone)]
-struct SSLFilterMetrics {
-    total_events_processed: u64,
-    filtered_events_count: u64, 
-    passed_events_count: u64,
-}
-
-static SSL_FILTER_GLOBAL_METRICS: OnceLock<Arc<Mutex<SSLFilterMetrics>>> = OnceLock::new();
-
-/// Print global SSL filter metrics
-pub fn print_global_ssl_filter_metrics() {
-    if let Some(metrics_ref) = SSL_FILTER_GLOBAL_METRICS.get() {
-        if let Ok(metrics) = metrics_ref.lock() {
-            println!("[SSLFilter Global Metrics] Total: {}, Filtered: {}, Passed: {}", 
-                     metrics.total_events_processed, 
-                     metrics.filtered_events_count, 
-                     metrics.passed_events_count);
-        }
-    } else {
-        println!("[SSLFilter Global Metrics] No metrics available");
-    }
-}
-
-/// Update global SSL filter metrics
-fn update_global_ssl_metrics(total: u64, filtered: u64, passed: u64) {
-    let metrics = SSL_FILTER_GLOBAL_METRICS.get_or_init(|| {
-        Arc::new(Mutex::new(SSLFilterMetrics {
-            total_events_processed: 0,
-            filtered_events_count: 0,
-            passed_events_count: 0,
-        }))
-    });
-    
-    if let Ok(mut m) = metrics.lock() {
-        m.total_events_processed += total;
-        m.filtered_events_count += filtered;
-        m.passed_events_count += passed;
-    }
-}


### PR DESCRIPTION
You asked me to dedup the `http_filter` / `ssl_filter` global-metrics duplication. Done — with one honest caveat below.

## What was duplicated
Each filter carried its own copy of: a `{total,filtered,passed}` counts struct, an `OnceLock` global slot, a `print_global_*` function, and an `update_global_*` function. Extracted into `analyzers/filter_metrics.rs` (`FilterCounts` + `set`/`add`/`print` over a `MetricsSlot`).

## The subtlety the duplication was hiding
They were **not** identical: the HTTP filter **overwrites** the global snapshot inline per event (`set`), while the SSL filter **adds** its totals once on `Drop` (`add`). A naive merge would have silently changed one filter's reported numbers. Both semantics are preserved as distinct `set()`/`add()` helpers, and the divergence is now documented instead of implicit.

The public `print_global_*` names and the per-instance atomic counters / hot-path increments are unchanged.

## Honest note on LOC
**Net ≈ −2 lines.** Extracting into a documented shared module costs about as many lines as the duplication it removes. The win here is *single source of truth* (change metrics behavior once, not twice) and surfacing the set-vs-add divergence — not raw line count. As I flagged earlier, this codebase doesn't have much fat left to trim via dedup; real LOC cuts would mean removing features/tests.

## Verification
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 101 + 3 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)