### PR TITLE
bpf: share one JSONL escaping impl; demote browsertrace; fix doc drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,8 +18,8 @@ cd collector && cargo build --release   # Rust collector only
 cd frontend && npm install && npm run build  # Frontend only
 
 # Tests
-cd bpf && make test              # 60 C unit tests
-cd collector && cargo test       # 89+ Rust tests
+cd bpf && make test              # C unit + runtime tests
+cd collector && cargo test       # Rust tests
 cd frontend && npm run lint      # Frontend linting
 
 # Run a single Rust test
@@ -67,11 +67,15 @@ eBPF Programs (kernel) → JSON stdout → Rust Runners → Analyzer Chain → O
 
 ### Key Components
 
-- **`bpf/`** — C eBPF programs. `sslsniff` hooks SSL_read/SSL_write via uprobes; `process` tracks process lifecycle via tracepoints. Both emit JSON to stdout.
-- **`collector/src/framework/`** — Rust streaming framework:
-  - `runners/` — Execute eBPF binaries and parse their JSON output into event streams (SslRunner, ProcessRunner, SystemRunner, FakeRunner)
-  - `analyzers/` — Pluggable stream processors: SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, AuthHeaderRemover, TimestampNormalizer, OtelExporter (maps LLM HTTP pairs to OpenTelemetry `gen_ai.*` spans, exported via OTLP/HTTP JSON; enabled by `debug trace --otel`, see `docs/otel.md`)
-  - `core/events.rs` — Standardized `Event` struct with JSON payloads
+- **`bpf/`** — C eBPF programs. `sslsniff` hooks SSL_read/SSL_write via uprobes; `process` tracks process lifecycle via tracepoints; `stdiocap` captures stdio payloads. All emit JSONL to stdout via the shared `bpf/jsonl.h` helpers. `browsertrace` is experimental (`make experimental`) and not embedded in the collector.
+- **`collector/src/`** — Rust streaming pipeline (flat module layout):
+  - `runners/` — Execute eBPF binaries and parse their JSON output into event streams (BinaryRunner, ProcessRunner, SystemRunner, AgentRunner, FakeRunner for tests)
+  - `analyzers/` — Pluggable stream processors: SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, AuthHeaderRemover, TimestampNormalizer, MaterializingAnalyzer (feeds the materialized view)
+  - `sources/` — Non-eBPF inputs: agent-native session files (`~/.claude`, `~/.codex`), `/proc` snapshots, saved SQLite databases
+  - `view/` — MaterializedView: projects events into rows (llm_calls, audit_events, process_nodes, ...) and serves snapshots
+  - `sinks/` — ViewSink implementations: SQLite row store, OTel exporter (maps LLM call rows to OpenTelemetry `gen_ai.*` spans via OTLP/HTTP JSON; enabled by `debug trace --otel`, see `docs/otel.md`)
+  - `output/` — CLI/TUI rendering of snapshots
+  - `event.rs` — Standardized `Event` struct with JSON payloads; `model.rs` — view row types + ViewSink trait
   - `binary_extractor.rs` — Extracts embedded eBPF binaries to temp files at runtime
 - **`collector/src/main.rs`** — CLI entry point. Main subcommands: `stat`, `top`, `record`, `report` (`summary`, `token`, `audit`, `prompts`, `export`, `list`), `discover`, and `debug` (`ssl`, `process`, `stdio`, `trace`, `system`).
 - **`collector/src/server/`** — Hyper-based embedded web server serving frontend assets and `/api/events`

--- a/bpf/Makefile
+++ b/bpf/Makefile
@@ -31,7 +31,11 @@ CFLAGS += $(ASAN_FLAGS)
 ALL_LDFLAGS += $(ASAN_FLAGS)
 endif
 
-APPS = sslsniff browsertrace stdiocap process test_process_utils test_process_filter test_process_ext_map_flush test_process_ext_types # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+APPS = sslsniff stdiocap process test_process_utils test_process_filter test_process_ext_map_flush test_process_ext_types # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+
+# Experimental programs: built only via `make experimental` (or by name), not
+# shipped in the default build or embedded into the collector.
+EXPERIMENTAL_APPS = browsertrace
 
 # All test programs (no BPF skeleton needed)
 TEST_APPS = test_process_utils test_process_filter test_process_ext_map_flush test_process_ext_types
