### PR TITLE
[codex] prune redundant prompt detail fields

### DIFF
--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use crate::analyzers::common;
 use crate::event::Event;
 use crate::model::{AuditEventRow, LlmCallRow, TokenSummary};
-use crate::text::truncate_with_ellipsis as truncate;
+use crate::text::{extract_prompt_text, truncate_with_ellipsis as truncate};
 
 #[derive(Debug, Default, Serialize)]
 pub(crate) struct ResourcePeaks {
@@ -977,38 +977,6 @@ fn prompt_preview(value: &Value, max: usize) -> String {
 
 pub(crate) fn prompt_text_chars(value: &Value) -> Option<usize> {
     extract_prompt_text(value).map(|text| text.chars().count())
-}
-
-fn extract_prompt_text(value: &Value) -> Option<String> {
-    if let Some(prompt) = value.get("prompt").and_then(|v| v.as_str()) {
-        return Some(prompt.to_string());
-    }
-    let mut parts = Vec::new();
-    for key in ["messages", "contents"] {
-        if let Some(items) = value.get(key).and_then(|v| v.as_array()) {
-            for item in items {
-                collect_content_text(item.get("content").unwrap_or(item), &mut parts);
-            }
-        }
-    }
-    (!parts.is_empty()).then(|| parts.join(" "))
-}
-
-fn collect_content_text(value: &Value, out: &mut Vec<String>) {
-    match value {
-        Value::String(s) => out.push(s.clone()),
-        Value::Array(items) => items
-            .iter()
-            .for_each(|item| collect_content_text(item, out)),
-        Value::Object(obj) => {
-            for key in ["text", "content", "parts"] {
-                if let Some(v) = obj.get(key) {
-                    collect_content_text(v, out);
-                }
-            }
-        }
-        _ => {}
-    }
 }
 
 #[cfg(test)]

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -12,7 +12,9 @@ use crate::model::{
     AGENT_NATIVE_SOURCE, AuditEventRow, SessionRow, Snapshot, SnapshotOptions, TokenUsageRow,
     ToolCallRow,
 };
-use crate::text::{sanitize_ascii_identifier as sanitize_id, short_session_id, truncate_text};
+use crate::text::{
+    clean_prompt_text, sanitize_ascii_identifier as sanitize_id, short_session_id, truncate_text,
+};
 use crate::view::MaterializedView;
 
 pub(crate) struct SessionCache {
@@ -168,6 +170,40 @@ pub(crate) fn observed_session_prompt_rows(audit_rows: &[AuditEventRow]) -> Vec<
     let mut rows = Vec::new();
     let mut seen = HashSet::new();
     for row in audit_rows {
+        if row.audit_type == "process"
+            && row.action.as_deref() == Some("exec")
+            && is_codex_cli_entrypoint(row.target.as_deref())
+        {
+            let Some(prompt) = row
+                .details
+                .get("full_command")
+                .and_then(Value::as_str)
+                .and_then(codex_exec_prompt)
+            else {
+                continue;
+            };
+            rows.push(AuditEventRow {
+                id: format!(
+                    "audit-codex-exec-prompt-{}-{}",
+                    row.timestamp_ms,
+                    row.pid.unwrap_or(0)
+                ),
+                timestamp_ms: row.timestamp_ms,
+                audit_type: "llm".to_string(),
+                pid: row.pid,
+                comm: row.comm.clone().or_else(|| Some("codex".to_string())),
+                subject: None,
+                action: Some("request".to_string()),
+                target: row.target.clone(),
+                status: Some("observed".to_string()),
+                summary: Some(truncate_text(&prompt, 160)),
+                details: serde_json::json!({
+                    "text_content": prompt,
+                    "prompt_source": "local",
+                }),
+            });
+            continue;
+        }
         if row.audit_type != "file" {
             continue;
         }
@@ -216,6 +252,35 @@ pub(crate) fn observed_session_prompt_rows(audit_rows: &[AuditEventRow]) -> Vec<
         });
     }
     rows
+}
+
+fn is_codex_cli_entrypoint(target: Option<&str>) -> bool {
+    target.is_some_and(|target| {
+        Path::new(target).file_name().and_then(|name| name.to_str()) == Some("codex")
+            && !target.contains("/node_modules/")
+    })
+}
+
+fn codex_exec_prompt(command: &str) -> Option<String> {
+    let mut args = command.split_once(" exec ")?.1.trim();
+    while let Some(rest) = strip_codex_exec_option(args) {
+        args = rest.trim_start();
+    }
+    (!args.starts_with('-'))
+        .then(|| args.trim_matches(['"', '\'']))
+        .and_then(clean_prompt_text)
+}
+
+fn strip_codex_exec_option(args: &str) -> Option<&str> {
+    let (head, rest) = args.split_once(char::is_whitespace).unwrap_or((args, ""));
+    match head {
+        "--json" | "--skip-git-repo-check" | "--ephemeral" => Some(rest),
+        "-C" | "-a" | "-s" | "-m" | "-c" | "-p" => rest
+            .trim_start()
+            .split_once(char::is_whitespace)
+            .map(|(_, rest)| rest),
+        _ => None,
+    }
 }
 
 fn audit_session_path(row: &AuditEventRow) -> Option<PathBuf> {
@@ -544,14 +609,14 @@ fn parse_content(
             ("claude", "queue-operation") if prompt_preview.is_none() => {
                 if obj.get("operation").and_then(Value::as_str) == Some("enqueue")
                     && let Some(text) = obj.get("content").and_then(Value::as_str)
-                    && let Some(text) = cleaned_prompt_text(text)
+                    && let Some(text) = clean_prompt_text(text)
                 {
                     prompt_preview = Some(text);
                 }
             }
             ("claude", "last-prompt") if prompt_preview.is_none() => {
                 if let Some(text) = obj.get("lastPrompt").and_then(Value::as_str)
-                    && let Some(text) = cleaned_prompt_text(text)
+                    && let Some(text) = clean_prompt_text(text)
                 {
                     prompt_preview = Some(text);
                 }
@@ -753,12 +818,7 @@ fn claude_usage_key(obj: &Value) -> String {
 fn local_message_preview(value: &Value) -> Option<String> {
     let mut parts = Vec::new();
     collect_local_text(value, &mut parts);
-    cleaned_prompt_text(&parts.join(" "))
-}
-
-fn cleaned_prompt_text(text: &str) -> Option<String> {
-    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    (!text.is_empty()).then_some(text)
+    clean_prompt_text(&parts.join(" "))
 }
 
 fn collect_local_text(value: &Value, out: &mut Vec<String>) {
@@ -832,5 +892,20 @@ mod tests {
             session.prompt_preview.as_deref(),
             Some("Run the command and summarize it.")
         );
+    }
+
+    #[test]
+    fn codex_exec_entrypoint_projects_prompt_without_vendor_duplicate() {
+        assert_eq!(
+            codex_exec_prompt(
+                "/usr/bin/env node /usr/local/bin/codex -a never -s read-only exec --json -C /tmp --skip-git-repo-check Reply exactly: hello"
+            )
+            .as_deref(),
+            Some("Reply exactly: hello")
+        );
+        assert!(is_codex_cli_entrypoint(Some("/usr/local/bin/codex")));
+        assert!(!is_codex_cli_entrypoint(Some(
+            "/opt/codex/node_modules/@openai/codex/vendor/bin/codex"
+        )));
     }
 }

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -209,13 +209,9 @@ pub(crate) fn observed_session_prompt_rows(audit_rows: &[AuditEventRow]) -> Vec<
             summary: Some(truncate_text(prompt, 160)),
             details: serde_json::json!({
                 "text_content": prompt,
-                "prompt": prompt,
                 "prompt_source": "local",
-                "prompt_sources": ["local"],
-                "path": path.to_string_lossy(),
                 "session_id": view_id(&session),
                 "agent": session.agent,
-                "source": AGENT_NATIVE_SOURCE,
             }),
         });
     }

