### PR TITLE
[codex] fix SSL prompt capture and dedupe

### DIFF
--- a/collector/src/binary_resolver.rs
+++ b/collector/src/binary_resolver.rs
@@ -152,13 +152,14 @@ fn newest_nvm_bin(home: &std::path::Path) -> Option<std::path::PathBuf> {
 ///
 /// Node.js bundles OpenSSL directly into the `node` binary, so there is no
 /// system `libssl.so` for sslsniff to hook — it must attach to the binary
-/// itself. We detect this by scanning for the `SSL_write` symbol-name string
-/// in the file. Dynamically-linked runtimes like CPython call into a separate
-/// `libssl.so` (via `_ssl.so`) and do NOT contain this string, so they keep
-/// using sslsniff's system-libssl attachment with comm filtering intact.
+/// itself. We detect this by scanning for static OpenSSL/BoringSSL marker
+/// strings in the file. Dynamically-linked runtimes like CPython call into a
+/// separate `libssl.so` (via `_ssl.so`) and do NOT contain these markers in the
+/// executable, so they keep using sslsniff's system-libssl attachment with comm
+/// filtering intact.
 pub(crate) fn binary_embeds_ssl(path: &str) -> bool {
     use std::io::Read;
-    const NEEDLE: &[u8] = b"SSL_write";
+    const NEEDLES: &[&[u8]] = &[b"SSL_write", b"BoringSSLError", b"OPENSSL_internal"];
     let mut f = match std::fs::File::open(path) {
         Ok(f) => f,
         Err(_) => return false,
@@ -166,6 +167,12 @@ pub(crate) fn binary_embeds_ssl(path: &str) -> bool {
     let mut buf = vec![0u8; 1 << 20]; // 1 MiB chunks
     // Carry the tail of each chunk so a match spanning a boundary isn't missed.
     let mut carry: Vec<u8> = Vec::new();
+    let keep = NEEDLES
+        .iter()
+        .map(|needle| needle.len())
+        .max()
+        .unwrap_or(1)
+        .saturating_sub(1);
     loop {
         let n = match f.read(&mut buf) {
             Ok(0) => break,
@@ -173,10 +180,12 @@ pub(crate) fn binary_embeds_ssl(path: &str) -> bool {
             Err(_) => return false,
         };
         carry.extend_from_slice(&buf[..n]);
-        if carry.windows(NEEDLE.len()).any(|w| w == NEEDLE) {
+        if NEEDLES
+            .iter()
+            .any(|needle| carry.windows(needle.len()).any(|w| w == *needle))
+        {
             return true;
         }
-        let keep = NEEDLE.len() - 1;
         if carry.len() > keep {
             carry.drain(..carry.len() - keep);
         }
@@ -305,7 +314,7 @@ fn find_loaded_ssl_library(pid: u32) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_container_ref;
+    use super::{binary_embeds_ssl, parse_container_ref};
 
     #[test]
     fn parses_docker_double_slash_scheme() {
@@ -340,5 +349,23 @@ mod tests {
     fn rejects_empty_container_reference() {
         assert_eq!(parse_container_ref("docker://"), None);
         assert_eq!(parse_container_ref("docker:"), None);
+    }
+
+    #[test]
+    fn detects_boringssl_marker_in_static_binary() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("claude-like");
+        std::fs::write(&path, b"prefix BoringSSLError suffix").unwrap();
+
+        assert!(binary_embeds_ssl(path.to_str().unwrap()));
+    }
+
+    #[test]
+    fn ignores_binary_without_static_ssl_markers() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("plain");
+        std::fs::write(&path, b"no tls marker here").unwrap();
+
+        assert!(!binary_embeds_ssl(path.to_str().unwrap()));
     }
 }

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -358,7 +358,14 @@ mod tests {
         assert_eq!(
             prompt
                 .details
-                .pointer("/messages/0/content/0/text")
+                .get("text_content")
+                .and_then(|value| value.as_str()),
+            Some("db prompt")
+        );
+        assert_eq!(
+            prompt
+                .details
+                .pointer("/request/messages/0/content/0/text")
                 .and_then(|value| value.as_str()),
             Some("db prompt")
         );

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -15,6 +15,8 @@ use crate::model::{
 use crate::text::{sanitize_ascii_identifier as sanitize_id, short_session_id, truncate_text};
 use crate::view::MaterializedView;
 
+const MAX_PROMPT_TEXT_CHARS: usize = 4096;
+
 pub(crate) struct SessionCache {
     entries: HashMap<PathBuf, CacheEntry>,
     cached_sessions: Vec<LocalSession>,
@@ -164,10 +166,8 @@ pub(crate) fn import_into_view(view: &mut MaterializedView, sessions: &[LocalSes
     }
 }
 
-pub(crate) fn import_observed_session_prompts(
-    view: &mut MaterializedView,
-    audit_rows: &[AuditEventRow],
-) {
+pub(crate) fn observed_session_prompt_rows(audit_rows: &[AuditEventRow]) -> Vec<AuditEventRow> {
+    let mut rows = Vec::new();
     let mut seen = HashSet::new();
     for row in audit_rows {
         if row.audit_type != "file" {
@@ -195,7 +195,7 @@ pub(crate) fn import_observed_session_prompts(
             continue;
         };
 
-        view.apply_audit_event(&AuditEventRow {
+        rows.push(AuditEventRow {
             id: format!(
                 "audit-agent-native-prompt-{}-{pid}",
                 sanitize_id(&session.display_id)
@@ -211,7 +211,9 @@ pub(crate) fn import_observed_session_prompts(
             summary: Some(truncate_text(prompt, 160)),
             details: serde_json::json!({
                 "text_content": prompt,
+                "prompt": prompt,
                 "prompt_source": "local",
+                "prompt_sources": ["local"],
                 "path": path.to_string_lossy(),
                 "session_id": view_id(&session),
                 "agent": session.agent,
@@ -219,6 +221,7 @@ pub(crate) fn import_observed_session_prompts(
             }),
         });
     }
+    rows
 }
 
 fn audit_session_path(row: &AuditEventRow) -> Option<PathBuf> {
@@ -544,9 +547,26 @@ fn parse_content(
                     }
                 }
             }
+            ("claude", "queue-operation") if prompt_preview.is_none() => {
+                if obj.get("operation").and_then(Value::as_str) == Some("enqueue")
+                    && let Some(text) = obj.get("content").and_then(Value::as_str)
+                    && let Some(text) = cleaned_prompt_text(text)
+                {
+                    prompt_preview = Some(text);
+                }
+            }
+            ("claude", "last-prompt") if prompt_preview.is_none() => {
+                if let Some(text) = obj.get("lastPrompt").and_then(Value::as_str)
+                    && let Some(text) = cleaned_prompt_text(text)
+                {
+                    prompt_preview = Some(text);
+                }
+            }
             ("claude", "user") => {
-                if let Some(text) =
-                    local_message_preview(obj.pointer("/message/content").unwrap_or(&obj))
+                if prompt_preview.is_none()
+                    && !is_claude_tool_result(&obj)
+                    && let Some(text) =
+                        local_message_preview(obj.pointer("/message/content").unwrap_or(&obj))
                 {
                     prompt_preview = Some(text);
                 }
@@ -739,12 +759,12 @@ fn claude_usage_key(obj: &Value) -> String {
 fn local_message_preview(value: &Value) -> Option<String> {
     let mut parts = Vec::new();
     collect_local_text(value, &mut parts);
-    let text = parts
-        .join(" ")
-        .split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ");
-    (!text.is_empty()).then(|| truncate_text(&text, 80))
+    cleaned_prompt_text(&parts.join(" "))
+}
+
+fn cleaned_prompt_text(text: &str) -> Option<String> {
+    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!text.is_empty()).then(|| truncate_text(&text, MAX_PROMPT_TEXT_CHARS))
 }
 
 fn collect_local_text(value: &Value, out: &mut Vec<String>) {
@@ -759,7 +779,9 @@ fn collect_local_text(value: &Value, out: &mut Vec<String>) {
             if obj
                 .get("type")
                 .and_then(|value| value.as_str())
-                .is_some_and(|typ| typ == "tool_use" || typ == "function_call")
+                .is_some_and(|typ| {
+                    typ == "tool_use" || typ == "function_call" || typ == "tool_result"
+                })
             {
                 return;
             }
@@ -773,6 +795,48 @@ fn collect_local_text(value: &Value, out: &mut Vec<String>) {
     }
 }
 
+fn is_claude_tool_result(obj: &Value) -> bool {
+    obj.get("toolUseResult").is_some()
+        || obj.get("tool_use_result").is_some()
+        || obj
+            .pointer("/message/content")
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| item.get("type").and_then(Value::as_str) == Some("tool_result"))
+            })
+}
+
 fn json_u64(value: &Value, key: &str) -> u64 {
     value.get(key).and_then(|value| value.as_u64()).unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_prompt_preview_keeps_user_prompt_when_tool_result_follows() {
+        let (_temp, path) = create_temp_session_path("claude");
+        let content = concat!(
+            r#"{"type":"queue-operation","operation":"enqueue","sessionId":"session-1","content":"Run the command and summarize it."}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":"Run the command and summarize it."},"sessionId":"session-1"}"#,
+            "\n",
+            r#"{"type":"assistant","message":{"model":"claude-opus-4-6","content":[{"type":"tool_use","name":"Bash","input":{"command":"printf tool-output"}}],"usage":{"input_tokens":1,"output_tokens":1}},"requestId":"req-1","sessionId":"session-1"}"#,
+            "\n",
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result","content":"tool-output","is_error":false}]},"toolUseResult":{"stdout":"tool-output"},"sessionId":"session-1"}"#,
+            "\n",
+            r#"{"type":"last-prompt","lastPrompt":"Run the command and summarize it.","sessionId":"session-1"}"#,
+            "\n",
+        );
+
+        let session = parse_content_for_test("claude", &path, UNIX_EPOCH, content).unwrap();
+
+        assert_eq!(
+            session.prompt_preview.as_deref(),
+            Some("Run the command and summarize it.")
+        );
+    }
 }

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -12,10 +12,7 @@ use crate::model::{
     AGENT_NATIVE_SOURCE, AuditEventRow, SessionRow, Snapshot, SnapshotOptions, TokenUsageRow,
     ToolCallRow,
 };
-use crate::text::{
-    MAX_PROMPT_TEXT_CHARS, sanitize_ascii_identifier as sanitize_id, short_session_id,
-    truncate_text,
-};
+use crate::text::{sanitize_ascii_identifier as sanitize_id, short_session_id, truncate_text};
 use crate::view::MaterializedView;
 
 pub(crate) struct SessionCache {
@@ -765,7 +762,7 @@ fn local_message_preview(value: &Value) -> Option<String> {
 
 fn cleaned_prompt_text(text: &str) -> Option<String> {
     let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    (!text.is_empty()).then(|| truncate_text(&text, MAX_PROMPT_TEXT_CHARS))
+    (!text.is_empty()).then_some(text)
 }
 
 fn collect_local_text(value: &Value, out: &mut Vec<String>) {

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -12,10 +12,11 @@ use crate::model::{
     AGENT_NATIVE_SOURCE, AuditEventRow, SessionRow, Snapshot, SnapshotOptions, TokenUsageRow,
     ToolCallRow,
 };
-use crate::text::{sanitize_ascii_identifier as sanitize_id, short_session_id, truncate_text};
+use crate::text::{
+    MAX_PROMPT_TEXT_CHARS, sanitize_ascii_identifier as sanitize_id, short_session_id,
+    truncate_text,
+};
 use crate::view::MaterializedView;
-
-const MAX_PROMPT_TEXT_CHARS: usize = 4096;
 
 pub(crate) struct SessionCache {
     entries: HashMap<PathBuf, CacheEntry>,

--- a/collector/src/sources/sqlite.rs
+++ b/collector/src/sources/sqlite.rs
@@ -4,9 +4,14 @@
 use crate::model::{AuditEventRow, LlmCallRow, ProcessNodeRow, ViewResult};
 use crate::sinks::sqlite::SqliteStore;
 use crate::sources::agent_native;
+use crate::text::truncate_text;
 use crate::view::MaterializedView;
+use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::path::Path;
+
+const PROMPT_DEDUP_WINDOW_MS: u64 = 10_000;
+const MAX_PROMPT_TEXT_CHARS: usize = 4096;
 
 pub(crate) fn load_view(path: impl AsRef<Path>) -> ViewResult<MaterializedView> {
     load_view_inner(path, false)
@@ -41,6 +46,9 @@ fn load_view_inner(
     let mut audit_rows = Vec::new();
     if let Ok(rows) = store.all_audit_event_rows() {
         for row in &rows {
+            if include_observed_session_prompts && is_reprojected_llm_request(row) {
+                continue;
+            }
             view.apply_audit_event(row);
         }
         audit_rows = rows;
@@ -69,8 +77,14 @@ fn load_view_inner(
     }
     if include_observed_session_prompts {
         import_observed_process_nodes(&mut view, &llm_rows, &process_pids);
-        import_llm_call_prompts(&mut view, &llm_rows);
-        agent_native::import_observed_session_prompts(&mut view, &audit_rows);
+        let mut prompt_rows = llm_call_prompt_rows(&llm_rows);
+        append_deduped_local_session_prompt_rows(
+            &mut prompt_rows,
+            agent_native::observed_session_prompt_rows(&audit_rows),
+        );
+        for row in prompt_rows {
+            view.apply_audit_event(&row);
+        }
     }
 
     Ok(view)
@@ -109,12 +123,20 @@ fn import_observed_process_nodes(
     }
 }
 
-fn import_llm_call_prompts(view: &mut MaterializedView, rows: &[LlmCallRow]) {
+fn is_reprojected_llm_request(row: &AuditEventRow) -> bool {
+    row.audit_type == "llm" && row.action.as_deref() == Some("request")
+}
+
+fn llm_call_prompt_rows(rows: &[LlmCallRow]) -> Vec<AuditEventRow> {
+    let mut prompts = Vec::new();
     for row in rows {
         if row.request.is_null() || row.request.as_object().is_some_and(|obj| obj.is_empty()) {
             continue;
         }
-        view.apply_audit_event(&AuditEventRow {
+        let Some(text) = prompt_text_from_request(&row.request) else {
+            continue;
+        };
+        prompts.push(AuditEventRow {
             id: format!("audit-{}-request", row.id),
             timestamp_ms: row.start_timestamp_ms,
             audit_type: "llm".to_string(),
@@ -124,8 +146,257 @@ fn import_llm_call_prompts(view: &mut MaterializedView, rows: &[LlmCallRow]) {
             action: Some("request".to_string()),
             target: row.host.clone(),
             status: Some("observed".to_string()),
-            summary: Some("LLM request".to_string()),
-            details: row.request.clone(),
+            summary: Some(truncate_text(&text, 160)),
+            details: json!({
+                "text_content": text,
+                "prompt": text,
+                "prompt_source": "ssl",
+                "prompt_sources": ["ssl"],
+                "source": "ssl",
+                "request": row.request,
+                "provider": row.provider,
+                "host": row.host,
+                "path": row.path,
+                "model": row.model,
+            }),
         });
+    }
+    prompts
+}
+
+fn append_deduped_local_session_prompt_rows(
+    ssl_rows: &mut Vec<AuditEventRow>,
+    local_rows: Vec<AuditEventRow>,
+) {
+    for local in local_rows {
+        if !ssl_rows
+            .iter()
+            .any(|ssl| local_prompt_duplicates_ssl(&local, ssl))
+        {
+            ssl_rows.push(local);
+        }
+    }
+}
+
+fn local_prompt_duplicates_ssl(local: &AuditEventRow, ssl: &AuditEventRow) -> bool {
+    if prompt_source(ssl) != Some("ssl") {
+        return false;
+    }
+    if let (Some(local_pid), Some(ssl_pid)) = (local.pid, ssl.pid)
+        && local_pid != ssl_pid
+    {
+        return false;
+    }
+    if local.timestamp_ms.abs_diff(ssl.timestamp_ms) > PROMPT_DEDUP_WINDOW_MS {
+        return false;
+    }
+    if !models_match(local.subject.as_deref(), ssl.subject.as_deref()) {
+        return false;
+    }
+    let Some(local_text) = prompt_text_from_details(&local.details) else {
+        return false;
+    };
+    let Some(ssl_text) = prompt_text_from_details(&ssl.details) else {
+        return false;
+    };
+    normalize_prompt_text_for_match(&local_text) == normalize_prompt_text_for_match(&ssl_text)
+}
+
+fn models_match(local: Option<&str>, ssl: Option<&str>) -> bool {
+    match (local, ssl) {
+        (Some(local), Some(ssl)) => local == ssl,
+        _ => true,
+    }
+}
+
+fn prompt_source(row: &AuditEventRow) -> Option<&str> {
+    row.details.get("prompt_source").and_then(Value::as_str)
+}
+
+fn normalize_prompt_text_for_match(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_lowercase()
+}
+
+fn prompt_text_from_details(details: &Value) -> Option<String> {
+    details
+        .get("text_content")
+        .and_then(Value::as_str)
+        .or_else(|| details.get("prompt").and_then(Value::as_str))
+        .and_then(clean_prompt_text)
+}
+
+fn prompt_text_from_request(value: &Value) -> Option<String> {
+    if let Some(prompt) = value.get("prompt").and_then(Value::as_str) {
+        return clean_prompt_text(prompt);
+    }
+    let mut parts = Vec::new();
+    for key in ["messages", "contents"] {
+        if let Some(items) = value.get(key).and_then(Value::as_array) {
+            for item in items {
+                collect_prompt_text(item.get("content").unwrap_or(item), &mut parts);
+            }
+        }
+    }
+    clean_prompt_text(&parts.join(" "))
+}
+
+fn collect_prompt_text(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(text) => out.push(text.clone()),
+        Value::Array(items) => {
+            for item in items {
+                collect_prompt_text(item, out);
+            }
+        }
+        Value::Object(obj) => {
+            for key in ["text", "content", "parts"] {
+                if let Some(value) = obj.get(key) {
+                    collect_prompt_text(value, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn clean_prompt_text(text: &str) -> Option<String> {
+    let mut text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if let Some(inner) = text
+        .strip_prefix("<session>")
+        .and_then(|text| text.strip_suffix("</session>"))
+    {
+        text = inner.trim().to_string();
+    }
+    (!text.is_empty()).then(|| truncate_text(&text, MAX_PROMPT_TEXT_CHARS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn keeps_local_prompt_when_ssl_text_matches_but_model_differs() {
+        let ssl_rows = [ssl_call_row(
+            "claude-haiku-4-5",
+            "<session>\nRun the command.\n</session>",
+        )];
+        let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
+        let local = local_prompt_row(
+            "local-prompt",
+            1_500,
+            Some("claude-opus-4-6"),
+            "Run the command.",
+        );
+
+        append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
+
+        assert_eq!(prompt_rows.len(), 2);
+        assert_eq!(
+            prompt_rows[0]
+                .details
+                .get("prompt_source")
+                .and_then(Value::as_str),
+            Some("ssl")
+        );
+        assert_eq!(
+            prompt_rows[1]
+                .details
+                .get("prompt_source")
+                .and_then(Value::as_str),
+            Some("local")
+        );
+    }
+
+    #[test]
+    fn dedupes_local_prompt_when_ssl_has_same_model_and_text() {
+        let ssl_rows = [ssl_call_row("claude-opus-4-6", "Run the command.")];
+        let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
+        let local = local_prompt_row(
+            "local-prompt",
+            1_500,
+            Some("claude-opus-4-6"),
+            "Run the command.",
+        );
+
+        append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
+
+        assert_eq!(prompt_rows.len(), 1);
+        assert_eq!(
+            prompt_rows[0]
+                .details
+                .get("text_content")
+                .and_then(Value::as_str),
+            Some("Run the command.")
+        );
+        assert_eq!(
+            prompt_rows[0]
+                .details
+                .get("prompt_source")
+                .and_then(Value::as_str),
+            Some("ssl")
+        );
+    }
+
+    fn ssl_call_row(model: &str, text: &str) -> LlmCallRow {
+        LlmCallRow {
+            id: "ssl-call".to_string(),
+            start_timestamp_ms: 1_000,
+            end_timestamp_ms: None,
+            pid: Some(42),
+            comm: Some("HTTP Client".to_string()),
+            provider: Some("anthropic".to_string()),
+            model: Some(model.to_string()),
+            host: Some("api.anthropic.com".to_string()),
+            path: Some("/v1/messages".to_string()),
+            status_code: None,
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            request: json!({
+                "model": model,
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": text
+                            }
+                        ]
+                    }
+                ]
+            }),
+            response: Value::Null,
+        }
+    }
+
+    fn local_prompt_row(
+        id: &str,
+        timestamp_ms: u64,
+        model: Option<&str>,
+        text: &str,
+    ) -> AuditEventRow {
+        AuditEventRow {
+            id: id.to_string(),
+            timestamp_ms,
+            audit_type: "llm".to_string(),
+            pid: Some(42),
+            comm: Some("claude".to_string()),
+            subject: model.map(ToString::to_string),
+            action: Some("request".to_string()),
+            target: Some("/home/user/.claude/session.jsonl".to_string()),
+            status: Some("observed".to_string()),
+            summary: Some(text.to_string()),
+            details: json!({
+                "text_content": text,
+                "prompt": text,
+                "prompt_source": "local",
+                "prompt_sources": ["local"]
+            }),
+        }
     }
 }

--- a/collector/src/sources/sqlite.rs
+++ b/collector/src/sources/sqlite.rs
@@ -4,15 +4,13 @@
 use crate::model::{AuditEventRow, LlmCallRow, ProcessNodeRow, ViewResult};
 use crate::sinks::sqlite::SqliteStore;
 use crate::sources::agent_native;
-use crate::text::truncate_text;
+use crate::text::{MAX_PROMPT_TEXT_CHARS, truncate_text};
 use crate::view::MaterializedView;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
 use std::path::Path;
 
 const PROMPT_DEDUP_WINDOW_MS: u64 = 10_000;
-const MAX_PROMPT_TEXT_CHARS: usize = 4096;
-
 pub(crate) fn load_view(path: impl AsRef<Path>) -> ViewResult<MaterializedView> {
     load_view_inner(path, false)
 }
@@ -203,10 +201,7 @@ fn local_prompt_duplicates_ssl(local: &AuditEventRow, ssl: &AuditEventRow) -> bo
 }
 
 fn models_match(local: Option<&str>, ssl: Option<&str>) -> bool {
-    match (local, ssl) {
-        (Some(local), Some(ssl)) => local == ssl,
-        _ => true,
-    }
+    matches!((local, ssl), (Some(local), Some(ssl)) if local == ssl)
 }
 
 fn prompt_source(row: &AuditEventRow) -> Option<&str> {
@@ -339,6 +334,17 @@ mod tests {
                 .and_then(Value::as_str),
             Some("ssl")
         );
+    }
+
+    #[test]
+    fn keeps_local_prompt_when_either_model_is_missing() {
+        let ssl_rows = [ssl_call_row("claude-opus-4-6", "Run the command.")];
+        let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
+        let local = local_prompt_row("local-prompt", 1_500, None, "Run the command.");
+
+        append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
+
+        assert_eq!(prompt_rows.len(), 2);
     }
 
     fn ssl_call_row(model: &str, text: &str) -> LlmCallRow {

--- a/collector/src/sources/sqlite.rs
+++ b/collector/src/sources/sqlite.rs
@@ -4,7 +4,7 @@
 use crate::model::{AuditEventRow, LlmCallRow, ProcessNodeRow, ViewResult};
 use crate::sinks::sqlite::SqliteStore;
 use crate::sources::agent_native;
-use crate::text::{MAX_PROMPT_TEXT_CHARS, truncate_text};
+use crate::text::truncate_text;
 use crate::view::MaterializedView;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
@@ -265,7 +265,7 @@ fn clean_prompt_text(text: &str) -> Option<String> {
     {
         text = inner.trim().to_string();
     }
-    (!text.is_empty()).then(|| truncate_text(&text, MAX_PROMPT_TEXT_CHARS))
+    (!text.is_empty()).then_some(text)
 }
 
 #[cfg(test)]

--- a/collector/src/text.rs
+++ b/collector/src/text.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-pub(crate) const MAX_PROMPT_TEXT_CHARS: usize = 4096;
-
 pub(crate) fn short_session_id(id: &str) -> String {
     let id = id.trim();
     if id.is_empty() {

--- a/collector/src/text.rs
+++ b/collector/src/text.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
+pub(crate) const MAX_PROMPT_TEXT_CHARS: usize = 4096;
+
 pub(crate) fn short_session_id(id: &str) -> String {
     let id = id.trim();
     if id.is_empty() {

--- a/frontend/src/components/process-tree/BlockAdapters.tsx
+++ b/frontend/src/components/process-tree/BlockAdapters.tsx
@@ -87,6 +87,7 @@ export function adaptEventToUnifiedBlock(event: TreeAuditEvent): UnifiedBlockDat
   const expandedContent = expandedEventContent(event, type);
   const tags = [
     style.tag,
+    promptSourceTag(event, type),
     eventModel(event),
     event.action?.toUpperCase(),
     event.status,
@@ -105,6 +106,11 @@ export function adaptEventToUnifiedBlock(event: TreeAuditEvent): UnifiedBlockDat
     foldContent: foldedEventContent(event, expandedContent),
     expandedContent,
   };
+}
+
+function promptSourceTag(event: TreeAuditEvent, type: TreeEventType): string {
+  const source = eventDetails(event).prompt_source;
+  return type === 'prompt' && typeof source === 'string' ? source.toUpperCase() : '';
 }
 
 function styleForEvent(type: TreeEventType, event: TreeAuditEvent) {
@@ -128,7 +134,9 @@ function styleForEvent(type: TreeEventType, event: TreeAuditEvent) {
 }
 
 function foldedEventContent(event: TreeAuditEvent, expandedContent: string): string {
-  if (event.promptDiff?.summary) return `Changed: ${event.promptDiff.summary}`;
+  if (event.promptDiff?.hasChanges && event.promptDiff.summary) {
+    return `Changed: ${event.promptDiff.summary}`;
+  }
   return event.summary
     || eventTarget(event)
     || preview(expandedContent, 120)
@@ -141,6 +149,8 @@ function expandedEventContent(event: TreeAuditEvent, type: TreeEventType): strin
 
   if (type === 'stdio') {
     content = formatStdio(details);
+  } else if (type === 'prompt' && typeof details.text_content === 'string' && details.text_content.trim()) {
+    content = formatPromptDetails(details);
   } else if (typeof details.json_content === 'string' && details.json_content.trim()) {
     content = formatJsonish(details.json_content);
   } else if (typeof details.text_content === 'string' && details.text_content.trim()) {
@@ -151,7 +161,7 @@ function expandedEventContent(event: TreeAuditEvent, type: TreeEventType): strin
     content = JSON.stringify(event.details ?? event, null, 2);
   }
 
-  if (event.promptDiff?.diff) {
+  if (event.promptDiff?.hasChanges && event.promptDiff.diff) {
     return [
       '=== CHANGES FROM PREVIOUS PROMPT ===',
       event.promptDiff.diff,
@@ -162,6 +172,16 @@ function expandedEventContent(event: TreeAuditEvent, type: TreeEventType): strin
   }
 
   return content;
+}
+
+function formatPromptDetails(details: Record<string, any>): string {
+  const text = details.text_content.trim();
+  const meta = Object.fromEntries(
+    Object.entries(details).filter(([key]) => !['text_content', 'prompt'].includes(key)),
+  );
+  return Object.keys(meta).length > 0
+    ? `${text}\n\n${JSON.stringify(meta, null, 2)}`
+    : text;
 }
 
 function formatStdio(details: Record<string, any>): string {

--- a/frontend/src/components/process-tree/UnifiedBlock.tsx
+++ b/frontend/src/components/process-tree/UnifiedBlock.tsx
@@ -50,12 +50,7 @@ export function UnifiedBlock({ data, isExpanded, onToggle }: UnifiedBlockProps) 
     });
   };
 
-  const shouldShowExpandButton = data.expandedContent.length > 300;
   const handleToggle = () => {
-    if (!shouldShowExpandButton) {
-      return;
-    }
-
     const selection = window.getSelection();
     if (selection && selection.toString().length > 0) {
       return;
@@ -123,15 +118,13 @@ export function UnifiedBlock({ data, isExpanded, onToggle }: UnifiedBlockProps) 
                 <span className="text-xs text-gray-500">
                   {formatTimestamp(data.timestamp)}
                 </span>
-                {shouldShowExpandButton && (
-                  <div className="flex-shrink-0">
-                    {isExpanded ? (
-                      <ChevronDownIcon className={`h-4 w-4 ${data.iconColor}`} />
-                    ) : (
-                      <ChevronRightIcon className={`h-4 w-4 ${data.iconColor}`} />
-                    )}
-                  </div>
-                )}
+                <div className="flex-shrink-0">
+                  {isExpanded ? (
+                    <ChevronDownIcon className={`h-4 w-4 ${data.iconColor}`} />
+                  ) : (
+                    <ChevronRightIcon className={`h-4 w-4 ${data.iconColor}`} />
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/utils/jsonDiff.ts
+++ b/frontend/src/utils/jsonDiff.ts
@@ -55,6 +55,7 @@ function extractPrompt(data: any): any | null {
       return null;
     }
   }
+  if (typeof data?.text_content === 'string') return { prompt: data.text_content };
   return data?.messages || data?.prompt ? data : null;
 }
 


### PR DESCRIPTION
## Summary
- Detect newer Claude/BoringSSL binaries for SSL capture so record can attach without manual --binary-path.
- Preserve local Claude prompts without tool-result overwrite, and project SSL/local prompts with explicit source metadata.
- Deduplicate only exact same-model local prompts covered by SSL, while keeping local prompt segments otherwise.
- Let process-tree events always expand and show prompt source/request details.

## Root Cause
Newer Claude binaries do not expose the SSL_write marker used by the previous static TLS heuristic, so record skipped the explicit SSL attach target and captured no SSL events. The DB view also projected raw SSL request JSON and local session prompts as separate, incompatible prompt shapes, which caused prompt diff noise in the UI.

## Validation
- cargo test -p agentsight
- npm run build
- manual record verification: SSLFilter captured events and /api/v1/snapshot shows SSL and local prompt rows with prompt_source metadata.