@@ -81,6 +85,9 @@ $(call allow-override,LD,$(CROSS_COMPILE)ld)
 .PHONY: all
 all: $(APPS)
 
+.PHONY: experimental
+experimental: $(EXPERIMENTAL_APPS)
+
 .PHONY: debug
 debug:
 	$(MAKE) ASAN=1 all
@@ -92,14 +99,15 @@ sslsniff-debug:
 .PHONY: clean
 clean:
 	$(call msg,CLEAN)
-	$(Q)rm -rf $(OUTPUT) $(APPS)
+	$(Q)rm -rf $(OUTPUT) $(APPS) $(EXPERIMENTAL_APPS)
 
 .PHONY: help
 help:
 	@echo "Available targets:"
 	@echo "  all          - Build all applications"
+	@echo "  experimental - Build experimental programs (browsertrace)"
 	@echo "  sslsniff     - Build sslsniff only"
-	@echo "  browsertrace - Build browsertrace only"
+	@echo "  browsertrace - Build browsertrace only (experimental)"
 	@echo "  stdiocap     - Build stdiocap only"
 	@echo "  process      - Build process tracer only"
 	@echo "  test         - Build and run tests"
@@ -198,7 +206,10 @@ $(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
 	$(Q)$(BPFTOOL) gen skeleton $< > $@
 
 # Build user-space code (exclude all test programs from the skel.h requirement)
-$(patsubst %,$(OUTPUT)/%.o,$(filter-out $(TEST_APPS),$(APPS))): %.o: %.skel.h
+$(patsubst %,$(OUTPUT)/%.o,$(filter-out $(TEST_APPS),$(APPS) $(EXPERIMENTAL_APPS))): %.o: %.skel.h
+
+# Shared JSONL emit helpers used by all userspace loaders
+$(patsubst %,$(OUTPUT)/%.o,$(filter-out $(TEST_APPS),$(APPS))): jsonl.h
 
 # Special rule for test programs (no BPF skeleton needed)
 $(OUTPUT)/test_process_utils.o: test_process_utils.c $(wildcard *.h) | $(OUTPUT)
@@ -226,7 +237,7 @@ $(patsubst %,$(OUTPUT)/%.o,$(BZS_APPS)): $(LIBBLAZESYM_HEADER)
 $(BZS_APPS): $(LIBBLAZESYM_OBJ)
 
 # Build application binary (exclude all test programs)
-$(filter-out $(TEST_APPS),$(APPS)): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+$(filter-out $(TEST_APPS),$(APPS) $(EXPERIMENTAL_APPS)): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 	$(call msg,BINARY,$@)
 	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
 

--- a/bpf/jsonl.h
+++ b/bpf/jsonl.h
@@ -1,0 +1,158 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+/*
+ * jsonl.h — shared JSONL emit helpers for AgentSight userspace loaders.
+ *
+ * Every eBPF userspace program (sslsniff, stdiocap, process) emits one JSON
+ * object per line on stdout. This header is the single owner of JSON string
+ * escaping so a malformed escape cannot corrupt the JSONL stream in one
+ * program but not another.
+ */
+#ifndef AGENTSIGHT_JSONL_H
+#define AGENTSIGHT_JSONL_H
+
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+/*
+ * Validate a UTF-8 sequence starting at str. Returns the sequence length in
+ * bytes, or 0 when invalid (bad start byte, truncated, overlong encoding,
+ * surrogate, or out-of-range code point). Requires a UTF-8 locale to be set
+ * by the caller's main() for mbrtowc().
+ */
+static inline int validate_utf8_char(const unsigned char *str, size_t remaining)
+{
+	unsigned char c;
+	int expected_len = 0;
+	char temp[5] = {0};
+	wchar_t wc;
+	mbstate_t state;
+	size_t result;
+
+	if (!str || remaining == 0)
+		return 0;
+
+	c = str[0];
+	if (c < 0x80)
+		return 1;
+
+	if ((c & 0xE0) == 0xC0)
+		expected_len = 2;
+	else if ((c & 0xF0) == 0xE0)
+		expected_len = 3;
+	else if ((c & 0xF8) == 0xF0)
+		expected_len = 4;
+	else
+		return 0;
+
+	if (remaining < (size_t)expected_len)
+		return 0;
+
+	memcpy(temp, str, expected_len > 4 ? 4 : expected_len);
+	memset(&state, 0, sizeof(state));
+	result = mbrtowc(&wc, temp, expected_len, &state);
+	if (result == (size_t)-1 || result == (size_t)-2 || result == 0)
+		return 0;
+
+	if (expected_len == 2) {
+		unsigned int codepoint = ((c & 0x1F) << 6) | (str[1] & 0x3F);
+
+		if (codepoint < 0x80)
+			return 0; /* overlong */
+	} else if (expected_len == 3) {
+		unsigned int codepoint = ((c & 0x0F) << 12) |
+					 ((str[1] & 0x3F) << 6) |
+					 (str[2] & 0x3F);
+
+		if (codepoint < 0x800)
+			return 0; /* overlong */
+		if (codepoint >= 0xD800 && codepoint <= 0xDFFF)
+			return 0; /* surrogate */
+	} else if (expected_len == 4) {
+		unsigned int codepoint = ((c & 0x07) << 18) |
+					 ((str[1] & 0x3F) << 12) |
+					 ((str[2] & 0x3F) << 6) |
+					 (str[3] & 0x3F);
+
+		if (codepoint < 0x10000 || codepoint > 0x10FFFF)
+			return 0;
+	}
+
+	return expected_len;
+}
+
+/*
+ * Stream buf as JSON string contents (no surrounding quotes) to stdout.
+ * Valid UTF-8 passes through; control characters and invalid bytes are
+ * \uXXXX-escaped so the output line stays valid JSON for any input.
+ */
+static inline void json_print_escaped(const char *buf, unsigned int len)
+{
+	unsigned int i;
+
+	for (i = 0; i < len; i++) {
+		unsigned char c = buf[i];
+
+		if (c == '"' || c == '\\')
+			printf("\\%c", c);
+		else if (c == '\n')
+			printf("\\n");
+		else if (c == '\r')
+			printf("\\r");
+		else if (c == '\t')
+			printf("\\t");
+		else if (c == '\b')
+			printf("\\b");
+		else if (c == '\f')
+			printf("\\f");
+		else if (c >= 32 && c <= 126)
+			printf("%c", c);
+		else if (c >= 128) {
+			int utf8_len = validate_utf8_char(
+				(const unsigned char *)&buf[i], len - i);
+			if (utf8_len > 0) {
+				int j;
+
+				for (j = 0; j < utf8_len; j++)
+					printf("%c", buf[i + j]);
+				i += utf8_len - 1;
+			} else {
+				printf("\\u%04x", c);
+			}
+		} else {
+			printf("\\u%04x", c);
+		}
+	}
+}
+
+/* Same as json_print_escaped but wrapped in double quotes. */
+static inline void json_print_escaped_quoted(const char *buf, unsigned int len)
+{
+	printf("\"");
+	json_print_escaped(buf, len);
+	printf("\"");
+}
+
+/*
+ * Escape a NUL-terminated string into dst for embedding in a JSON string
+ * (minimal set: backslash, quote, newline, tab). Used where output is
+ * composed into a fixed buffer instead of streamed.
+ */
+static inline void json_escape(const char *src, char *dst, size_t dst_size)
+{
+	size_t j = 0;
+
+	for (size_t i = 0; src[i] && j < dst_size - 2; i++) {
+		switch (src[i]) {
+		case '\\': if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = '\\'; } break;
+		case '"':  if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = '"'; } break;
+		case '\n': if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 'n'; } break;
+		case '\t': if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 't'; } break;
+		default:   dst[j++] = src[i]; break;
+		}
+	}
+	dst[j] = '\0';
+}
+
+#endif /* AGENTSIGHT_JSONL_H */

