### PR TITLE
[codex] Remove stat command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ Build requirements and source build commands live in [docs/build.md](https://git
 
 ### Querying Past Sessions
 
-Every `stat -- <command>` or `record` session is automatically saved to SQLite. Start with the perf-style commands, then use `agentsight report` for structured queries:
+Every `record` session is automatically saved to SQLite. Start with the live and record commands, then use `agentsight report` for structured queries:
 
 ```bash
-agentsight stat                              # counters for the latest saved session
 sudo agentsight top                          # live ranked view of current agent sessions
 agentsight top --db run.db --once            # ranked view of a saved session
 sudo agentsight record -- claude             # record a command
@@ -170,13 +169,13 @@ collector setup and backend integration.
 ## ❓ Frequently Asked Questions
 
 **Q: What permissions does AgentSight need?**
-A: eBPF probes need root privileges, so AgentSight may prompt for `sudo`. With `record -- <command>` or `stat -- <command>`, the monitored agent still runs as your normal user; only the probes are elevated.
+A: eBPF probes need root privileges, so AgentSight may prompt for `sudo`. With `record -- <command>`, the monitored agent still runs as your normal user; only the probes are elevated.
 
 **Q: What's the performance impact?**
 A: Our evaluation reports less than 3% CPU overhead for typical traced agent workloads.
 
 **Q: Where does captured data go?**
-A: `record` and `stat -- <command>` store sessions locally in SQLite by default. Use `agentsight stat`, `agentsight top`, `agentsight report`, `agentsight report list`, `agentsight report audit --json`, and `agentsight report token` to inspect prior runs. Captured data can include prompts, responses, paths, headers, and network targets, so treat logs and DBs as sensitive.
+A: `record` stores sessions locally in SQLite by default. Use `agentsight top`, `agentsight report`, `agentsight report list`, `agentsight report audit --json`, and `agentsight report token` to inspect prior runs. Captured data can include prompts, responses, paths, headers, and network targets, so treat logs and DBs as sensitive.
 
 **Q: Why doesn't AgentSight capture traffic from Claude Code, Node.js, or Gemini CLI?**
 A: These applications statically link their SSL library (BoringSSL for Claude/Bun, OpenSSL for **all** Node.js — both NVM and system installs) into their own binary instead of using system `libssl.so`, so there's nothing for sslsniff to hook by default. AgentSight handles this for you: `record -- <command>` always discovers the binary, and `record -c node` now auto-discovers the Node binary too. For Claude attach mode, pass `--binary-path`. See the "Zero-Config: record" and "Monitoring Node.js AI Tools" sections.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -108,7 +108,7 @@ make build
 
 ### Web 界面
 
-`stat -- <command>` 和 `record` 默认启动 Web UI。低层 `debug trace` 需要传入 `--server`：
+`record -- <command>` 默认启动 Web UI。低层 `debug trace` 需要传入 `--server`：
 - **时间线视图**：http://127.0.0.1:7395/timeline
 - **进程树**：http://127.0.0.1:7395/tree
 - **原始日志**：http://127.0.0.1:7395/logs

--- a/collector/src/cmd_exec.rs
+++ b/collector/src/cmd_exec.rs
@@ -68,7 +68,7 @@ pub(crate) fn print_session_summary(db_path: &str) {
         return;
     };
     if let Ok(summary) = SessionSummary::from_view(&view) {
-        print_record_session_summary(&summary);
+        print_record_session_summary(db_path, &summary);
     }
 }
 

--- a/collector/src/cmd_perf.rs
+++ b/collector/src/cmd_perf.rs
@@ -6,8 +6,7 @@ use crate::model::{
     AuditCounters, ResourceSampleRow, SessionRow, Snapshot, SnapshotOptions, ViewResult,
 };
 use crate::output::{
-    AgentTopOutput, AgentTopRow, ResourcePeaks, StatOutput, TopOptions, clear_screen,
-    print_agent_top, print_json, print_stat,
+    AgentTopOutput, AgentTopRow, ResourcePeaks, TopOptions, clear_screen, print_agent_top,
 };
 use crate::text::short_session_id;
 use crate::view::top::{recent_failures, sort_agent_rows, top_sections};
@@ -17,19 +16,6 @@ use std::time::Duration;
 
 #[cfg(test)]
 use crate::sources::agent_native as agent_native_sessions;
-
-pub(crate) fn run_stat_query(
-    db: &str,
-    json: bool,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let stat = load_stat(db)?;
-    if json {
-        print_json(&stat)?;
-    } else {
-        print_stat(&stat);
-    }
-    Ok(())
-}
 
 pub(crate) fn run_top_query(
     db: &str,
@@ -62,48 +48,6 @@ pub(crate) fn run_top_query(
     }
 
     Ok(())
-}
-
-fn load_stat(db: &str) -> ViewResult<StatOutput> {
-    let view = load_agentsight_view(Some(db))?;
-    let snapshot = view.export_snapshot(SnapshotOptions {
-        audit_limit: 50_000,
-    });
-    let resources = resource_peaks_from_samples(&snapshot.resource_samples);
-    let tool_calls = snapshot.tool_calls.len() as i64;
-    let audit = AuditCounters::from_rows(&snapshot.audit_events);
-
-    let network_hosts = snapshot
-        .network_targets
-        .iter()
-        .map(|target| target.host.clone())
-        .collect::<BTreeSet<_>>()
-        .len();
-    let http_errors = snapshot
-        .network_targets
-        .iter()
-        .map(|target| target.error_count.max(0) as usize)
-        .sum();
-
-    Ok(StatOutput {
-        db: db.to_string(),
-        duration_s: snapshot.summary.duration_s(),
-        view_events: snapshot.summary.view_events,
-        llm_calls: snapshot.summary.llm_calls,
-        input_tokens: snapshot.summary.input_tokens,
-        output_tokens: snapshot.summary.output_tokens,
-        total_tokens: snapshot.summary.total_tokens,
-        process_execs: audit.process_execs,
-        process_exits: audit.process_exits,
-        process_exit_success: audit.process_exit_success,
-        process_exit_failure: audit.process_exit_failure,
-        file_events: audit.file_events,
-        unique_files: audit.unique_files.len(),
-        network_hosts,
-        http_errors,
-        tool_calls,
-        resources,
-    })
 }
 
 fn build_session_top<'a>(
@@ -329,7 +273,7 @@ mod tests {
     use crate::model::AuditEventRow;
 
     #[test]
-    fn stat_tokens_ignore_touched_local_log_without_usage() {
+    fn session_tokens_ignore_touched_local_log_without_usage() {
         let (_temp, path) = agent_native_sessions::create_temp_session_path("claude");
         std::fs::write(
             &path,

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -49,7 +49,7 @@ use cli_db::{
 use cli_discover::run_discover;
 use cmd_debug::{run_raw_process, run_raw_ssl, run_raw_stdio, run_system};
 use cmd_exec::{default_session_db_path, print_session_summary, run_exec};
-use cmd_perf::{run_stat_query, run_top_query};
+use cmd_perf::run_top_query;
 use cmd_perf_live::run_live_top_query;
 use cmd_perf_tui::run_live_top_tui;
 use cmd_trace::{
@@ -173,9 +173,8 @@ async fn setup_signal_handler(suppress_terminal_output: bool) {
 #[command(
     author,
     version,
-    about = "AgentSight: stat/top/record/report for AI agent runs.\n\n\
+    about = "AgentSight: top/record/report for AI agent runs.\n\n\
              Common flow:\n\
-               sudo agentsight stat -- claude\n\
                sudo agentsight record -- claude\n\
                sudo agentsight top\n\
                agentsight report\n\
@@ -194,28 +193,6 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Print counters for a recorded session, or run a command and print counters when it exits.
-    /// Examples: agentsight stat --db run.db     (or)  sudo agentsight stat -- claude
-    Stat {
-        /// SQLite database path (defaults to latest session when no command is passed)
-        #[arg(long)]
-        db: Option<String>,
-        /// Emit JSON output. For clean JSON, use this with --db instead of a live command.
-        #[arg(long)]
-        json: bool,
-        /// Override the auto-discovered SSL binary path when tracing a command
-        #[arg(long)]
-        binary_path: Option<String>,
-        /// Disable the web server while tracing a command
-        #[arg(long)]
-        no_server: bool,
-        /// Server port for the web UI while tracing a command
-        #[arg(long, default_value = "7395")]
-        server_port: u16,
-        /// Optional command to launch and trace before printing counters
-        #[arg(last = true)]
-        command: Vec<String>,
-    },
     /// Show live agent sessions, or a saved session with --db.
     Top {
         /// SQLite database path for saved session mode
@@ -646,12 +623,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             }
             Some(ReportCommands::List) => run_db_list()?,
         },
-        Commands::Stat {
-            db, json, command, ..
-        } if command.is_empty() => {
-            let db = resolve_db_or_latest(db)?;
-            run_stat_query(&db, *json)?;
-        }
         Commands::Top {
             db: Some(db),
             pid,
@@ -706,37 +677,6 @@ async fn run_with_extractor(
     binary_extractor: &BinaryExtractor,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     match &cli.command {
-        Commands::Stat {
-            binary_path,
-            db,
-            json,
-            no_server,
-            server_port,
-            command,
-        } => {
-            if command.is_empty() {
-                unreachable!("stat without a command is handled before binary extraction");
-            }
-            if *json {
-                return Err("stat --json currently requires --db for clean JSON output".into());
-            }
-            let recorded_db = run_exec(
-                binary_extractor,
-                command,
-                binary_path.as_deref(),
-                configured_db_path(db),
-                !*no_server,
-                &cli.listen,
-                *server_port,
-                false,
-            )
-            .await
-            .map_err(convert_runner_error)?;
-            let db = recorded_db
-                .as_deref()
-                .ok_or("stat command did not produce a SQLite session database")?;
-            run_stat_query(db, false)?;
-        }
         Commands::Record {
             comm,
             pid,

--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -18,27 +18,6 @@ pub(crate) struct ResourcePeaks {
     pub(crate) samples: usize,
 }
 
-#[derive(Debug, Serialize)]
-pub(crate) struct StatOutput {
-    pub(crate) db: String,
-    pub(crate) duration_s: f64,
-    pub(crate) view_events: i64,
-    pub(crate) llm_calls: i64,
-    pub(crate) input_tokens: i64,
-    pub(crate) output_tokens: i64,
-    pub(crate) total_tokens: i64,
-    pub(crate) process_execs: usize,
-    pub(crate) process_exits: usize,
-    pub(crate) process_exit_success: usize,
-    pub(crate) process_exit_failure: usize,
-    pub(crate) file_events: usize,
-    pub(crate) unique_files: usize,
-    pub(crate) network_hosts: usize,
-    pub(crate) http_errors: usize,
-    pub(crate) tool_calls: i64,
-    pub(crate) resources: ResourcePeaks,
-}
-
 pub(crate) type TopSection = (&'static str, &'static str, Vec<(String, i64)>);
 
 pub(crate) fn sorted_top_counts<T>(counts: BTreeMap<String, T>, limit: usize) -> Vec<(String, T)>
@@ -566,40 +545,6 @@ pub(crate) fn print_llm_prompts(rows: &[LlmCallRow]) {
     }
 }
 
-pub(crate) fn print_stat(stat: &StatOutput) {
-    println!("AgentSight stat");
-    field("db", &stat.db);
-    field("elapsed time", format!("{:.3} s", stat.duration_s));
-    field("view events", stat.view_events);
-    field("LLM calls", stat.llm_calls);
-    field(
-        "tokens",
-        format!(
-            "{} total (in: {}, out: {})",
-            stat.total_tokens, stat.input_tokens, stat.output_tokens
-        ),
-    );
-    field("tool calls", stat.tool_calls);
-    field("process execs", stat.process_execs);
-    field(
-        "process exits",
-        format!(
-            "{} (success: {}, failure: {})",
-            stat.process_exits, stat.process_exit_success, stat.process_exit_failure
-        ),
-    );
-    field(
-        "file events",
-        format!("{} (unique files: {})", stat.file_events, stat.unique_files),
-    );
-    field("network hosts", stat.network_hosts);
-    field("HTTP/LLM errors", stat.http_errors);
-    if stat.resources.samples > 0 {
-        field("max CPU", format!("{:.2}%", stat.resources.max_cpu_percent));
-        field("max RSS", format!("{} MB", stat.resources.max_rss_mb));
-    }
-}
-
 pub(crate) fn print_agent_top(top: &AgentTopOutput<'_>) {
     let generated_at = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
     let db = top.db.map(|db| format!(" · {db}")).unwrap_or_default();
@@ -856,12 +801,8 @@ pub(crate) fn print_discovery(
                 dir.display()
             );
         }
-        println!("\n  Run `agentsight report` or `agentsight stat` to analyze the latest session.");
+        println!("\n  Run `agentsight report` to analyze the latest session.");
     }
-}
-
-fn field(label: &str, value: impl std::fmt::Display) {
-    println!("  {:<20}{value}", format!("{label}:"));
 }
 
 fn print_count_map(label: &str, counts: &BTreeMap<String, usize>) {

--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -464,9 +464,25 @@ pub(crate) fn print_record_shutdown() {
     println!("\n✓ Shutdown requested. Stopping target and monitoring.");
 }
 
-pub(crate) fn print_record_session_summary(summary: &SessionSummary) {
+pub(crate) fn print_record_session_summary(db_path: &str, summary: &SessionSummary) {
+    let api_calls: i64 = summary.models.iter().map(|m| m.4).sum();
+    let tokens: i64 = summary.models.iter().map(|m| m.3).sum();
+    let execs: usize = summary.processes.values().sum();
     println!();
-    print_session_summary(summary);
+    println!(
+        "Recorded {} to {}",
+        format_duration_compact(summary.duration_s),
+        db_path
+    );
+    println!(
+        "{} API calls · {} tokens · {} execs · {} files · {} network endpoints",
+        api_calls,
+        format_count(tokens),
+        execs,
+        summary.files.len(),
+        summary.endpoints.len()
+    );
+    println!("Run: agentsight report");
 }
 
 pub(crate) fn print_record_target_status_error(error: impl std::fmt::Display) {

--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -482,7 +482,7 @@ pub(crate) fn print_record_session_summary(db_path: &str, summary: &SessionSumma
         summary.files.len(),
         summary.endpoints.len()
     );
-    println!("Run: agentsight report");
+    println!("Run: agentsight report --db {}", shell_quote(db_path));
 }
 
 pub(crate) fn print_record_target_status_error(error: impl std::fmt::Display) {
@@ -835,6 +835,17 @@ fn print_count_map(label: &str, counts: &BTreeMap<String, usize>) {
         .collect::<Vec<_>>()
         .join(", ");
     println!("\n{total} {label}: {top}");
+}
+
+fn shell_quote(value: &str) -> String {
+    if value
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '/' | '.' | '-' | '_' | ':' | '+'))
+    {
+        value.to_string()
+    } else {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
 }
 
 fn print_process_exits(counts: &BTreeMap<String, usize>) {

--- a/collector/tests/export_snapshot_test.rs
+++ b/collector/tests/export_snapshot_test.rs
@@ -36,10 +36,9 @@ fn agentsight_stdout_with_env(args: &[&str], envs: &[(&str, &std::ffi::OsStr)]) 
 fn top_level_help_surfaces_perf_strace_flow() {
     let help = agentsight_stdout(&["--help"]);
     assert!(
-        help.contains("stat/top/record/report for AI agent runs"),
+        help.contains("top/record/report for AI agent runs"),
         "{help}"
     );
-    assert!(help.contains("stat"), "{help}");
     assert!(help.contains("top"), "{help}");
     assert!(help.contains("record"), "{help}");
     assert!(help.contains("report"), "{help}");

--- a/collector/tests/real_cli_smoke_test.rs
+++ b/collector/tests/real_cli_smoke_test.rs
@@ -92,21 +92,23 @@ fn gemini_token_total(db: &std::path::Path) -> i64 {
     .expect("token query should run")
 }
 
-fn stat_total_tokens(db: &std::path::Path) -> i64 {
+fn report_total_tokens(db: &std::path::Path) -> i64 {
     let db = db.to_str().expect("db path");
-    let output = run_agentsight_user(&["stat", "--db", db, "--json"]);
+    let output = run_agentsight_user(&["report", "token", "--db", db, "--json"]);
     assert!(
         output.status.success(),
-        "agentsight stat failed\nstdout:\n{}\nstderr:\n{}",
+        "agentsight report token failed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
     let value: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("stat JSON should parse");
+        serde_json::from_slice(&output.stdout).expect("token report JSON should parse");
     value
-        .get("total_tokens")
-        .and_then(|value| value.as_i64())
-        .unwrap_or_default()
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(|row| row.get("total_tokens").and_then(|value| value.as_i64()))
+        .sum()
 }
 
 fn report_text(db: &std::path::Path) -> String {
@@ -210,7 +212,7 @@ fn real_claude_code_smoke_captures_observed_tokens() {
         ]);
         assert_agentsight_success(output, "real Claude Code smoke");
 
-        last_session_total = stat_total_tokens(&db);
+        last_session_total = report_total_tokens(&db);
         if last_session_total > 0 {
             return;
         }
@@ -259,7 +261,7 @@ fn real_claude_code_tool_use_smoke_captures_tool_calls() {
         ]);
         assert_agentsight_success(output, "real Claude Code tool-use smoke");
 
-        last_session_total = stat_total_tokens(&db);
+        last_session_total = report_total_tokens(&db);
         last_report = report_text(&db);
         if last_session_total > 0 && last_report.contains("tool calls:") {
             return;
@@ -378,5 +380,5 @@ fn real_openclaw_provider_smoke_captures_http_tokens() {
 
     assert_agentsight_success(trigger, "trigger OpenClaw inference");
     assert!(trace_status.success(), "agentsight debug trace failed");
-    assert!(stat_total_tokens(&db) > 0);
+    assert!(report_total_tokens(&db) > 0);
 }

--- a/collector/tests/real_cli_smoke_test.rs
+++ b/collector/tests/real_cli_smoke_test.rs
@@ -103,10 +103,10 @@ fn report_total_tokens(db: &std::path::Path) -> i64 {
     );
     let value: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("token report JSON should parse");
-    value
+    let rows = value
         .as_array()
-        .into_iter()
-        .flatten()
+        .expect("token report JSON should be an array");
+    rows.iter()
         .filter_map(|row| row.get("total_tokens").and_then(|value| value.as_i64()))
         .sum()
 }

--- a/docs/design/session-centric-top.md
+++ b/docs/design/session-centric-top.md
@@ -142,7 +142,6 @@ saved session is present.
 SQLite is the durable evidence store used by:
 
 - `agentsight record`
-- `agentsight stat -- <command>` when it captures a run
 - `agentsight report`
 - explicit `--db`
 - exported dashboards and CI artifacts
@@ -177,8 +176,6 @@ Default local persistence should be bounded and predictable.
 Recommended policy:
 
 - `record`: durable SQLite by default.
-- `stat -- <command>`: may create a temporary or durable session only because it
-  needs post-run counters; this should be explicit in help text.
 - `report`: reads the latest local/native session or latest AgentSight DB; when
   it materializes a report artifact, that artifact is explicit.
 - `top`: should not create an unbounded durable DB just because it was opened.

--- a/docs/design/vis/ux.md
+++ b/docs/design/vis/ux.md
@@ -28,10 +28,9 @@ This document defines the desired command line and report experience. It complem
 
 Current CLI note: the user-facing entrypoint is `agentsight top` for live
 session monitoring. Use `agentsight record -- <command>` to save a run and
-`agentsight report` / `agentsight stat` to inspect saved runs. Low-level tracing
-is currently exposed as `agentsight debug trace`; top-level `script`, `trace`,
-and `export` commands below are future UX proposals unless explicitly marked as
-current.
+`agentsight report` to inspect saved runs. Low-level tracing is currently
+exposed as `agentsight debug trace`; top-level `script`, `trace`, and `export`
+commands below are future UX proposals unless explicitly marked as current.
 
 ## Product Positioning
 
@@ -39,7 +38,6 @@ AgentSight should borrow the interaction grammar of familiar systems tools:
 
 | Tool | User expectation | AgentSight equivalent |
 | --- | --- | --- |
-| `perf stat` | run a command, print counters | `agentsight stat -- <agent>` |
 | `perf top` / `top` | live ranked activity | `agentsight top` |
 | `perf record` | capture a session artifact | `agentsight record -- <agent>` |
 | `perf report` | inspect a saved artifact | `agentsight report` |
@@ -58,7 +56,7 @@ to decide whether an agent run was correct, safe, efficient, or explainable.
 
 | Scenario | User question | Best first answer | Evidence needed |
 | --- | --- | --- | --- |
-| Normal run receipt | What did the agent actually do? | `stat` + `report` summary | LLM calls, commands, files, network, exits |
+| Normal run receipt | What did the agent actually do? | `report` summary | LLM calls, commands, files, network, exits |
 | PR review | Can I trust this AI-generated diff? | blast radius section in `report` | read/write set, changed files, tests, high-risk paths |
 | File-level review | Why did this file change? | provenance chain for one path | prompt/tool/process/file event/diff hunk |
 | Debugging | Why did the agent fail or loop? | failed-command and repeated-work sections | tool calls, process exits, repeated reads/greps, tokens |
@@ -204,10 +202,9 @@ surface should answer a different class of questions:
 
 | Surface | Primary question | Secondary questions |
 | --- | --- | --- |
-| `stat` | How big was this run? | tokens, commands, files, network, failures, resource peaks |
 | `top` | What is active or dominant right now? | hot processes, risky paths, token-heavy model calls, unattributed activity |
 | `record` | What artifact did we capture? | DB path, capture health, attach target, replay commands |
-| `report` | What happened and why does it matter? | intent/effect chain, blast radius, side effects, warnings |
+| `report` | What happened and why does it matter? | counters, intent/effect chain, blast radius, side effects, warnings |
 | `script` | What is the ordered evidence stream? | exact time, PID, command, event kind, raw summary |
 | `trace` | What did this process family do in detail? | strace-like filtered process/file/network/LLM events |
 
@@ -229,8 +226,8 @@ Raw evidence pointers
 ## Implementation Boundary: Analyzer vs Renderer
 
 AgentSight currently has an `OutputAnalyzer`, but that is not the human-readable
-`stat`/`top`/`report` printer. It is a streaming analyzer that prints each event
-as raw JSON while the capture stream is being drained.
+`top`/`report` printer. It is a streaming analyzer that prints each event as raw
+JSON while the capture stream is being drained.
 
 The product output should use a separate query-time rendering layer:
 
@@ -242,7 +239,7 @@ runners
         -> MaterializingAnalyzer
           -> row sinks (SQLite / OTEL)
             -> query model
-              -> stat/top/report/script renderers
+              -> top/report/script renderers
 ```
 
 Responsibilities:
@@ -251,8 +248,8 @@ Responsibilities:
   running. It should not own terminal table layout or report wording.
 - Storage/projector: persist raw events and project canonical events, LLM calls,
   token usage, audit events, sessions, and adapter results.
-- Query model: aggregate saved data into `StatOutput`, `AgentTopSnapshot`,
-  `AgentSection`, `ActivityRow`, `ReportModel`, and similar typed structures.
+- Query model: aggregate saved data into `AgentTopSnapshot`, `AgentSection`,
+  `ActivityRow`, `ReportModel`, and similar typed structures.
 - Renderer: print text, JSON, Markdown, or other formats from those typed query
   models.
 
@@ -262,7 +259,6 @@ logic should move toward a dedicated module such as:
 ```text
 collector/src/cli_print/
   mod.rs
-  stat.rs
   top.rs
   report.rs
   script.rs
@@ -281,7 +277,6 @@ raw event stream printer used for debug/live event output.
 Current top-level command set:
 
 ```bash
-agentsight stat    [options] [-- command ...]
 agentsight top     [options]
 agentsight record  [options] [-- command ...]
 agentsight report  [options]
@@ -301,45 +296,12 @@ agentsight trace   [options]
 agentsight export  [options]
 ```
 
-### `agentsight stat`
+### Run Counters
 
-Like `perf stat`: run a command or read a saved run and print counters.
-
-Examples:
-
-```bash
-agentsight stat -- claude "fix the failing API test"
-agentsight stat --db run.db
-agentsight stat --json --db run.db
-agentsight stat --repeat 5 -- claude -p "summarize this repo"
-```
-
-Default output should be quiet and counter-focused:
-
-```text
-AgentSight stat for: claude "fix the failing API test"
-
-  13.241 s      elapsed time
-       1        LLM calls
-   1,380        tokens total              # 1,200 in, 180 out
-       4        process execs
-       4        process exits             # 2 success, 2 failure
-       3        files touched             # 2 writes, 1 lockfile update
-       2        network hosts             # api.anthropic.com, registry.npmjs.org
-       1        failed commands
-   42.8 MB      max RSS
-    6.2 %       max CPU
-
-  run db: ~/.local/share/agentsight/sessions/20260602-113015.db
-```
-
-Rules:
-
-- `stat -- <command>` should suppress setup chatter by default.
-- Use `--verbose` to show attach/probe details.
-- Do not start a server by default for `stat`.
-- JSON output should be clean JSON. If a command is run, setup logs go to
-  stderr or require `--json --db`.
+The old top-level counter surface has been removed. Counter-focused views now
+live under `agentsight report`: the default report prints a concise run summary,
+while structured counters are available through focused report queries such as
+`agentsight report token --json`.
 
 ### `agentsight top`
 
@@ -449,7 +411,6 @@ At exit:
 Recorded 13.2s to ~/.local/share/agentsight/sessions/20260602-113015.db
 Run:
   agentsight report --db ...
-  agentsight stat --db ...
 ```
 
 ### `agentsight report`
@@ -661,7 +622,6 @@ Capture health
 
 This belongs in:
 
-- `stat`
 - `report`
 - exported reports
 
@@ -673,7 +633,6 @@ Empty states should be action-oriented:
 No run loaded.
 
 Start a run:
-  agentsight stat -- claude
   agentsight record -- claude
 
 Or open an existing run:
@@ -741,7 +700,7 @@ The same filter grammar should work in:
 
 ### P0: Make the Core Claim Visible
 
-1. Run receipt in `stat` and `report`.
+1. Run receipt in `report`.
 2. Intent -> effect chain in `report`.
 3. Side effects and blast radius sections in `report`.
 4. Capture health block.
@@ -768,7 +727,7 @@ The same filter grammar should work in:
 The next release is good enough when a user can run:
 
 ```bash
-agentsight stat -- claude "fix the failing API test"
+agentsight record -- claude "fix the failing API test"
 agentsight report
 agentsight script --summary
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,7 +71,7 @@ sudo ./collector/target/release/agentsight debug ssl --http-parser
 Use `top` for the normal live view. Use `record` when you want a durable
 agent-run artifact; it starts SSL, process, system, and web-view collection with
 AgentSight's default filters, and saves a local SQLite session for `report`,
-`top --db`, `prompts`, and other report queries.
+`top --db`, `report prompts`, and other report queries.
 
 Use `debug trace` only when you need low-level control over capture sources or
 filters. It is the advanced replacement for a raw trace command, not the normal

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -57,7 +57,6 @@ sudo ./collector/target/release/agentsight record -- claude
 
 # Inspect the latest saved run
 ./collector/target/release/agentsight report
-./collector/target/release/agentsight stat
 
 # Attach to an already-running process family
 sudo ./collector/target/release/agentsight record -c claude
@@ -72,7 +71,7 @@ sudo ./collector/target/release/agentsight debug ssl --http-parser
 Use `top` for the normal live view. Use `record` when you want a durable
 agent-run artifact; it starts SSL, process, system, and web-view collection with
 AgentSight's default filters, and saves a local SQLite session for `report`,
-`stat`, `top --db`, `prompts`, and `db` queries.
+`top --db`, `prompts`, and other report queries.
 
 Use `debug trace` only when you need low-level control over capture sources or
 filters. It is the advanced replacement for a raw trace command, not the normal

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -57,7 +57,6 @@ sudo ./collector/target/release/agentsight record -- claude
 
 # 查看最近保存的运行
 ./collector/target/release/agentsight report
-./collector/target/release/agentsight stat
 
 # 附加到已经运行的进程族
 sudo ./collector/target/release/agentsight record -c claude


### PR DESCRIPTION
## Summary

- Remove the top-level `agentsight stat` command and its dedicated stat output model.
- Keep saved-run counters available through `agentsight report`, especially `report token --json` for structured token queries.
- Replace the verbose `record` exit summary with a compact receipt that prints the DB path and headline counters.
- Update README, usage docs, design notes, and tests so the user-facing command model is `top`, `record`, and `report`.

## Validation

- `cargo fmt --manifest-path collector/Cargo.toml`
- `cargo check --manifest-path collector/Cargo.toml`
- `cargo test --manifest-path collector/Cargo.toml`
- `collector/target/debug/agentsight --help`
- `collector/target/debug/agentsight stat --help` now reports `unrecognized subcommand 'stat'` as expected.

## Notes

The PR diff is net negative overall: 59 insertions and 264 deletions. The local development worktree still has unrelated existing changes under `docs/visexp`, frontend build output, and generated vendor frontend files; those are not included in this PR.