### PR TITLE
feat: make SSEProcessor honor timeout_ms (evict idle SSE buffers)

### DIFF
--- a/collector/src/framework/analyzers/sse_processor.rs
+++ b/collector/src/framework/analyzers/sse_processor.rs
@@ -17,8 +17,8 @@ use super::event::SSEProcessorEvent;
 pub struct SSEProcessor {
     /// Store accumulated SSE content by connection + message ID
     sse_buffers: Arc<Mutex<HashMap<String, SSEAccumulator>>>,
-    /// Timeout for incomplete SSE streams (in milliseconds)
-    #[allow(dead_code)]
+    /// Evict SSE accumulators idle longer than this (milliseconds), bounding
+    /// memory for streams that never send a terminating chunk.
     timeout_ms: u64,
     /// Enable debug output (matches Python quiet flag)
     debug: bool,
@@ -425,6 +425,7 @@ impl Analyzer for SSEProcessor {
         self.debug_print("[DEBUG] SSEProcessor: Starting SSE event processing");
         
         let debug = self.debug;
+        let timeout_ms = self.timeout_ms;
         let processed_stream = stream.filter_map(move |event| {
             let buffers = Arc::clone(&sse_buffers);
             
@@ -509,7 +510,11 @@ impl Analyzer for SSEProcessor {
                 
                 // Store/accumulate SSE events for this connection
                 let mut buffers_lock = buffers.lock().unwrap();
-                
+
+                // Evict accumulators idle past the timeout (streams that never
+                // sent a terminating chunk) so the buffer map can't grow forever.
+                buffers_lock.retain(|_, acc| event.timestamp.saturating_sub(acc.last_update) <= timeout_ms);
+
                 // Improve message ID matching - use the first available message ID as connection ID
                 let mut final_connection_id = connection_id.clone();
                 


### PR DESCRIPTION
You asked me to investigate `SSEProcessor::timeout_ms` and, given the finding, implement it (minimal code).

## The finding
`timeout_ms` was **stored but never read** — the SSE timeout feature was completely unimplemented. The accumulator map (`sse_buffers`) only removed an entry when a stream sent its **terminating chunk** (sse_processor.rs:595). A stream that drops or is killed mid-flight (connection reset, agent SIGKILL, malformed end) **leaks its buffer forever** — latent unbounded memory growth. `timeout_ms` was the intended (never-written) guard.

## The fix (minimal)
On each SSE event, evict accumulators idle longer than `timeout_ms`:

```rust
buffers_lock.retain(|_, acc| event.timestamp.saturating_sub(acc.last_update) <= timeout_ms);
```

Two functional lines (capture `timeout_ms` into the closure + the `retain`), reusing the existing `last_update: u64` field. Also drops the now-unneeded `#[allow(dead_code)]`. **Net +5 lines.**

## Correctness check
The comparison assumes ms-since-epoch timestamps. Verified that `TimestampNormalizer` (ns→ms) precedes `SSEProcessor` in **all three** SSL chains (`ssl`, `trace`, `record`), so it's always ms-to-ms. If someone ever reorders those analyzers, eviction would misfire — worth a guard, but adding a full-pipeline test exceeds the "minimal code" ask; flagging it here instead.

## Verification
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 101 + 3 pass (synthetic test timestamps are small, so nothing evicts — no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)