--- a/collector/src/sources/sqlite.rs
+++ b/collector/src/sources/sqlite.rs
@@ -147,15 +147,10 @@ fn llm_call_prompt_rows(rows: &[LlmCallRow]) -> Vec<AuditEventRow> {
             summary: Some(truncate_text(&text, 160)),
             details: json!({
                 "text_content": text,
-                "prompt": text,
                 "prompt_source": "ssl",
-                "prompt_sources": ["ssl"],
-                "source": "ssl",
                 "request": row.request,
                 "provider": row.provider,
-                "host": row.host,
                 "path": row.path,
-                "model": row.model,
             }),
         });
     }
@@ -219,7 +214,6 @@ fn prompt_text_from_details(details: &Value) -> Option<String> {
     details
         .get("text_content")
         .and_then(Value::as_str)
-        .or_else(|| details.get("prompt").and_then(Value::as_str))
         .and_then(clean_prompt_text)
 }
 
@@ -399,9 +393,7 @@ mod tests {
             summary: Some(text.to_string()),
             details: json!({
                 "text_content": text,
-                "prompt": text,
-                "prompt_source": "local",
-                "prompt_sources": ["local"]
+                "prompt_source": "local"
             }),
         }
     }

--- a/collector/src/sources/sqlite.rs
+++ b/collector/src/sources/sqlite.rs
@@ -4,7 +4,7 @@
 use crate::model::{AuditEventRow, LlmCallRow, ProcessNodeRow, ViewResult};
 use crate::sinks::sqlite::SqliteStore;
 use crate::sources::agent_native;
