### PR TITLE
Fix nested Codex exec attribution

### DIFF
--- a/collector/src/sources/proc.rs
+++ b/collector/src/sources/proc.rs
@@ -102,22 +102,6 @@ impl ProcSnapshot {
         process_family(root, &self.children_by_ppid(), &self.procs)
     }
 
-    pub(crate) fn process_tree(
-        &self,
-        root: u32,
-        children: &HashMap<u32, Vec<u32>>,
-    ) -> Option<ProcessTree> {
-        let root_key = self.procs.get(&root)?.process_key();
-        let members = process_family(root, children, &self.procs)
-            .into_iter()
-            .filter_map(|pid| self.procs.get(&pid).map(ProcInfo::process_key))
-            .collect();
-        Some(ProcessTree {
-            root: root_key,
-            members,
-        })
-    }
-
     pub(crate) fn seeds_for_all(&self) -> Vec<PidSeed> {
         self.procs.values().map(ProcInfo::seed).collect()
     }
@@ -185,6 +169,15 @@ pub(crate) fn process_family(
     children: &HashMap<u32, Vec<u32>>,
     procs: &BTreeMap<u32, ProcInfo>,
 ) -> Vec<u32> {
+    process_family_excluding(root, children, procs, &HashSet::new())
+}
+
+pub(crate) fn process_family_excluding(
+    root: u32,
+    children: &HashMap<u32, Vec<u32>>,
+    procs: &BTreeMap<u32, ProcInfo>,
+    excluded_roots: &HashSet<u32>,
+) -> Vec<u32> {
     let mut out = Vec::new();
     let mut stack = vec![root];
     let mut seen = HashSet::new();
@@ -194,7 +187,12 @@ pub(crate) fn process_family(
         }
         out.push(pid);
         if let Some(child_pids) = children.get(&pid) {
-            stack.extend(child_pids.iter().copied());
+            stack.extend(
+                child_pids
+                    .iter()
+                    .copied()
+                    .filter(|child_pid| !excluded_roots.contains(child_pid)),
+            );
         }
     }
     out

