### PR TITLE
refactor: remove dead live-streaming infra + ignored filter params (−95 LOC)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ eBPF Programs (kernel) → JSON stdout → Rust Runners → Analyzer Chain → O
 - **`bpf/`** — C eBPF programs. `sslsniff` hooks SSL_read/SSL_write via uprobes; `process` tracks process lifecycle via tracepoints. Both emit JSON to stdout.
 - **`collector/src/framework/`** — Rust streaming framework:
   - `runners/` — Execute eBPF binaries and parse their JSON output into event streams (SslRunner, ProcessRunner, SystemRunner, FakeRunner)
-  - `analyzers/` — Pluggable stream processors: ChunkMerger, SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, FileLogger, AuthHeaderRemover, OtelExporter (maps LLM HTTP pairs to OpenTelemetry `gen_ai.*` spans, exported via OTLP/HTTP JSON; enabled by `trace --otel`, see `docs/otel.md`)
+  - `analyzers/` — Pluggable stream processors: SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, FileLogger, AuthHeaderRemover, TimestampNormalizer, OtelExporter (maps LLM HTTP pairs to OpenTelemetry `gen_ai.*` spans, exported via OTLP/HTTP JSON; enabled by `trace --otel`, see `docs/otel.md`)
   - `core/events.rs` — Standardized `Event` struct with JSON payloads
   - `binary_extractor.rs` — Extracts embedded eBPF binaries to temp files at runtime
 - **`collector/src/main.rs`** — CLI entry point. Subcommands: `ssl`, `process`, `trace` (most flexible), `record` (optimized defaults)

--- a/collector/src/framework/analyzers/LOG_ROTATION_DESIGN.md
+++ b/collector/src/framework/analyzers/LOG_ROTATION_DESIGN.md
@@ -215,7 +215,6 @@ async fn test_concurrent_rotation()
 
 ### Existing API Unchanged
 - `FileLogger::new()` continues to work without rotation
-- `FileLogger::new_with_options()` remains deprecated but functional
 - All existing tests pass without modification
 
 ### Migration Path

--- a/collector/src/framework/analyzers/file_logger.rs
+++ b/collector/src/framework/analyzers/file_logger.rs
@@ -92,16 +92,6 @@ impl FileLogger {
         Self::with_rotation(file_path, config)
     }
 