-use crate::text::truncate_text;
+use crate::text::{clean_prompt_text, extract_prompt_text, truncate_text};
 use crate::view::MaterializedView;
 use serde_json::{Value, json};
 use std::collections::BTreeSet;
@@ -131,7 +131,7 @@ fn llm_call_prompt_rows(rows: &[LlmCallRow]) -> Vec<AuditEventRow> {
         if row.request.is_null() || row.request.as_object().is_some_and(|obj| obj.is_empty()) {
             continue;
         }
-        let Some(text) = prompt_text_from_request(&row.request) else {
+        let Some(text) = extract_prompt_text(&row.request) else {
             continue;
         };
         prompts.push(AuditEventRow {
@@ -162,104 +162,44 @@ fn append_deduped_local_session_prompt_rows(
     local_rows: Vec<AuditEventRow>,
 ) {
     for local in local_rows {
-        if !ssl_rows
-            .iter()
-            .any(|ssl| local_prompt_duplicates_ssl(&local, ssl))
-        {
+        let Some(local_text) = prompt_text_from_details(&local.details) else {
+            ssl_rows.push(local);
+            continue;
+        };
+        let duplicate = ssl_rows.iter().any(|ssl| {
+            if ssl.details.get("prompt_source").and_then(Value::as_str) != Some("ssl") {
+                return false;
+            }
+            if let (Some(local_pid), Some(ssl_pid)) = (local.pid, ssl.pid)
+                && local_pid != ssl_pid
+            {
+                return false;
+            }
+            if local.timestamp_ms.abs_diff(ssl.timestamp_ms) > PROMPT_DEDUP_WINDOW_MS {
+                return false;
+            }
+            let Some((local_model, ssl_model)) =
+                local.subject.as_deref().zip(ssl.subject.as_deref())
+            else {
+                return false;
+            };
+            let Some(ssl_text) = prompt_text_from_details(&ssl.details) else {
+                return false;
+            };
+            local_model == ssl_model && local_text.eq_ignore_ascii_case(&ssl_text)
+        });
+        if !duplicate {
             ssl_rows.push(local);
         }
     }
-}
-
-fn local_prompt_duplicates_ssl(local: &AuditEventRow, ssl: &AuditEventRow) -> bool {
-    if prompt_source(ssl) != Some("ssl") {
-        return false;
-    }
-    if let (Some(local_pid), Some(ssl_pid)) = (local.pid, ssl.pid)
-        && local_pid != ssl_pid
-    {
-        return false;
-    }
-    if local.timestamp_ms.abs_diff(ssl.timestamp_ms) > PROMPT_DEDUP_WINDOW_MS {
-        return false;
-    }
-    if !models_match(local.subject.as_deref(), ssl.subject.as_deref()) {
-        return false;
-    }
-    let Some(local_text) = prompt_text_from_details(&local.details) else {
-        return false;
-    };
-    let Some(ssl_text) = prompt_text_from_details(&ssl.details) else {
-        return false;
-    };
-    normalize_prompt_text_for_match(&local_text) == normalize_prompt_text_for_match(&ssl_text)
-}
-
-fn models_match(local: Option<&str>, ssl: Option<&str>) -> bool {
-    matches!((local, ssl), (Some(local), Some(ssl)) if local == ssl)
-}
-
-fn prompt_source(row: &AuditEventRow) -> Option<&str> {
-    row.details.get("prompt_source").and_then(Value::as_str)
-}
-
-fn normalize_prompt_text_for_match(text: &str) -> String {
-    text.split_whitespace()
-        .collect::<Vec<_>>()
-        .join(" ")
-        .to_ascii_lowercase()
 }
 
 fn prompt_text_from_details(details: &Value) -> Option<String> {
     details
         .get("text_content")
         .and_then(Value::as_str)
+        .or_else(|| details.get("prompt").and_then(Value::as_str))
         .and_then(clean_prompt_text)
-}
-
-fn prompt_text_from_request(value: &Value) -> Option<String> {
-    if let Some(prompt) = value.get("prompt").and_then(Value::as_str) {
-        return clean_prompt_text(prompt);
-    }
-    let mut parts = Vec::new();
-    for key in ["messages", "contents"] {
-        if let Some(items) = value.get(key).and_then(Value::as_array) {
-            for item in items {
-                collect_prompt_text(item.get("content").unwrap_or(item), &mut parts);
-            }
-        }
-    }
-    clean_prompt_text(&parts.join(" "))
-}
-
-fn collect_prompt_text(value: &Value, out: &mut Vec<String>) {
-    match value {
-        Value::String(text) => out.push(text.clone()),
-        Value::Array(items) => {
-            for item in items {
-                collect_prompt_text(item, out);
-            }
-        }
-        Value::Object(obj) => {
-            for key in ["text", "content", "parts"] {
-                if let Some(value) = obj.get(key) {
-                    collect_prompt_text(value, out);
-                }
-            }
-        }
-        _ => {}
-    }
-}
-
-fn clean_prompt_text(text: &str) -> Option<String> {
-    let mut text = text.split_whitespace().collect::<Vec<_>>().join(" ");
-    if let Some(inner) = text
-        .strip_prefix("<session>")
-        .and_then(|text| text.strip_suffix("</session>"))
-    {
-        text = inner.trim().to_string();
-    }
-    (!text.is_empty()).then_some(text)
 }
 
 #[cfg(test)]
@@ -268,77 +208,43 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn keeps_local_prompt_when_ssl_text_matches_but_model_differs() {
-        let ssl_rows = [ssl_call_row(
-            "claude-haiku-4-5",
-            "<session>\nRun the command.\n</session>",
-        )];
-        let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
-        let local = local_prompt_row(
-            "local-prompt",
-            1_500,
-            Some("claude-opus-4-6"),
-            "Run the command.",
-        );
+    fn dedupes_local_prompt_only_when_ssl_matches_model_and_text() {
+        for (name, local_model, local_details, expected_rows) in [
+            (
+                "same model and text",
+                Some("claude-opus-4-6"),
+                json!({"text_content": "Run the command.", "prompt_source": "local"}),
+                1,
+            ),
+            (
+                "legacy prompt field",
+                Some("claude-opus-4-6"),
+                json!({"prompt": "Run the command.", "prompt_source": "local"}),
+                1,
+            ),
+            (
+                "different model",
+                Some("claude-haiku-4-5"),
+                json!({"text_content": "Run the command.", "prompt_source": "local"}),
+                2,
+            ),
+            (
+                "missing model",
+                None,
+                json!({"text_content": "Run the command.", "prompt_source": "local"}),
+                2,
+            ),
+        ] {
+            let ssl_rows = [ssl_call_row("claude-opus-4-6", "Run the command.")];
+            let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
+            let mut local =
+                local_prompt_row("local-prompt", 1_500, local_model, "Run the command.");
+            local.details = local_details;
 
-        append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
+            append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
 
-        assert_eq!(prompt_rows.len(), 2);
-        assert_eq!(
-            prompt_rows[0]
-                .details
-                .get("prompt_source")
-                .and_then(Value::as_str),
-            Some("ssl")
-        );
-        assert_eq!(
-            prompt_rows[1]
-                .details
-                .get("prompt_source")
-                .and_then(Value::as_str),
-            Some("local")
-        );
-    }
-
-    #[test]
-    fn dedupes_local_prompt_when_ssl_has_same_model_and_text() {
-        let ssl_rows = [ssl_call_row("claude-opus-4-6", "Run the command.")];
-        let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
-        let local = local_prompt_row(
-            "local-prompt",
-            1_500,
-            Some("claude-opus-4-6"),
-            "Run the command.",
-        );
-
-        append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
-
-        assert_eq!(prompt_rows.len(), 1);
-        assert_eq!(
-            prompt_rows[0]
-                .details
-                .get("text_content")
-                .and_then(Value::as_str),
-            Some("Run the command.")
-        );
-        assert_eq!(
-            prompt_rows[0]
-                .details
-                .get("prompt_source")
-                .and_then(Value::as_str),
-            Some("ssl")
-        );
-    }
-
-    #[test]
-    fn keeps_local_prompt_when_either_model_is_missing() {
-        let ssl_rows = [ssl_call_row("claude-opus-4-6", "Run the command.")];
-        let mut prompt_rows = llm_call_prompt_rows(&ssl_rows);
-        let local = local_prompt_row("local-prompt", 1_500, None, "Run the command.");
-
-        append_deduped_local_session_prompt_rows(&mut prompt_rows, vec![local]);
-
-        assert_eq!(prompt_rows.len(), 2);
+            assert_eq!(prompt_rows.len(), expected_rows, "{name}");
+        }
     }
 
     fn ssl_call_row(model: &str, text: &str) -> LlmCallRow {

--- a/collector/src/text.rs
+++ b/collector/src/text.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
+use serde_json::Value;
+
 pub(crate) fn short_session_id(id: &str) -> String {
     let id = id.trim();
     if id.is_empty() {
@@ -50,5 +52,47 @@ pub(crate) fn truncate_with_ellipsis(text: &str, max: usize) -> String {
             "{}...",
             text.chars().take(max.saturating_sub(3)).collect::<String>()
         )
+    }
+}
+
+pub(crate) fn clean_prompt_text(text: &str) -> Option<String> {
+    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    let text = text
+        .strip_prefix("<session>")
+        .and_then(|text| text.strip_suffix("</session>"))
+        .unwrap_or(&text)
+        .trim();
+    (!text.is_empty()).then(|| text.to_string())
+}
+
+pub(crate) fn extract_prompt_text(value: &Value) -> Option<String> {
+    if let Some(prompt) = value.get("prompt").and_then(Value::as_str) {
+        return clean_prompt_text(prompt);
+    }
+    let mut parts = Vec::new();
+    for key in ["messages", "contents"] {
+        if let Some(items) = value.get(key).and_then(Value::as_array) {
+            for item in items {
+                collect_content_text(item.get("content").unwrap_or(item), &mut parts);
+            }
+        }
+    }
+    clean_prompt_text(&parts.join(" "))
+}
+
+fn collect_content_text(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::String(text) => out.push(text.clone()),
+        Value::Array(items) => items
+            .iter()
+            .for_each(|item| collect_content_text(item, out)),
+        Value::Object(obj) => {
+            for key in ["text", "content", "parts"] {
+                if let Some(value) = obj.get(key) {
+                    collect_content_text(value, out);
+                }
+            }
+        }
+        _ => {}
     }
 }

--- a/frontend/src/components/process-tree/BlockAdapters.tsx
+++ b/frontend/src/components/process-tree/BlockAdapters.tsx
@@ -175,10 +175,8 @@ function expandedEventContent(event: TreeAuditEvent, type: TreeEventType): strin
 }
 
 function formatPromptDetails(details: Record<string, any>): string {
-  const text = details.text_content.trim();
-  const meta = Object.fromEntries(
-    Object.entries(details).filter(([key]) => key !== 'text_content'),
-  );
+  const { text_content, prompt, ...meta } = details;
+  const text = text_content.trim();
   return Object.keys(meta).length > 0
     ? `${text}\n\n${JSON.stringify(meta, null, 2)}`
     : text;

--- a/frontend/src/components/process-tree/BlockAdapters.tsx
+++ b/frontend/src/components/process-tree/BlockAdapters.tsx
@@ -177,7 +177,7 @@ function expandedEventContent(event: TreeAuditEvent, type: TreeEventType): strin
 function formatPromptDetails(details: Record<string, any>): string {
   const text = details.text_content.trim();
   const meta = Object.fromEntries(
-    Object.entries(details).filter(([key]) => !['text_content', 'prompt'].includes(key)),
+    Object.entries(details).filter(([key]) => key !== 'text_content'),
   );
   return Object.keys(meta).length > 0
     ? `${text}\n\n${JSON.stringify(meta, null, 2)}`


### PR DESCRIPTION
## Summary
- Remove redundant prompt detail fields now that `text_content` is the canonical prompt text field.
- Drop duplicate prompt source/source metadata and fields already represented by audit row subject/target.
- Keep only useful prompt expansion metadata such as request, provider/path, local session id, and agent.

## Validation
- cargo test -p agentsight
- npm run build