--- a/collector/src/view/live_top.rs
+++ b/collector/src/view/live_top.rs
@@ -139,7 +139,12 @@ impl LiveView {
             let Some(matched) = matches.by_session_id.get(&session.id) else {
                 continue;
             };
-            let family = procfs::process_family(matched.root_pid, &children, &sample.procs);
+            let family = matched
+                .matched_pids
+                .iter()
+                .copied()
+                .filter(|pid| sample.procs.contains_key(pid))
+                .collect::<Vec<_>>();
             if family.is_empty() {
                 continue;
             }
@@ -565,13 +570,22 @@ fn live_process_candidates(
     live_rows: &[AgentTopRow],
     children: &HashMap<u32, Vec<u32>>,
 ) -> Vec<LiveProcessCandidate> {
+    let roots = live_rows
+        .iter()
+        .filter_map(|row| row.pid)
+        .collect::<HashSet<_>>();
     live_rows
         .iter()
         .filter_map(|row| {
             let root_pid = row.pid?;
-            let tree = sample.process_tree(root_pid, children)?;
+            let root = sample.procs.get(&root_pid)?.process_key();
+            let members =
+                procfs::process_family_excluding(root_pid, children, &sample.procs, &roots)
+                    .into_iter()
+                    .filter_map(|pid| sample.procs.get(&pid).map(procfs::ProcInfo::process_key))
+                    .collect();
             Some(LiveProcessCandidate {
-                tree,
+                tree: procfs::ProcessTree { root, members },
                 agent: row.agent.clone(),
                 age_s: row.age_s,
                 cwd: row.workspace.clone(),
@@ -595,10 +609,11 @@ fn live_process_rows(
     children: &HashMap<u32, Vec<u32>>,
 ) -> Vec<AgentTopRow> {
     let roots = process_select::live_root_pids(sample, options.pid, options.comm.as_deref());
+    let root_set = roots.iter().copied().collect::<HashSet<_>>();
     let mut rows = Vec::new();
 
     for root_pid in roots {
-        let family = procfs::process_family(root_pid, children, &sample.procs);
+        let family = procfs::process_family_excluding(root_pid, children, &sample.procs, &root_set);
         if family.is_empty() {
             continue;
         }
@@ -743,6 +758,79 @@ mod tests {
         assert_eq!(top.rows[0].session, "claude:cwd");
         assert_eq!(top.rows[0].pid, Some(42));
         assert_eq!(top.rows[0].trace, "agent-native+proc+cwd_recent");
+    }
+
+    #[test]
+    fn live_process_rows_split_nested_codex_exec_from_app_server() {
+        let options = TopOptions {
+            pid: None,
+            comm: None,
+            sort: "cpu".to_string(),
+            view: "all".to_string(),
+        };
+        let sample = LiveSample {
+            procs: BTreeMap::from([
+                (
+                    1,
+                    ProcInfo {
+                        pid: 1,
+                        comm: "node".to_string(),
+                        command: "node /opt/node/bin/codex app-server --listen sock".to_string(),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    2,
+                    ProcInfo {
+                        pid: 2,
+                        ppid: 1,
+                        comm: "node".to_string(),
+                        command: "node /opt/node/bin/codex exec -C /work hello".to_string(),
+                        cwd: Some(PathBuf::from("/work")),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    3,
+                    ProcInfo {
+                        pid: 3,
+                        ppid: 2,
+                        comm: "codex".to_string(),
+                        command: "/opt/node_modules/@openai/codex-linux-x64/bin/codex exec -C /work hello".to_string(),
+                        cwd: Some(PathBuf::from("/work")),
+                        ..Default::default()
+                    },
+                ),
+            ]),
+            ..Default::default()
+        };
+        let children = sample.children_by_ppid();
+        let rows = live_process_rows(&sample, None, &options, &children);
+        let candidates = live_process_candidates(&sample, &rows, &children);
+
+        assert_eq!(
+            rows.iter()
+                .filter_map(|row| row.pid.map(|pid| (pid, row.processes)))
+                .collect::<Vec<_>>(),
+            vec![(1, 1), (2, 2)]
+        );
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|candidate| {
+                    (
+                        candidate.tree.root.pid,
+                        candidate
+                            .tree
+                            .members
+                            .iter()
+                            .map(|key| key.pid)
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .collect::<Vec<_>>(),
+            vec![(1, vec![1]), (2, vec![2, 3])]
+        );
     }
 
     #[test]

--- a/collector/src/view/process_select.rs
+++ b/collector/src/view/process_select.rs
@@ -88,8 +88,10 @@ fn root_pids_for_known_agents(snapshot: &ProcSnapshot) -> Vec<u32> {
         let Some(label) = known_agent_label(&proc_info.comm, &proc_info.command) else {
             continue;
         };
+        let nested_codex_exec = label == "codex" && is_codex_exec_invocation(proc_info);
         if has_matching_ancestor(snapshot, proc_info, |parent| {
             known_agent_label(&parent.comm, &parent.command) == Some(label)
+                && (!nested_codex_exec || is_codex_exec_invocation(parent))
         }) {
             continue;
         }
@@ -241,6 +243,35 @@ fn label_from_known_package_path(path: &str) -> Option<&'static str> {
     }
 }
 
+pub(crate) fn is_codex_exec_invocation(proc_info: &ProcInfo) -> bool {
+    known_agent_label(&proc_info.comm, &proc_info.command) == Some("codex")
+        && has_codex_exec_subcommand(&proc_info.command)
+}
+
+fn has_codex_exec_subcommand(command: &str) -> bool {
+    let mut previous = "";
+    for token in command.split_whitespace() {
+        if is_codex_executable_token(previous) && token == "exec" {
+            return true;
+        }
+        previous = token;
+    }
+    false
+}
+
+fn is_codex_executable_token(token: &str) -> bool {
+    let token = token.trim_matches(|ch| matches!(ch, '"' | '\''));
+    if token.is_empty() {
+        return false;
+    }
+    let lower = token.to_ascii_lowercase();
+    let basename = Path::new(&lower)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(lower.as_str());
+    matches!(basename, "codex" | "codex-cli")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -334,6 +365,42 @@ mod tests {
         };
 
         assert_eq!(live_root_pids(&snapshot, None, None), vec![1, 3]);
+    }
+
+    #[test]
+    fn live_roots_keep_nested_codex_exec_under_app_server() {
+        let procs = [
+            ProcInfo {
+                pid: 1,
+                comm: "node".to_string(),
+                command: "node /opt/node/bin/codex app-server --listen sock".to_string(),
+                ..Default::default()
+            },
+            ProcInfo {
+                pid: 2,
+                ppid: 1,
+                comm: "node".to_string(),
+                command: "node /opt/node/bin/codex exec -C /work hello".to_string(),
+                ..Default::default()
+            },
+            ProcInfo {
+                pid: 3,
+                ppid: 2,
+                comm: "codex".to_string(),
+                command: "/opt/node_modules/@openai/codex-linux-x64/bin/codex exec -C /work hello"
+                    .to_string(),
+                ..Default::default()
+            },
+        ];
+        let snapshot = ProcSnapshot {
+            procs: procs
+                .into_iter()
+                .map(|proc_info| (proc_info.pid, proc_info))
+                .collect(),
+            ..Default::default()
+        };
+
+        assert_eq!(live_root_pids(&snapshot, None, None), vec![1, 2]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Treat nested `codex exec` processes under the Codex Desktop app-server as their own live attribution roots.
- Split live process families at nested root boundaries so the parent app-server row no longer double-counts the child invocation subtree.
- Reuse the same partitioned process tree for session matching and monitor samples, so local Codex session files bind to the exec wrapper pid instead of the app-server pid.

## Root cause

The live root selector suppressed any known-agent process if an ancestor had the same agent label. In Codex Desktop, tool-launched `codex exec` runs under the app-server tree, so the exec wrapper was suppressed and the app-server candidate consumed the whole descendant family. That made the UI and monitor DB attribute the child invocation to the parent app-server.

## Validation

- `cargo test --manifest-path collector/Cargo.toml`
- `cargo clippy --manifest-path collector/Cargo.toml -- -D warnings`
- Manual dynamic check: ran this branch's temporary monitor and a nested `codex exec ... sleep 20`; monitor DB recorded the unique marker session with root pid `1195587`, the `codex exec` wrapper pid, not the app-server pid.