-    /// Create a new FileLogger with custom options (for backward compatibility)
-    #[cfg(test)]
-    pub fn new_with_options<P: AsRef<Path>>(
-        file_path: P,
-        _pretty_print: bool,  // Ignored - we always use raw JSON
-        _log_all_events: bool, // Ignored - we always log all events
-    ) -> Result<Self, std::io::Error> {
-        Self::new(file_path)
-    }
-
     /// Convert binary data to hex string
     fn data_to_string(data: &serde_json::Value) -> String {
         match data {
@@ -262,7 +252,7 @@ mod tests {
     #[tokio::test]
     async fn test_file_logger_with_options() {
         let temp_file = NamedTempFile::new().unwrap();
-        let logger = FileLogger::new_with_options(temp_file.path(), false, false).unwrap();
+        let logger = FileLogger::new(temp_file.path()).unwrap();
         assert_eq!(logger.name(), "FileLogger");
     }
 

--- a/collector/src/framework/analyzers/http_filter.rs
+++ b/collector/src/framework/analyzers/http_filter.rs
@@ -249,7 +249,9 @@ impl FilterExpression {
         if target == "request" {
             self.evaluate_request_condition(field, operator, value, data)
         } else if target == "response" {
-            self.evaluate_response_condition(field, operator, value, data)
+            // Response conditions match by equality (status_code) or substring
+            // (text/header/body) only; operators are not supported here.
+            self.evaluate_response_condition(field, value, data)
         } else {
             false
         }
@@ -304,7 +306,7 @@ impl FilterExpression {
     }
 
     /// Evaluate response conditions
-    fn evaluate_response_condition(&self, field: &str, _operator: &str, value: &str, data: &Value) -> bool {
+    fn evaluate_response_condition(&self, field: &str, value: &str, data: &Value) -> bool {
         match field {
             "status_code" | "status" | "code" => {
                 let status_code = data.get("status_code").and_then(|v| v.as_u64()).unwrap_or(0);

--- a/collector/src/framework/runners/fake.rs
+++ b/collector/src/framework/runners/fake.rs
@@ -280,7 +280,7 @@ mod tests {
         let mut runner = FakeRunner::new()
             .event_count(2)
             .delay_ms(10)
-            .add_analyzer(Box::new(FileLogger::new_with_options(test_log_file, true, true).unwrap()));
+            .add_analyzer(Box::new(FileLogger::new(test_log_file).unwrap()));
 
         let stream = runner.run().await.unwrap();
         let events: Vec<_> = stream.collect().await;
@@ -343,8 +343,8 @@ mod tests {
             .event_count(2)
             .delay_ms(10)
             .add_analyzer(Box::new(SSEProcessor::new_with_timeout(5000)))
-            .add_analyzer(Box::new(FileLogger::new_with_options(test_log_file1, true, true).unwrap()))
-            .add_analyzer(Box::new(FileLogger::new_with_options(test_log_file2, false, false).unwrap())) // Different settings
+            .add_analyzer(Box::new(FileLogger::new(test_log_file1).unwrap()))
+            .add_analyzer(Box::new(FileLogger::new(test_log_file2).unwrap())) // Different settings
             .add_analyzer(Box::new(OutputAnalyzer::new()))
             .add_analyzer(Box::new(OutputAnalyzer::new())); // Different settings
 
@@ -576,7 +576,7 @@ mod tests {
             .event_count(10) // 20 events total
             .delay_ms(25) // Realistic timing
             .add_analyzer(Box::new(SSEProcessor::new_with_timeout(10000))) // 10 second timeout
-            .add_analyzer(Box::new(FileLogger::new_with_options(test_log_file, true, true).unwrap()))
+            .add_analyzer(Box::new(FileLogger::new(test_log_file).unwrap()))
             .add_analyzer(Box::new(OutputAnalyzer::new())); // Silent for test
 
         let start_time = Instant::now();

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -11,7 +11,6 @@ use clap::{Parser, Subcommand};
 use futures::stream::StreamExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use tokio::signal;
-use tokio::sync::broadcast;
 
 mod framework;
 mod server;
@@ -480,8 +479,6 @@ async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bo
     
     let mut ssl_runner = SslRunner::from_binary_extractor(binary_extractor.get_sslsniff_path());
 
-    // Set up event broadcasting for server if enabled
-    let (event_sender, _event_receiver) = broadcast::channel(1000);
 
     // Translate a `docker://<container>` binary path to the host /proc/<pid>/exe
     // of the container's SSL-embedding process (see resolve_container_binary_path).
@@ -561,18 +558,13 @@ async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bo
     }
     
     // Start web server if enabled
-    let _server_handle = start_web_server_if_enabled(enable_server, server_port, Some(log_file), event_sender.clone()).await
+    let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
         .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
 
     let mut stream = ssl_runner.run().await?;
     
-    // Consume the stream to actually process events
-    while let Some(event) = stream.next().await {
-        // Forward events to web server if enabled
-        if enable_server {
-            let _ = event_sender.send(event);
-        }
-    }
+    // Drive the stream so the analyzer chain (file logging, etc.) runs.
+    while stream.next().await.is_some() {}
     
     Ok(())
 }
@@ -584,8 +576,6 @@ async fn run_raw_process(binary_extractor: &BinaryExtractor, quiet: bool, rotate
     
     let mut process_runner = ProcessRunner::from_binary_extractor(binary_extractor.get_process_path());
 
-    // Set up event broadcasting for server if enabled
-    let (event_sender, _event_receiver) = broadcast::channel(1000);
 
     // Add additional arguments if provided
     if !args.is_empty() {
@@ -609,19 +599,14 @@ async fn run_raw_process(binary_extractor: &BinaryExtractor, quiet: bool, rotate
         ));
 
     // Start web server if enabled
-    let _server_handle = start_web_server_if_enabled(enable_server, server_port, Some(log_file), event_sender.clone()).await
+    let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
         .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
     
     println!("Starting process event stream with raw JSON output (press Ctrl+C to stop):");
     let mut stream = process_runner.run().await?;
 
-    // Consume the stream to actually process events
-    while let Some(event) = stream.next().await {
-        // Forward events to web server if enabled
-        if enable_server {
-            let _ = event_sender.send(event);
-        }
-    }
+    // Drive the stream so the analyzer chain (file logging, etc.) runs.
+    while stream.next().await.is_some() {}
 
     Ok(())
 }
@@ -650,8 +635,6 @@ async fn run_raw_stdio(binary_extractor: &BinaryExtractor, pid: u32, uid: Option
 
     let mut stdio_runner = StdioRunner::from_binary_extractor(binary_extractor.get_stdiocap_path()?);
 
-    // Set up event broadcasting for server if enabled
-    let (event_sender, _event_receiver) = broadcast::channel(1000);
 
     let stdio_args = build_stdio_args(pid, uid, comm, all_fds, max_bytes);
     stdio_runner = stdio_runner.with_args(&stdio_args);
@@ -673,17 +656,14 @@ async fn run_raw_stdio(binary_extractor: &BinaryExtractor, pid: u32, uid: Option
         ));
 
     // Start web server if enabled
-    let _server_handle = start_web_server_if_enabled(enable_server, server_port, Some(log_file), event_sender.clone()).await
+    let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
         .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
 
     println!("Starting stdio event stream for PID {} (press Ctrl+C to stop):", pid);
     let mut stream = stdio_runner.run().await?;
 
-    while let Some(event) = stream.next().await {
-        if enable_server {
-            let _ = event_sender.send(event);
-        }
-    }
+    // Drive the stream so the analyzer chain (file logging, etc.) runs.
+    while stream.next().await.is_some() {}
 
     Ok(())
 }
@@ -928,8 +908,6 @@ async fn run_trace(
     let server_port = cfg.server_port;
     let log_file = cfg.log_file.clone();
 
-    // Set up event broadcasting for server if enabled
-    let (event_sender, _event_receiver) = broadcast::channel(1000);
 
     let mut agent = build_trace_agent(binary_extractor, &cfg)?;
 
@@ -939,18 +917,13 @@ async fn run_trace(
     println!("Press Ctrl+C to stop");
 
     // Start web server if enabled
-    let _server_handle = start_web_server_if_enabled(enable_server, server_port, Some(&log_file), event_sender.clone()).await
+    let _server_handle = start_web_server_if_enabled(enable_server, server_port, &log_file).await
         .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
 
     let mut stream = agent.run().await?;
 
-    // Consume the stream to actually process events
-    while let Some(event) = stream.next().await {
-        // Forward events to web server if enabled
-        if enable_server {
-            let _ = event_sender.send(event);
-        }
-    }
+    // Drive the stream so the analyzer chain (file logging, etc.) runs.
+    while stream.next().await.is_some() {}
 
     Ok(())
 }
@@ -1008,7 +981,6 @@ async fn run_exec(
     };
     println!("✓ Process filter (--comm): {}", comm);
 
-    let (event_sender, _event_receiver) = broadcast::channel(1000);
 
     // Same optimized filters as the `record` command.
     let cfg = TraceConfig {
@@ -1033,7 +1005,7 @@ async fn run_exec(
     let mut agent = build_trace_agent(binary_extractor, &cfg)?;
 
     // Start web server before launching the child so the UI is ready immediately.
-    let _server_handle = start_web_server_if_enabled(enable_server, server_port, Some(log_file), event_sender.clone()).await
+    let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
         .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
 
     // Attach eBPF first (uprobes bind to the binary file, so they catch the
@@ -1057,11 +1029,7 @@ async fn run_exec(
         tokio::select! {
             maybe_event = stream.next() => {
                 match maybe_event {
-                    Some(event) => {
-                        if enable_server {
-                            let _ = event_sender.send(event);
-                        }
-                    }
+                    Some(_event) => {} // drive the stream; events are persisted via the file logger
                     None => break, // event stream ended
                 }
             }
@@ -1135,8 +1103,6 @@ async fn run_system(
     println!("{}", "=".repeat(60));
     println!("Starting system monitoring (press Ctrl+C to stop):");
 
-    // Set up event broadcasting for server if enabled
-    let (event_sender, _event_receiver) = broadcast::channel(1000);
 
     // Add TimestampNormalizer first
     system_runner = system_runner.add_analyzer(Box::new(TimestampNormalizer::new()));
@@ -1157,23 +1123,13 @@ async fn run_system(
     }
 
     // Start web server if enabled
-    let _server_handle = start_web_server_if_enabled(
-        enable_server,
-        server_port,
-        Some(log_file),
-        event_sender.clone()
-    ).await
+    let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
         .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
 
     let mut stream = system_runner.run().await?;
 
-    // Consume the stream to actually process events
-    while let Some(event) = stream.next().await {
-        // Forward events to web server if enabled
-        if enable_server {
-            let _ = event_sender.send(event);
-        }
-    }
+    // Drive the stream so the analyzer chain (file logging, etc.) runs.
+    while stream.next().await.is_some() {}
 
     Ok(())
 }
@@ -1181,8 +1137,7 @@ async fn run_system(
 async fn start_web_server_if_enabled(
     enable_server: bool,
     port: u16,
-    log_file: Option<&str>,
-    event_sender: broadcast::Sender<crate::framework::core::Event>,
+    log_file: &str,
 ) -> Result<Option<tokio::task::JoinHandle<()>>, Box<dyn std::error::Error>> {
     if !enable_server {
         return Ok(None);
@@ -1191,7 +1146,7 @@ async fn start_web_server_if_enabled(
     let addr = format!("0.0.0.0:{}", port).parse()
         .map_err(|e| format!("Invalid server address: {}", e))?;
 
-    let web_server = WebServer::new(event_sender, log_file).map_err(|e| format!("Failed to create web server: {}", e))?;
+    let web_server = WebServer::new(log_file).map_err(|e| format!("Failed to create web server: {}", e))?;
 
     println!("🌐 Starting web server on http://{}", addr);
     println!("   Frontend will be available once the server starts");

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use crate::framework::core::Event;
 use crate::server::assets::FrontendAssets;
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -12,21 +11,18 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
-use tokio::sync::broadcast;
 
 pub struct WebServer {
     assets: Arc<FrontendAssets>,
-    event_sender: broadcast::Sender<Event>,
-    log_file: Option<String>,
+    log_file: String,
 }
 
 impl WebServer {
-    pub fn new(event_sender: broadcast::Sender<Event>, log_file: Option<&str>) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    pub fn new(log_file: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let assets = FrontendAssets::new()?;
         Ok(Self {
             assets: Arc::new(assets),
-            event_sender,
-            log_file: log_file.map(|s| s.to_string()),
+            log_file: log_file.to_string(),
         })
     }
     
@@ -47,13 +43,12 @@ impl WebServer {
         loop {
             let (stream, _) = listener.accept().await.map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
             let assets = Arc::clone(&self.assets);
-            let event_sender = self.event_sender.clone();
             let log_file = self.log_file.clone();
-            
+
             tokio::spawn(async move {
                 let io = TokioIo::new(stream);
                 let service = service_fn(move |req| {
-                    handle_request(req, assets.clone(), event_sender.clone(), log_file.clone())
+                    handle_request(req, assets.clone(), log_file.clone())
                 });
                 
                 if let Err(err) = http1::Builder::new()
@@ -70,17 +65,16 @@ impl WebServer {
 async fn handle_request(
     req: Request<hyper::body::Incoming>,
     assets: Arc<FrontendAssets>,
-    event_sender: broadcast::Sender<Event>,
-    log_file: Option<String>,
+    log_file: String,
 ) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
     let path = req.uri().path();
-    
+
     log::info!("📨 {} {}", req.method(), path);
-    
+
     match (req.method(), path) {
         // API endpoints first
         (&Method::GET, "/api/events") => {
-            serve_events_api(event_sender, log_file).await
+            serve_events_api(&log_file).await
         }
         (&Method::GET, "/api/assets") => {
             serve_assets_list(assets).await
@@ -126,62 +120,26 @@ async fn serve_asset(
 }
 
 async fn serve_events_api(
-    _event_sender: broadcast::Sender<Event>,
-    log_file: Option<String>,
+    log_path: &str,
 ) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
-    // If log file is specified, read and return its contents
-    if let Some(log_path) = log_file {
-        match tokio::fs::read_to_string(&log_path).await {
-            Ok(content) => {
-                log::info!("📊 Serving log file: {} ({} bytes)", log_path, content.len());
-                Ok(Response::builder()
-                    .header("Content-Type", "text/plain")
-                    .header("Access-Control-Allow-Origin", "*")
-                    .body(Full::new(Bytes::from(content)))
-                    .unwrap())
-            }
-            Err(e) => {
-                log::error!("❌ Failed to read log file {}: {}", log_path, e);
-                Ok(Response::builder()
-                    .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .header("Content-Type", "text/plain")
-                    .header("Access-Control-Allow-Origin", "*")
-                    .body(Full::new(Bytes::from(format!("Failed to read log file: {}", e))))
-                    .unwrap())
-            }
+    match tokio::fs::read_to_string(log_path).await {
+        Ok(content) => {
+            log::info!("📊 Serving log file: {} ({} bytes)", log_path, content.len());
+            Ok(Response::builder()
+                .header("Content-Type", "text/plain")
+                .header("Access-Control-Allow-Origin", "*")
+                .body(Full::new(Bytes::from(content)))
+                .unwrap())
         }
-    } else {
-        // Return sample events as JSON for now
-        let events = serde_json::json!([
-            {
-                "timestamp": 1234567890,
-                "source": "ssl",
-                "pid": 1234,
-                "comm": "python",
-                "data": {"message": "SSL handshake completed", "url": "https://api.example.com"}
-            },
-            {
-                "timestamp": 1234567891,
-                "source": "process",
-                "pid": 1235,
-                "comm": "node",
-                "data": {"message": "Process started", "args": ["node", "server.js"]}
-            },
-            {
-                "timestamp": 1234567892,
-                "source": "ssl",
-                "pid": 1234,
-                "comm": "python",
-                "data": {"message": "HTTP request", "method": "GET", "url": "https://api.example.com/users"}
-            }
-        ]);
-        
-        log::info!("📊 Serving sample events API");
-        Ok(Response::builder()
-            .header("Content-Type", "application/json")
-            .header("Access-Control-Allow-Origin", "*")
-            .body(Full::new(Bytes::from(events.to_string())))
-            .unwrap())
+        Err(e) => {
+            log::error!("❌ Failed to read log file {}: {}", log_path, e);
+            Ok(Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .header("Content-Type", "text/plain")
+                .header("Access-Control-Allow-Origin", "*")
+                .body(Full::new(Bytes::from(format!("Failed to read log file: {}", e))))
+                .unwrap())
+        }
     }
 }
 


### PR DESCRIPTION
Acting on the half-built-feature audit. Significant code reduction: **56 insertions, 151 deletions (net −95)**.

## 1. Live event streaming — never implemented, now removed
A `broadcast::channel` was created in **6 handlers** and every event pushed into it, but the web server's `serve_events_api` took the receiver as `_event_sender` and **ignored it** — the channel had no consumer. `/api/events` actually serves the **log file** (the UI polls it). Removed:
- the channel creation (×6), every `event_sender.send(event)` (×6)
- the `WebServer` field + `WebServer::new` param + `start_web_server_if_enabled` sender arg + `handle_request`/`serve_events_api` params
- the `tokio::sync::broadcast` import

Consume loops now just drive the stream (`while stream.next().await.is_some() {}`) so the file logger still runs.

## 2. Sample-data fallback — dead code, removed
`/api/events` returned hardcoded fake events when given no log file, but all 6 callers pass `Some(log_file)`, so it was unreachable. `serve_events_api` now takes a required `&str`; `WebServer::new(&str)`.

## 3. HTTP response filter operators — silent-wrong, made honest
`evaluate_response_condition` **ignored** its `operator` (status_code only `==`, others substring), so `response.status_code >= 400` was silently treated as `==`. Dropped the misleading param and documented response conditions as equality/substring only. (Request-side `path` operators unchanged.)

## 4. `FileLogger::new_with_options` — pointless shim, removed
Test-only; ignored both bool args and forwarded to `new()`. Inlined its 5 (test) call sites, removed the shim.

## 5. Doc fix
CLAUDE.md listed a non-existent `ChunkMerger` analyzer; corrected to the real set.

## Verification
- **Web server end-to-end**: `/api/events` → HTTP 200 serving the log file (not sample JSON), `/api/assets` → 200, no panic.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 101 + 3 pass.

(Aside: testing surfaced a real *pre-existing* bug — `FileLogger::new(...).unwrap()` panics in the non-rotate path — logged for the separate unwrap-hardening follow-up; not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)