### PR TITLE
[codex] report runner exit errors

### DIFF
--- a/collector/src/cmd_exec.rs
+++ b/collector/src/cmd_exec.rs
@@ -224,7 +224,12 @@ pub(crate) async fn run_exec(
         tokio::select! {
             maybe_event = stream.next() => {
                 match maybe_event {
-                    Some(_event) => {}
+                    Some(event) => {
+                        if let Some(error) = crate::runners::common::runner_error_from_event(&event) {
+                            stop_child(&mut child).await;
+                            return Err(error);
+                        }
+                    }
                     None => {
                         print_record_monitoring_stream_ended();
                         break;
@@ -239,7 +244,7 @@ pub(crate) async fn run_exec(
                     Err(e) => print_record_target_wait_error(e),
                 }
                 target_exited = true;
-                drain_stream_for(&mut stream, tokio::time::Duration::from_millis(5000)).await;
+                drain_stream_for(&mut stream, tokio::time::Duration::from_millis(5000)).await?;
                 break;
             }
             _ = shutdown.notified() => {

--- a/collector/src/cmd_trace.rs
+++ b/collector/src/cmd_trace.rs
@@ -16,6 +16,7 @@ use crate::output::{
     print_trace_shutdown, print_trace_ssl_binary_discovered, print_trace_start,
     print_web_server_error, print_web_server_start,
 };
+use crate::runners::common::runner_error_from_event;
 use crate::runners::{
     AgentRunner, BinaryRunner, EventStream, ProcessRunner, Runner, RunnerError, SystemRunner,
 };
@@ -365,7 +366,7 @@ pub(crate) async fn run_trace(
     let mut stream = agent.run().await?;
 
     // Drive the stream so the analyzer chain (file logging, storage, etc.) runs.
-    drive_stream_until_shutdown(&mut stream, !cfg.quiet).await;
+    drive_stream_until_shutdown(&mut stream, !cfg.quiet).await?;
     drop(stream);
     drop(agent);
 
@@ -422,13 +423,19 @@ pub(crate) async fn start_web_server_if_enabled(
     }))
 }
 
-pub(crate) async fn drive_stream_until_shutdown(stream: &mut EventStream, print_events: bool) {
+pub(crate) async fn drive_stream_until_shutdown(
+    stream: &mut EventStream,
+    print_events: bool,
+) -> Result<(), RunnerError> {
     let shutdown = crate::shutdown_notify();
     loop {
         tokio::select! {
             maybe_event = stream.next() => {
                 match maybe_event {
                     Some(event) => {
+                        if let Some(error) = runner_error_from_event(&event) {
+                            return Err(error);
+                        }
                         if print_events {
                             print_event_json(&event);
                         }
@@ -442,17 +449,26 @@ pub(crate) async fn drive_stream_until_shutdown(stream: &mut EventStream, print_
             }
         }
     }
+    Ok(())
 }
 
-pub(crate) async fn drain_stream_for(stream: &mut EventStream, duration: tokio::time::Duration) {
+pub(crate) async fn drain_stream_for(
+    stream: &mut EventStream,
+    duration: tokio::time::Duration,
+) -> Result<(), RunnerError> {
     let shutdown = crate::shutdown_notify();
     let deadline = tokio::time::sleep(duration);
     tokio::pin!(deadline);
     loop {
         tokio::select! {
             maybe_event = stream.next() => {
-                if maybe_event.is_none() {
-                    break;
+                match maybe_event {
+                    Some(event) => {
+                        if let Some(error) = runner_error_from_event(&event) {
+                            return Err(error);
+                        }
+                    }
+                    None => break,
                 }
             }
             _ = &mut deadline => {
@@ -463,6 +479,7 @@ pub(crate) async fn drain_stream_for(stream: &mut EventStream, duration: tokio::
             }
         }
     }
+    Ok(())
 }
 
 pub(crate) fn convert_runner_error(e: RunnerError) -> Box<dyn std::error::Error + Send + Sync> {
@@ -507,6 +524,6 @@ pub(crate) async fn run_debug_runner<R: Runner>(
             .await
             .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
     let mut stream = runner.run().await?;
-    drive_stream_until_shutdown(&mut stream, !quiet).await;
+    drive_stream_until_shutdown(&mut stream, !quiet).await?;
     Ok(())
 }

--- a/collector/src/runners/common.rs
+++ b/collector/src/runners/common.rs
@@ -17,6 +17,7 @@ use tokio::process::Command as TokioCommand;
 
 /// Type alias for JSON stream
 pub type JsonStream = Pin<Box<dyn Stream<Item = serde_json::Value> + Send>>;
+const RUNNER_ERROR_TYPE: &str = "runner_error";
 
 fn preview_line(line: &str, max_chars: usize) -> String {
     let mut chars = line.chars();
@@ -26,6 +27,41 @@ fn preview_line(line: &str, max_chars: usize) -> String {
     } else {
         preview
     }
+}
+
+fn runner_label(runner_name: Option<&str>, binary_path: &str) -> String {
+    runner_name.map(str::to_string).unwrap_or_else(|| {
+        Path::new(binary_path)
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("binary")
+            .to_string()
+    })
+}
+
+fn runner_error_json(runner: &str, message: String) -> serde_json::Value {
+    let timestamp = current_boot_time_ns();
+    serde_json::json!({
+        "timestamp": timestamp,
+        "timestamp_ns": timestamp,
+        "pid": 0,
+        "comm": runner,
+        "type": RUNNER_ERROR_TYPE,
+        "message": message,
+    })
+}
+
+pub fn runner_error_from_event(event: &Event) -> Option<RunnerError> {
+    (event.data.get("type").and_then(|v| v.as_str()) == Some(RUNNER_ERROR_TYPE)).then(|| {
+        RunnerError::from(
+            event
+                .data
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("runner failed")
+                .to_string(),
+        )
+    })
 }
 
 struct ProbeProcessGuard {
@@ -225,10 +261,10 @@ impl BinaryExecutor {
         // Clone needed data for the stream
         let runner_name = self.runner_name.clone();
         let binary_path = self.binary_path.clone();
+        let label = runner_label(runner_name.as_deref(), &binary_path);
 
         // Spawn a task to read and log stderr
-        let stderr_runner_name = runner_name.clone();
-        let stderr_binary_path = binary_path.clone();
+        let stderr_label = label.clone();
         tokio::spawn(async move {
             let mut stderr_reader = BufReader::new(stderr);
             let mut stderr_line = String::new();
@@ -243,32 +279,7 @@ impl BinaryExecutor {
                     Ok(_) => {
                         let trimmed = stderr_line.trim();
                         if !trimmed.is_empty() {
-                            // Log stderr output as ERROR for visibility
-                            let runner_info = stderr_runner_name
-                                .as_ref()
-                                .map(|name| format!("[{}] ", name))
-                                .unwrap_or_else(|| {
-                                    format!(
-                                        "[{}] ",
-                                        std::path::Path::new(&stderr_binary_path)
-                                            .file_name()
-                                            .and_then(|n| n.to_str())
-                                            .unwrap_or("unknown")
-                                    )
-                                });
-
-                            // Check severity of the message
-                            if trimmed.contains("Failed")
-                                || trimmed.contains("Error")
-                                || trimmed.contains("cannot")
-                                || trimmed.contains("permission denied")
-                            {
-                                log::error!("{}STDERR: {}", runner_info, trimmed);
-                            } else if trimmed.contains("warn") || trimmed.contains("Warning") {
-                                log::warn!("{}STDERR: {}", runner_info, trimmed);
-                            } else {
-                                log::info!("{}STDERR: {}", runner_info, trimmed);
-                            }
+                            log::warn!("[{}] STDERR: {}", stderr_label, trimmed);
                         }
                     }
                     Err(e) => {
@@ -360,9 +371,12 @@ impl BinaryExecutor {
                 Ok(status) => {
                     debug!("Binary process terminated with status: {}", status);
                     guard.disarm();
+                    if !status.success() {
+                        yield runner_error_json(&label, format!("{label} exited with {status}"));
+                    }
                 }
                 Err(e) => {
-                    log::warn!("Error waiting for binary process: {}", e);
+                    yield runner_error_json(&label, format!("failed to wait for {label}: {e}"));
                 }
             }
         };


### PR DESCRIPTION
## Summary
- Emit a standard `runner_error` event when a binary runner exits nonzero or cannot be waited on.
- Make trace/debug/record consumers return that runner error instead of treating the stream as a clean EOF.
- Replace fragile stderr keyword severity detection with a single warning log path; the structured runner error now carries failure semantics.

## Why
Binary runner failures after startup were only visible as logs or EOF. That could make probe failures look like a clean empty stream. This keeps the analyzer stream shape unchanged while giving consumers one small structured error signal to fail on.

## Impact
This is intentionally narrower than changing the whole analyzer pipeline to `Stream<Item = Result<Event, _>>`. It reduces error handling surface area without forcing every analyzer to carry `Result` plumbing.

## Validation
- `cargo check`
- `cargo test`
- `timeout 30s cargo run --quiet -- debug process -- --bad-arg` returns status 1 with `Error: Process exited with exit status: 64`