--- a/bpf/process_ext/map_flush.h
+++ b/bpf/process_ext/map_flush.h
@@ -10,6 +10,7 @@
 #include <bpf/libbpf.h>
 #include <bpf/bpf.h>
 #include "process_ext/types.h"
+#include "jsonl.h"
 
 static const char *event_type_name(unsigned int type)
 {
@@ -31,22 +32,6 @@ static const char *event_type_name(unsigned int type)
 	case EVENT_TYPE_COW_FAULT:     return "COW_FAULT";
 	default:                       return "UNKNOWN";
 	}
-}
-
-/* Escape a string for JSON output (minimal: handle \, ", \n, \t, \0) */
-static void json_escape(const char *src, char *dst, size_t dst_size)
-{
-	size_t j = 0;
-	for (size_t i = 0; src[i] && j < dst_size - 2; i++) {
-		switch (src[i]) {
-		case '\\': if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = '\\'; } break;
-		case '"':  if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = '"'; } break;
-		case '\n': if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 'n'; } break;
-		case '\t': if (j + 2 < dst_size) { dst[j++] = '\\'; dst[j++] = 't'; } break;
-		default:   dst[j++] = src[i]; break;
-		}
-	}
-	dst[j] = '\0';
 }
 
 static bool parse_fd_detail(const char *detail, int *fd_out)

