### PR TITLE
Fix monitor detection for live Codex exec sessions

### DIFF
--- a/collector/src/cmd_monitor.rs
+++ b/collector/src/cmd_monitor.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 const MONITOR_INTERVAL_SECS: u64 = 2;
+const MONITOR_TOP_STALE_AFTER_SECS: u64 = MONITOR_INTERVAL_SECS * 5;
 const SESSION_SCAN_LIMIT: usize = 25;
 
 #[derive(Debug, Clone)]
@@ -207,6 +208,7 @@ fn load_monitor_top_rows(
 ) -> rusqlite::Result<Vec<AgentTopRow>> {
     let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
     let now_ms = now_epoch_ms();
+    let min_window_end_ms = now_ms.saturating_sub(MONITOR_TOP_STALE_AFTER_SECS * 1000);
     let mut stmt = conn.prepare(
         "SELECT
             t.session_id, t.display_id, t.agent_type, t.root_pid, t.first_seen_ms,
@@ -219,9 +221,10 @@ fn load_monitor_top_rows(
             FROM monitor_windows
             GROUP BY session_id, root_pid, root_starttime_ticks
          )
+         AND w.window_end_ms >= ?1
          ORDER BY w.window_end_ms DESC",
     )?;
-    let rows = stmt.query_map([], |row| {
+    let rows = stmt.query_map(params![min_window_end_ms as i64], |row| {
         let session_id: String = row.get(0)?;
         let display_id: String = row.get(1)?;
         let agent_type: String = row.get(2)?;
@@ -683,9 +686,10 @@ mod tests {
     fn monitor_store_persists_session_window() {
         let temp = tempfile::tempdir().unwrap();
         let mut store = MonitorStore::open_path(temp.path().join("monitor.db")).unwrap();
+        let now = now_epoch_ms();
         let sample = MonitorSample {
-            window_start_ms: 10,
-            window_end_ms: 20,
+            window_start_ms: now.saturating_sub(2_000),
+            window_end_ms: now,
             sessions: vec![MonitorSessionSample {
                 session_id: "local:codex:test".to_string(),
                 display_id: "codex:test".to_string(),
@@ -734,6 +738,50 @@ mod tests {
         assert_eq!((windows, file_targets), (1, 2));
         assert_eq!(top.rows.len(), 1);
         assert_eq!(top.rows[0].files, 2);
+    }
+
+    #[test]
+    fn monitor_top_ignores_stale_windows() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut store = MonitorStore::open_path(temp.path().join("monitor.db")).unwrap();
+        let now = now_epoch_ms();
+        let sample = MonitorSample {
+            window_start_ms: now.saturating_sub(60_000),
+            window_end_ms: now.saturating_sub(55_000),
+            sessions: vec![MonitorSessionSample {
+                session_id: "live:codex:42:100".to_string(),
+                display_id: "codex:exec:42".to_string(),
+                agent_type: "codex".to_string(),
+                root_pid: 42,
+                root_starttime_ticks: 100,
+                match_evidence: "process_exec".to_string(),
+                match_confidence: 0.5,
+                session_path: None,
+                command: "codex exec test".to_string(),
+                cwd: Some("/tmp".to_string()),
+                process_count: 1,
+                cpu_ms: 0,
+                rss_bytes: 4096,
+                read_bytes: 0,
+                write_bytes: 0,
+                file_targets: 0,
+            }],
+        };
+        store.insert_sample(&sample).unwrap();
+
+        let top = build_monitor_top(
+            store.path(),
+            10,
+            &TopOptions {
+                pid: None,
+                comm: None,
+                sort: "cpu".to_string(),
+                view: "all".to_string(),
+            },
+        )
+        .unwrap();
+
+        assert!(top.rows.is_empty());
     }
 
     #[test]

--- a/collector/src/view/live_top.rs
+++ b/collector/src/view/live_top.rs
@@ -15,6 +15,8 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+const TRACE_PROCESS_EXEC: &str = "process_exec";
+
 #[derive(Debug, Clone)]
 pub(crate) struct LiveCaptureSnapshot {
     snapshot: Snapshot,
@@ -167,6 +169,11 @@ impl LiveView {
                 family,
             });
         }
+        sessions.extend(live_codex_exec_monitor_sessions(
+            &sample,
+            &children,
+            &matches.by_pid,
+        ));
 
         let at_ms = now_ms();
         self.previous = Some(sample.clone());
@@ -588,6 +595,100 @@ fn session_process_trace(matched: &SessionProcessMatch, session_id: &str) -> Str
     format!("agent-native+proc+{}", matched.evidence)
 }
 
+fn live_codex_exec_monitor_sessions(
+    sample: &LiveSample,
+    children: &HashMap<u32, Vec<u32>>,
+    matched_pids: &HashMap<u32, String>,
+) -> Vec<LiveMonitorSession> {
+    sample
+        .procs
+        .values()
+        .filter(|proc_info| !matched_pids.contains_key(&proc_info.pid))
+        .filter(|proc_info| is_topmost_codex_exec_process(proc_info, sample))
+        .filter_map(|proc_info| live_codex_exec_monitor_session(proc_info, sample, children))
+        .collect()
+}
+
+fn live_codex_exec_monitor_session(
+    proc_info: &procfs::ProcInfo,
+    sample: &LiveSample,
+    children: &HashMap<u32, Vec<u32>>,
+) -> Option<LiveMonitorSession> {
+    let prompt = agent_session::codex_exec_prompt(&proc_info.command)?;
+    let root_pid = proc_info.pid;
+    let family = procfs::process_family(root_pid, children, &sample.procs);
+    if family.is_empty() {
+        return None;
+    }
+
+    let cwd = proc_info
+        .cwd
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
+
+    Some(LiveMonitorSession {
+        session_id: format!("live:codex:{}:{}", root_pid, proc_info.starttime_ticks),
+        agent_type: agent_session::AGENT_CODEX.to_string(),
+        display_id: format!("codex:exec:{root_pid}"),
+        session_path: None,
+        root_pid,
+        root_starttime_ticks: proc_info.starttime_ticks,
+        evidence: TRACE_PROCESS_EXEC,
+        confidence: 0.50,
+        command: format!("codex exec {prompt}"),
+        cwd,
+        family,
+    })
+}
+
+fn is_topmost_codex_exec_process(proc_info: &procfs::ProcInfo, sample: &LiveSample) -> bool {
+    if process_select::known_agent_label(&proc_info.comm, &proc_info.command)
+        != Some(agent_session::AGENT_CODEX)
+        || !has_codex_exec_subcommand(&proc_info.command)
+    {
+        return false;
+    }
+
+    let mut parent_pid = proc_info.ppid;
+    for _ in 0..128 {
+        if parent_pid == 0 {
+            break;
+        }
+        let Some(parent) = sample.procs.get(&parent_pid) else {
+            break;
+        };
+        if process_select::known_agent_label(&parent.comm, &parent.command)
+            == Some(agent_session::AGENT_CODEX)
+            && has_codex_exec_subcommand(&parent.command)
+        {
+            return false;
+        }
+        parent_pid = parent.ppid;
+    }
+    true
+}
+
+fn has_codex_exec_subcommand(command: &str) -> bool {
+    command
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .windows(2)
+        .any(|pair| is_codex_executable_token(pair[0]) && pair[1] == "exec")
+}
+
+fn is_codex_executable_token(token: &str) -> bool {
+    let token = token.trim_matches(|ch| matches!(ch, '"' | '\''));
+    if token.is_empty() {
+        return false;
+    }
+    let lower = token.to_ascii_lowercase();
+    let basename = Path::new(&lower)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(lower.as_str());
+    matches!(basename, "codex" | "codex-cli")
+}
+
 fn live_process_rows(
     sample: &LiveSample,
     previous: Option<&LiveSample>,
@@ -743,6 +844,74 @@ mod tests {
         assert_eq!(top.rows[0].session, "claude:cwd");
         assert_eq!(top.rows[0].pid, Some(42));
         assert_eq!(top.rows[0].trace, "agent-native+proc+cwd_recent");
+    }
+
+    #[test]
+    fn live_codex_exec_monitor_session_uses_process_fallback() {
+        let sample = LiveSample {
+            procs: BTreeMap::from([
+                (
+                    42,
+                    ProcInfo {
+                        pid: 42,
+                        comm: "node".to_string(),
+                        command: "node /opt/@openai/codex/bin/codex exec -C /work -s read-only AGENTSIGHT_DYNAMIC_CODEX_OK".to_string(),
+                        cwd: Some(PathBuf::from("/work")),
+                        starttime_ticks: 100,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    43,
+                    ProcInfo {
+                        pid: 43,
+                        ppid: 42,
+                        comm: "codex".to_string(),
+                        command: "/opt/@openai/codex-linux-x64/bin/codex exec -C /work -s read-only AGENTSIGHT_DYNAMIC_CODEX_OK".to_string(),
+                        cwd: Some(PathBuf::from("/work")),
+                        starttime_ticks: 101,
+                        ..Default::default()
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+        let children = sample.children_by_ppid();
+        let sessions = live_codex_exec_monitor_sessions(&sample, &children, &HashMap::new());
+
+        assert_eq!(sessions.len(), 1);
+        let session = &sessions[0];
+        assert_eq!(session.session_id, "live:codex:42:100");
+        assert_eq!(session.display_id, "codex:exec:42");
+        assert_eq!(session.evidence, TRACE_PROCESS_EXEC);
+        assert_eq!(session.command, "codex exec AGENTSIGHT_DYNAMIC_CODEX_OK");
+        assert_eq!(session.cwd.as_deref(), Some("/work"));
+        assert_eq!(session.family, vec![42, 43]);
+
+        let matched = HashMap::from([(42, "local:codex:test".to_string())]);
+        assert!(live_codex_exec_monitor_sessions(&sample, &children, &matched).is_empty());
+    }
+
+    #[test]
+    fn live_codex_exec_monitor_session_ignores_non_exec_subcommands() {
+        let sample = LiveSample {
+            procs: BTreeMap::from([(
+                42,
+                ProcInfo {
+                    pid: 42,
+                    comm: "node".to_string(),
+                    command: "node /opt/@openai/codex/bin/codex app-server prompt says exec later"
+                        .to_string(),
+                    cwd: Some(PathBuf::from("/work")),
+                    starttime_ticks: 100,
+                    ..Default::default()
+                },
+            )]),
+            ..Default::default()
+        };
+        let children = sample.children_by_ppid();
+
+        assert!(live_codex_exec_monitor_sessions(&sample, &children, &HashMap::new()).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add a monitor-only fallback for topmost `codex exec` processes when no local session-file/process match exists yet.
- Keep the fallback conservative: require a real `codex exec` argv shape, skip pids already attributed by the session matcher, and avoid wrapper/child double-counting.
- Make monitor-backed `top` show only recent monitor windows so short-lived process fallback rows do not linger as fake live sessions.

## Root cause

`monitor` only persisted sessions that could be matched through local agent session files and the live top candidate set. Fresh `codex exec` processes can be visible in `/proc` before that path has a stable local session match, so the background monitor can miss the process tree.

## Correctness notes

The fallback is intentionally weaker than session-file/fd evidence and is only used after stronger matching leaves a pid unattributed. It records a synthetic session keyed by pid/starttime, and `top` now filters stale monitor windows; long-term history remains in the monitor database for report-style views.

## Validation

- `cargo test --manifest-path collector/Cargo.toml live_codex_exec_monitor_session`
- `cargo test --manifest-path collector/Cargo.toml monitor_`
- `cargo test --manifest-path collector/Cargo.toml`
- Manual dynamic check with temporary monitor: ran `codex exec ... sleep 20`; current build captured the live run through the stronger session-file path, and after the process exited the monitor-backed `top` dropped the row after the stale window.