### PR TITLE
fix: clean error (not panic) on bad log path; bound OtelExporter pending map

### DIFF
--- a/collector/src/framework/analyzers/otel_exporter.rs
+++ b/collector/src/framework/analyzers/otel_exporter.rs
@@ -36,6 +36,10 @@ use std::sync::Arc;
 /// Default OTLP/HTTP receiver endpoint (OpenTelemetry Collector).
 const DEFAULT_OTLP_ENDPOINT: &str = "http://localhost:4318";
 
+/// Drop a pending request that never got a matching response after this long,
+/// bounding the correlation map for dropped/aborted/never-answered requests.
+const PENDING_REQUEST_TIMEOUT_NANOS: u128 = 5 * 60 * 1_000_000_000; // 5 minutes
+
 /// A request that is waiting for its matching response so a full span can be
 /// emitted. Keyed by `(pid, tid)` in the exporter's pending map.
 #[derive(Clone)]
@@ -298,6 +302,11 @@ impl Analyzer for OtelExporter {
             let key = (event.pid, tid);
             let msg_type = data.get("message_type").and_then(|v| v.as_str()).unwrap_or("");
             let unix_nano = (event.timestamp as u128) * 1_000_000; // ms -> ns
+
+            // Evict requests that never got a matching response so `pending`
+            // can't grow without bound (dropped connections, killed agents,
+            // responses on a different tid, …).
+            pending.retain(|_, req| unix_nano.saturating_sub(req.start_unix_nano) <= PENDING_REQUEST_TIMEOUT_NANOS);
 
             match msg_type {
                 "request" => {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -402,7 +402,16 @@ enum Commands {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn main() {
+    // Print errors as a clean one-line `Error: <message>` (Display) and exit 1,
+    // instead of the default `-> Result` behavior which prints them via Debug.
+    if let Err(e) = run().await {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Initialize env_logger with default log level of info
     env_logger::Builder::from_default_env()
         .filter_level(log::LevelFilter::Info)
@@ -545,13 +554,7 @@ async fn run_raw_ssl(binary_extractor: &BinaryExtractor, enable_chunk_merger: bo
     }
     
     ssl_runner = ssl_runner
-        .add_analyzer(Box::new(
-            if rotate_logs {
-                FileLogger::with_max_size(log_file, max_log_size).unwrap()
-            } else {
-                FileLogger::new(log_file).unwrap()
-            }
-        ));
+        .add_analyzer(Box::new(make_file_logger(log_file, rotate_logs, max_log_size)?));
     
     if !quiet {
         ssl_runner = ssl_runner.add_analyzer(Box::new(OutputAnalyzer::new()));
@@ -590,13 +593,7 @@ async fn run_raw_process(binary_extractor: &BinaryExtractor, quiet: bool, rotate
     }
 
     process_runner = process_runner
-        .add_analyzer(Box::new(
-            if rotate_logs {
-                FileLogger::with_max_size(log_file, max_log_size).unwrap()
-            } else {
-                FileLogger::new(log_file).unwrap()
-            }
-        ));
+        .add_analyzer(Box::new(make_file_logger(log_file, rotate_logs, max_log_size)?));
 
     // Start web server if enabled
     let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
@@ -647,13 +644,7 @@ async fn run_raw_stdio(binary_extractor: &BinaryExtractor, pid: u32, uid: Option
     }
 
     stdio_runner = stdio_runner
-        .add_analyzer(Box::new(
-            if rotate_logs {
-                FileLogger::with_max_size(log_file, max_log_size).unwrap()
-            } else {
-                FileLogger::new(log_file).unwrap()
-            }
-        ));
+        .add_analyzer(Box::new(make_file_logger(log_file, rotate_logs, max_log_size)?));
 
     // Start web server if enabled
     let _server_handle = start_web_server_if_enabled(enable_server, server_port, log_file).await
@@ -670,6 +661,17 @@ async fn run_raw_stdio(binary_extractor: &BinaryExtractor, pid: u32, uid: Option
 
 /// Build a configured AgentRunner from trace options without running it.
 /// Shared by `run_trace` and `run_exec` so they configure runners identically.
+/// Build a FileLogger, turning an open failure (missing dir, no permission, …)
+/// into a clean RunnerError instead of an `.unwrap()` panic.
+fn make_file_logger(log_file: &str, rotate_logs: bool, max_log_size: u64) -> Result<FileLogger, RunnerError> {
+    let result = if rotate_logs {
+        FileLogger::with_max_size(log_file, max_log_size)
+    } else {
+        FileLogger::new(log_file)
+    };
+    result.map_err(|e| RunnerError::from(format!("failed to open log file '{}': {}", log_file, e)))
+}
+
 fn build_trace_agent(
     binary_extractor: &BinaryExtractor,
     cfg: &TraceConfig,
@@ -851,13 +853,7 @@ fn build_trace_agent(
     
     // Add global analyzers (HTTP filter is now added to SSL runner instead)
 
-    agent = agent.add_global_analyzer(Box::new(
-        if rotate_logs {
-            FileLogger::with_max_size(log_file, max_log_size).unwrap()
-        } else {
-            FileLogger::new(log_file).unwrap()
-        }
-    ));
+    agent = agent.add_global_analyzer(Box::new(make_file_logger(log_file, rotate_logs, max_log_size)?));
     println!("✓ Logging to file: {}", log_file);
     
     if !quiet {
@@ -1109,13 +1105,7 @@ async fn run_system(
 
     // Add file logger
     system_runner = system_runner
-        .add_analyzer(Box::new(
-            if rotate_logs {
-                FileLogger::with_max_size(log_file, max_log_size).unwrap()
-            } else {
-                FileLogger::new(log_file).unwrap()
-            }
-        ));
+        .add_analyzer(Box::new(make_file_logger(log_file, rotate_logs, max_log_size)?));
 
     // Add console output unless quiet
     if !quiet {


### PR DESCRIPTION
Two reliability fixes from the half-built-feature audit.

## 1. Bad log path → clean error, not a panic
The 10 `FileLogger::{new,with_max_size}(...).unwrap()` sites crashed the whole tool with a Rust **panic** (backtrace, `src/main.rs:858`, no filename) when the log file couldn't be opened — e.g. `trace -o /no/such/dir/x.log` (missing parent dir / no permission).

`create(true)` creates the *file* but not parent *directories*, so `open` returns `Err` and `.unwrap()` panics.

- Added `make_file_logger()` that maps the error to a `RunnerError`; call sites use `?`.
- `main()` now prints `Error: <message>` (Display) and exits 1, instead of the default `-> Result` behavior that prints via `Debug` (which showed `Custom { kind: Other, ... }` noise).

**Behavior is unchanged — it still terminates** (you can't run without a log file). Only the *form* changed, per discussion:

```
# before
thread 'main' panicked at src/main.rs:858:39:
called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, ... }
# after
Error: failed to open log file '/no/such/dir/agent.log': No such file or directory (os error 2)
```

## 2. OtelExporter pending map now bounded
Requests are correlated to responses by `(pid, tid)` in a `HashMap`. A request that never gets a matching response (dropped connection, killed agent, response on a different tid) **leaked its entry forever** — unbounded growth. Same class of bug as the SSE buffer leak fixed in #54 (this one was introduced in the OTel PR #49).

Fix mirrors #54: evict entries older than 5 minutes on each event (`pending.retain(...)`).

## Verification
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 101 + 3 pass.
- Clean error verified by running `trace -o /no/such/dir/agent.log` (exit 1, one-line message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)