--- a/bpf/sslsniff.c
+++ b/bpf/sslsniff.c
@@ -23,6 +23,7 @@
 #include "sslsniff.skel.h"
 #include "sslsniff.h"
 #include "container_info.h"
+#include "jsonl.h"
 
 #define INVALID_UID -1
 #define INVALID_PID -1
@@ -447,62 +448,6 @@ char *find_library_path(const char *libname) {
 // Global buffer allocated once and reused
 static char *event_buf = NULL;
 
-// Function to validate UTF-8 sequence and return its length
-// Returns 0 if invalid, otherwise returns the number of bytes in the sequence
-int validate_utf8_char(const unsigned char *str, size_t remaining) {
-	if (!str || remaining == 0) return 0;
-	
-	unsigned char c = str[0];
-	
-	// ASCII character (0-127)
-	if (c < 0x80) return 1;
-	
-	// Determine the expected length of UTF-8 sequence
-	int expected_len = 0;
-	if ((c & 0xE0) == 0xC0) expected_len = 2;      // 110xxxxx
-	else if ((c & 0xF0) == 0xE0) expected_len = 3; // 1110xxxx
-	else if ((c & 0xF8) == 0xF0) expected_len = 4; // 11110xxx
-	else return 0; // Invalid start byte
-	
-	// Check if we have enough bytes
-	if (remaining < expected_len) return 0;
-	
-	// Create a buffer for mbstowcs
-	char temp[5] = {0};
-	for (int i = 0; i < expected_len && i < 4; i++) {
-		temp[i] = str[i];
-	}
-	
-	// Set locale for UTF-8 (done once in main)
-	wchar_t wc;
-	mbstate_t state;
-	memset(&state, 0, sizeof(state));
-	
-	// Try to convert the sequence
-	size_t result = mbrtowc(&wc, temp, expected_len, &state);
-	
-	// Check for conversion errors
-	if (result == (size_t)-1 || result == (size_t)-2 || result == 0) {
-		return 0; // Invalid sequence
-	}
-	
-	// Additional validation for overlong sequences and valid code points
-	if (expected_len == 2) {
-		unsigned int codepoint = ((c & 0x1F) << 6) | (str[1] & 0x3F);
-		if (codepoint < 0x80) return 0; // Overlong
-	} else if (expected_len == 3) {
-		unsigned int codepoint = ((c & 0x0F) << 12) | ((str[1] & 0x3F) << 6) | (str[2] & 0x3F);
-		if (codepoint < 0x800) return 0; // Overlong
-		if (codepoint >= 0xD800 && codepoint <= 0xDFFF) return 0; // Surrogate
-	} else if (expected_len == 4) {
-		unsigned int codepoint = ((c & 0x07) << 18) | ((str[1] & 0x3F) << 12) | 
-		                        ((str[2] & 0x3F) << 6) | (str[3] & 0x3F);
-		if (codepoint < 0x10000 || codepoint > 0x10FFFF) return 0; // Invalid range
-	}
-	
-	return expected_len;
-}
-
 // Function to print the event from the perf buffer in JSON format
 void print_event(struct probe_SSL_data_t *event, const char *evt) {
 	static unsigned long long start = 0;  // Use static to retain value across function calls
@@ -574,46 +519,10 @@ void print_event(struct probe_SSL_data_t *event, const char *evt) {
 	// Data field - always include both text and hex
 	if (buf_size > 0) {
 		// Text data
-		printf("\"data\":\"");
-		for (unsigned int i = 0; i < buf_size; i++) {
-			unsigned char c = event_buf[i];
-			if (c == '"' || c == '\\') {
-				printf("\\%c", c);
-			} else if (c == '\n') {
-				printf("\\n");
-			} else if (c == '\r') {
-				printf("\\r");
-			} else if (c == '\t') {
-				printf("\\t");
-			} else if (c == '\b') {
-				printf("\\b");
-			} else if (c == '\f') {
-				printf("\\f");
-			} else if (c >= 32 && c <= 126) {
-				// ASCII printable characters
-				printf("%c", c);
-			} else if (c >= 128) {
-				// Use our new UTF-8 validation function
-				int utf8_len = validate_utf8_char((unsigned char *)&event_buf[i], buf_size - i);
-				
-				if (utf8_len > 0) {
-					// Output the valid UTF-8 sequence
-					for (int j = 0; j < utf8_len; j++) {
-						printf("%c", event_buf[i + j]);
-					}
-					i += utf8_len - 1; // Skip the continuation bytes
-				} else {
-					// Invalid UTF-8 byte - escape it
-					printf("\\u%04x", c);
-				}
-			} else {
-				// Control characters (0-31, 127)
-				printf("\\u%04x", c);
-			}
-		}
-		printf("\",");
-		
-		
+		printf("\"data\":");
+		json_print_escaped_quoted(event_buf, buf_size);
+		printf(",");
+
 		// Add truncated info if data was truncated
 		if (buf_size < event->len) {
 			printf("\"truncated\":true,\"bytes_lost\":%d", event->len - buf_size);

--- a/bpf/stdiocap.c
+++ b/bpf/stdiocap.c
@@ -16,6 +16,7 @@
 
 #include "stdiocap.skel.h"
 #include "stdiocap.h"
+#include "jsonl.h"
 
 #define INVALID_UID -1
 #define INVALID_PID -1
@@ -133,43 +134,6 @@ static void sig_int(int signo)
 	exiting = 1;
 }
 
-static int validate_utf8_char(const unsigned char *str, size_t remaining)
-{
-	unsigned char c;
-	int expected_len = 0;
-	char temp[5] = {0};
-	wchar_t wc;
-	mbstate_t state;
-	size_t result;
-
-	if (!str || remaining == 0)
-		return 0;
-
-	c = str[0];
-	if (c < 0x80)
-		return 1;
-
-	if ((c & 0xE0) == 0xC0)
-		expected_len = 2;
-	else if ((c & 0xF0) == 0xE0)
-		expected_len = 3;
-	else if ((c & 0xF8) == 0xF0)
-		expected_len = 4;
-	else
-		return 0;
-
-	if (remaining < (size_t)expected_len)
-		return 0;
-
-	memcpy(temp, str, expected_len > 4 ? 4 : expected_len);
-	memset(&state, 0, sizeof(state));
-	result = mbrtowc(&wc, temp, expected_len, &state);
-	if (result == (size_t)-1 || result == (size_t)-2 || result == 0)
-		return 0;
-
-	return expected_len;
-}
-
 static const char *fd_role(int fd)
 {
 	switch (fd) {
@@ -245,46 +209,6 @@ static int refresh_session_pids(int map_fd, pid_t session_id)
 	return count;
 }
 
-static void print_json_escaped(const char *buf, unsigned int len)
-{
-	unsigned int i;
-
-	printf("\"");
-	for (i = 0; i < len; i++) {
-		unsigned char c = buf[i];
-
-		if (c == '"' || c == '\\')
-			printf("\\%c", c);
-		else if (c == '\n')
-			printf("\\n");
-		else if (c == '\r')
-			printf("\\r");
-		else if (c == '\t')
-			printf("\\t");
-		else if (c == '\b')
-			printf("\\b");
-		else if (c == '\f')
-			printf("\\f");
-		else if (c >= 32 && c <= 126)
-			printf("%c", c);
-		else if (c >= 128) {
-			int utf8_len = validate_utf8_char((const unsigned char *)&buf[i], len - i);
-			if (utf8_len > 0) {
-				int j;
-
-				for (j = 0; j < utf8_len; j++)
-					printf("%c", buf[i + j]);
-				i += utf8_len - 1;
-			} else {
-				printf("\\u%04x", c);
-			}
-		} else {
-			printf("\\u%04x", c);
-		}
-	}
-	printf("\"");
-}
-
 static void print_event(const struct stdiocap_event_t *event)
 {
 	unsigned int buf_size = event->buf_size;
@@ -317,7 +241,7 @@ static void print_event(const struct stdiocap_event_t *event)
 	printf("\"fd_role\":\"%s\",", fd_role(event->fd));
 	if (have_fd_target) {
 		printf("\"fd_target\":");
-		print_json_escaped(fd_target, strlen(fd_target));
+		json_print_escaped_quoted(fd_target, strlen(fd_target));
 		printf(",");
 	} else {
 		printf("\"fd_target\":null,");
@@ -332,7 +256,7 @@ static void print_event(const struct stdiocap_event_t *event)
 		return;
 	}
 
-	print_json_escaped(event_buf, buf_size);
+	json_print_escaped_quoted(event_buf, buf_size);
 	if (buf_size < event->len)
 		printf(",\"truncated\":true,\"bytes_lost\":%u}\n", event->len - buf_size);
 	else

--- a/collector/src/analyzers/http_parser.rs
+++ b/collector/src/analyzers/http_parser.rs
@@ -254,30 +254,25 @@ impl HTTPParser {
             parsed_message.body.as_ref().map(|b| b.len()).unwrap_or(0) +
             4; // +4 for \r\n\r\n separator
 
-        let mut http_event = HTTPEvent::new(
+        HTTPEvent {
             tid,
-            message_type_str.to_string(),
-            parsed_message.first_line,
-            parsed_message.method,
-            parsed_message.path,
-            parsed_message.protocol,
-            parsed_message.status_code,
-            parsed_message.status_text,
-            parsed_message.headers,
-            parsed_message.body,
+            message_type: message_type_str.to_string(),
+            first_line: parsed_message.first_line,
+            method: parsed_message.method,
+            path: parsed_message.path,
+            protocol: parsed_message.protocol,
+            status_code: parsed_message.status_code,
+            status_text: parsed_message.status_text,
+            headers: parsed_message.headers,
+            body: parsed_message.body,
             total_size,
             has_body,
             is_chunked,
             content_length,
-            "ssl".to_string(),
-        );
-
-        // Include raw data if requested
-        if include_raw_data {
-            http_event = http_event.with_raw_data(parsed_message.raw_data);
+            original_source: "ssl".to_string(),
+            raw_data: include_raw_data.then_some(parsed_message.raw_data),
         }
-
-        http_event.to_event(original_event)
+        .to_event(original_event)
     }
 
     /// Handle SSL events (HTTP request/response data)
@@ -616,27 +611,26 @@ fn create_http2_request_event(
     );
     let body = body_string(&state.request_body);
     let total_size = headers_size(&state.request_headers) + state.request_body.len();
-    let mut event = HTTPEvent::new(
-        synthetic_http2_tid(tid, stream_id),
-        "request".to_string(),
+    HTTPEvent {
+        tid: synthetic_http2_tid(tid, stream_id),
+        message_type: "request".to_string(),
         first_line,
         method,
         path,
-        Some("HTTP/2".to_string()),
-        None,
-        None,
-        state.request_headers.clone(),
-        body.clone(),
+        protocol: Some("HTTP/2".to_string()),
+        status_code: None,
+        status_text: None,
+        headers: state.request_headers.clone(),
+        content_length: body.as_ref().map(String::len),
+        has_body: body.is_some(),
+        is_chunked: false,
+        body,
         total_size,
-        body.is_some(),
-        false,
-        body.as_ref().map(String::len),
-        "ssl.http2".to_string(),
-    );
-    if include_raw_data {
-        event = event.with_raw_data(String::from_utf8_lossy(&state.request_body).to_string());
+        original_source: "ssl.http2".to_string(),
+        raw_data: include_raw_data
+            .then(|| String::from_utf8_lossy(&state.request_body).to_string()),
     }
-    event.to_event(original_event)
+    .to_event(original_event)
 }
 
 fn create_http2_response_event(
@@ -654,27 +648,26 @@ fn create_http2_response_event(
     let first_line = format!("HTTP/2 {}", status_code.unwrap_or(200));
     let body = body_string(&state.response_body);
     let total_size = headers_size(&state.response_headers) + state.response_body.len();
-    let mut event = HTTPEvent::new(
-        synthetic_http2_tid(tid, stream_id),
-        "response".to_string(),
+    HTTPEvent {
+        tid: synthetic_http2_tid(tid, stream_id),
+        message_type: "response".to_string(),
         first_line,
-        None,
-        None,
-        Some("HTTP/2".to_string()),
+        method: None,
+        path: None,
+        protocol: Some("HTTP/2".to_string()),
         status_code,
-        None,
-        state.response_headers.clone(),
-        body.clone(),
+        status_text: None,
+        headers: state.response_headers.clone(),
+        content_length: body.as_ref().map(String::len),
+        has_body: body.is_some(),
+        is_chunked: false,
+        body,
         total_size,
-        body.is_some(),
-        false,
-        body.as_ref().map(String::len),
-        "ssl.http2".to_string(),
-    );
-    if include_raw_data {
-        event = event.with_raw_data(String::from_utf8_lossy(&state.response_body).to_string());
+        original_source: "ssl.http2".to_string(),
+        raw_data: include_raw_data
+            .then(|| String::from_utf8_lossy(&state.response_body).to_string()),
     }
-    event.to_event(original_event)
+    .to_event(original_event)
 }
 
 fn synthetic_http2_tid(tid: u64, stream_id: u32) -> u64 {

--- a/collector/src/analyzers/protocol_events.rs
+++ b/collector/src/analyzers/protocol_events.rs
@@ -26,41 +26,6 @@ pub struct SSEProcessorEvent {
 }
 
 impl SSEProcessorEvent {
-    pub fn new(
-        connection_id: String,
-        message_id: Option<String>,
-        start_time: u64,
-        end_time: u64,
-        original_source: String,
-        function: String,
-        tid: u64,
-        json_content: String,
-        text_content: String,
-        total_size: usize,
-        event_count: usize,
-        has_message_start: bool,
-        sse_events: Vec<Value>,
-    ) -> Self {
-        let duration_ns = end_time.saturating_sub(start_time);
-
-        SSEProcessorEvent {
-            connection_id,
-            message_id,
-            start_time,
-            end_time,
-            duration_ns,
-            original_source,
-            function,
-            tid,
-            json_content,
-            text_content,
-            total_size,
-            event_count,
-            has_message_start,
-            sse_events,
-        }
-    }
-
     pub fn to_event(&self, original_event: &Event) -> Event {
         // Serialize struct to JSON Value to ensure exact match with struct fields
         let data = serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}));
@@ -104,48 +69,6 @@ pub struct HTTPEvent {
 }
 
 impl HTTPEvent {
-    pub fn new(
-        tid: u64,
-        message_type: String,
-        first_line: String,
-        method: Option<String>,
-        path: Option<String>,
-        protocol: Option<String>,
-        status_code: Option<u16>,
-        status_text: Option<String>,
-        headers: HashMap<String, String>,
-        body: Option<String>,
-        total_size: usize,
-        has_body: bool,
-        is_chunked: bool,
-        content_length: Option<usize>,
-        original_source: String,
-    ) -> Self {
-        HTTPEvent {
-            tid,
-            message_type,
-            first_line,
-            method,
-            path,
-            protocol,
-            status_code,
-            status_text,
-            headers,
-            body,
-            total_size,
-            has_body,
-            is_chunked,
-            content_length,
-            original_source,
-            raw_data: None,
-        }
-    }
-
-    pub fn with_raw_data(mut self, raw_data: String) -> Self {
-        self.raw_data = Some(raw_data);
-        self
-    }
-
     pub fn to_event(&self, original_event: &Event) -> Event {
         // Serialize struct to JSON Value to ensure exact match with struct fields
         let data = serde_json::to_value(self).unwrap_or_else(|_| serde_json::json!({}));

--- a/collector/src/analyzers/sse_processor.rs
+++ b/collector/src/analyzers/sse_processor.rs
@@ -337,34 +337,32 @@ impl SSEProcessor {
 
         let total_size = json_content.len() + text_content.len();
 
-        let sse_processor_event = SSEProcessorEvent::new(
+        SSEProcessorEvent {
             connection_id,
-            accumulator.message_id.clone(),
-            accumulator.start_time,
-            accumulator.end_time,
-            "ssl".to_string(),
-            original_event
+            message_id: accumulator.message_id.clone(),
+            start_time: accumulator.start_time,
+            end_time: accumulator.end_time,
+            duration_ns: accumulator.end_time.saturating_sub(accumulator.start_time),
+            original_source: "ssl".to_string(),
+            function: original_event
                 .data
                 .get("function")
-                .unwrap_or(&json!("unknown"))
-                .as_str()
+                .and_then(|v| v.as_str())
                 .unwrap_or("unknown")
                 .to_string(),
-            original_event
+            tid: original_event
                 .data
                 .get("tid")
-                .unwrap_or(&json!(0))
-                .as_u64()
+                .and_then(|v| v.as_u64())
                 .unwrap_or(0),
             json_content,
             text_content,
             total_size,
-            accumulator.events.len(),
-            accumulator.has_message_start,
-            sse_events_json,
-        );
-
-        sse_processor_event.to_event(original_event)
+            event_count: accumulator.events.len(),
+            has_message_start: accumulator.has_message_start,
+            sse_events: sse_events_json,
+        }
+        .to_event(original_event)
     }
 
     fn evict_over_capacity(buffers: &mut HashMap<String, SSEAccumulator>, max: usize) {

--- a/docs/design/materialized-view-architecture.md
+++ b/docs/design/materialized-view-architecture.md
@@ -85,7 +85,7 @@ instead.
 ## Code Layout
 
 ```text
-collector/src/framework/analyzers/materializing.rs
+collector/src/analyzers/materializing.rs
   Event-stream analyzer that drives the shared view.
 
 collector/src/view/mod.rs
@@ -95,10 +95,10 @@ collector/src/view/projection.rs
   Event normalization, LLM request/response matching, audit/process/resource
   row projection implemented directly on MaterializedView.
 
-collector/src/view/types.rs
+collector/src/model.rs
   Snapshot, row types, ViewSink.
 
-collector/src/stores/sqlite.rs
+collector/src/sinks/sqlite.rs
   SQLite row store and ViewSink implementation.
 
 collector/src/sinks/otel.rs


### PR DESCRIPTION
## Summary

Net **-95 lines** (256+/351-), behavior-preserving, all suites green.

- **`bpf/jsonl.h` becomes the single owner of JSON string escaping** for the userspace loaders. `sslsniff`, `stdiocap`, and `process` each carried their own implementation with diverging semantics — stdiocap's UTF-8 validator accepted overlong encodings and surrogates that sslsniff rejected. One bad escape corrupts the JSONL stream the collector parses, so this is a correctness consolidation: the strict validator (overlong/surrogate rejection) wins everywhere.
- **`browsertrace` moves out of the default `APPS`**: it is referenced nowhere in the collector (`binary_extractor.rs` embeds only process/sslsniff/stdiocap), so the default build, CI, and release artifact stop carrying ~1.5k LOC of experimental code. Still buildable via `make experimental` / `make browsertrace`.
- **Delete the 13/15-parameter constructors** in `protocol_events.rs` (`HTTPEvent::new`, `SSEProcessorEvent::new`, `with_raw_data`); call sites construct struct literals with named fields instead of positional argument lists.
- **Fix documentation drift**: `CLAUDE.md` described a `collector/src/framework/` tree that no longer exists; `materialized-view-architecture.md` pointed at `view/types.rs` and `stores/sqlite.rs` (now `model.rs` and `sinks/sqlite.rs`). Stale paths actively mislead agent-assisted development on this repo.

## Test plan

- `cd bpf && make && make test` — 160 C unit tests + process/stdiocap runtime tests pass
- `cd collector && cargo test` — 112 tests pass
- `cargo clippy --all-targets` — zero warnings
- Vendored eBPF binaries intentionally not touched — release CI rebuilds them (`[skip ci]` release commits own `collector/vendor/bpf`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)