### PR TITLE
[codex] Add agent behavior analysis skills

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -22,3 +22,8 @@ Current architecture notes:
 - [Materialized View Architecture](materialized-view-architecture.md)
 - [View, Session, And Process Model](view-session-process-model.md)
 - [AgentSight Top as a Session Monitor](session-centric-top.md)
+
+Product and workflow proposals:
+
+- [Agent Behavior Analysis Skills](agent-behavior-analysis-skills.md)
+- [Skill-Generated Example Dashboards](../skills/examples/README.md)

--- a/docs/design/agent-behavior-analysis-skills.md
+++ b/docs/design/agent-behavior-analysis-skills.md
@@ -1,0 +1,186 @@
+# Agent Behavior Analysis Skills 设计
+
+日期：2026-06-20（America/Vancouver）。本文是产品/设计草案，不是当前 CLI 行为说明。当前用户文档仍以 [README](../../README.md)、[Usage](../usage.md)、[OpenTelemetry GenAI Export](../otel.md) 和 [agent-session](../agent-session.md) 为准。
+
+## 结论
+
+第一版不拆成 `inventory -> friction -> artifact` 三个 pipeline skills，也不做一个什么都读的大 skill。更合理的是按 **证据边界** 拆成两个：
+
+```text
+agent-interaction-insights
+  读对话、session logs、LLM traces
+  分析用户交互、目标漂移、loop、summary trust、validation claim
+
+agentsight-system-friction
+  读 AgentSight/system evidence
+  分析进程、命令、文件、网络、资源、side effects、cleanup
+```
+
+核心原则：两个 skill 可以协作，但不要都去读 raw conversation。`agent-interaction-insights` 负责语义和用户交互；`agentsight-system-friction` 负责机器上真实发生了什么，并输出 join keys 供后续关联。
+
+如果 AgentSight export 或 SQLite 里带有 LLM prompt/response payload，`agentsight-system-friction` 也不读取这些 payload；它只使用 system rows、metadata、ids、timestamps、statuses、token counts 和 join keys。
+
+## 为什么不是一个 Skill
+
+一个大 skill 的体验很顺，但边界会糊：
+
+- 它既读对话又读系统 DB，容易过度收集隐私数据。
+- 它会同时承担语义判断和系统取证，scope 太大。
+- AgentSight 的独特价值会被压成“另一个数据源”，而不是系统边界事实层。
+- 两类 evidence 的隐私规则不同：raw prompt/response 和 raw path/host/header 的风险不同。
+
+所以，一个 skill 产品心智简单，但工程和隐私边界不够清楚。
+
+## 为什么不是三个 Pipeline Skills
+
+三层架构仍然成立：
+
+```text
+facts -> diagnosis -> expression
+```
+
+但这不应该成为三个用户入口。用户不会说“先 inventory，再 friction，再 artifact”。用户会说：
+
+```text
+看看最近 agent 哪里不对，生成个报告。
+```
+
+因此不要按 pipeline 阶段拆 skill。`inventory` 和 `artifact` 应该是每个 skill 内部的工作方式和输出形态，而不是用户必须理解的独立入口。
+
+## 两个 Skill 的边界
+
+### `agent-interaction-insights`
+
+输入：
+
+- Claude Code / Codex / Gemini CLI 本地日志
+- OpenTelemetry GenAI spans
+- LangSmith / Langfuse traces
+- Datadog MCP query results
+- plain transcripts
+- 已经摘要过的 AgentSight system findings（可选）
+
+不直接读取：
+
+- AgentSight record DB
+- AgentSight monitor DB
+- raw system snapshots
+
+输出：
+
+- session / model / tool / token / cost usage
+- interaction loops and retries
+- user corrections and interruptions
+- final summary vs visible validation
+- AGENTS.md / CLAUDE.md / tooling improvement suggestions
+- Markdown / PR comment / team brief / HTML artifact
+
+### `agentsight-system-friction`
+
+输入：
+
+- AgentSight report exports
+- saved SQLite sessions
+- monitor DBs under `~/.agentsight/monitor`
+- process tree, command, file, network, resource rows
+- session/process/timestamp join keys
+- 已经摘要过的 interaction findings（可选）
+
+不直接读取：
+
+- raw Claude/Codex/Gemini transcripts
+- raw prompt/response history
+
+输出：
+
+- long-running processes
+- failed/repeated commands
+- file scope risks
+- network scope risks
+- CPU/RSS/IO/time waste
+- capture gaps and correlation gaps
+- cleanup actions
+- system-level Markdown / incident brief / HTML artifact
+
+## 与 Claude `/insights` 的关系
+
+Claude Code `/insights` 更像 Claude Code 自己的 session 复盘入口。它分析 Claude Code sessions，生成 project areas、interaction patterns、friction points 一类报告。
+
+这两个 skills 借鉴 `/insights` 的“判断报告”体验，但做出差异：
+
+- `agent-interaction-insights` 是跨 agent、跨 trace backend 的交互分析，不绑定 Claude Code。
+- `agentsight-system-friction` 是 AgentSight 的系统证据分析，不读 raw conversation。
+- 两者都强调 observed fact、inference、missing evidence。
+- Dashboard-like output 是按问题生成的结果，不是预先定义的产品页面。
+
+## 目录结构
+
+```text
+skills/
+  README.md
+  agent-interaction-insights/
+    SKILL.md
+    agents/openai.yaml
+    references/
+      data-source-routing.md
+      common-evidence-model.md
+      friction-taxonomy.md
+      report-shapes.md
+      privacy-modes.md
+      example-patterns.md
+  agentsight-system-friction/
+    SKILL.md
+    agents/openai.yaml
+    references/
+      agentsight-sources.md
+      system-evidence-model.md
+      system-friction-taxonomy.md
+      report-shapes.md
+      privacy-modes.md
+      example-patterns.md
+```
+
+第一版不放 scripts。只有当 adapter 逻辑重复出现、需要 deterministic behavior，才考虑加入：
+
+```text
+scripts/export-claude-usage-data.py
+scripts/export-agentsight-snapshot.py
+scripts/otel-genai-to-evidence.py
+```
+
+HTML renderer 暂时不做成脚本，因为 artifact 形态变化快，交给 agent 按问题生成更合适。
+
+## 典型组合方式
+
+交互问题：
+
+```text
+Use agent-interaction-insights on my last 20 Claude/Codex sessions. Which interaction patterns wasted time?
+```
+
+系统问题：
+
+```text
+Use agentsight-system-friction on this monitor DB. Which sessions left processes running or touched unexpected paths?
+```
+
+组合问题：
+
+```text
+Use agentsight-system-friction to summarize system findings, then use agent-interaction-insights to compare them with the agent's final summary.
+```
+
+这里第二步消费的是 system findings summary，不是让两个 skills 都打开 raw conversation 和 raw system DB。
+
+跨 skill 的最小 handoff 是 `SystemFinding`：`source_skill`、`finding_id`、`severity`、`claim`、`evidence_summary`、`join_keys`、`privacy_mode`、`raw_data_included: false`。这样 interaction skill 可以用 system finding 做语义关联，而不需要重新打开 AgentSight DB。
+
+## 验证标准
+
+- 普通 transcript / Langfuse / LangSmith 请求触发 `agent-interaction-insights`。
+- AgentSight DB / monitor / process-file-network-resource 请求触发 `agentsight-system-friction`。
+- 两个 skills 都能输出 Markdown 或 HTML artifact，但 artifact 只是一种输出形态。
+- AgentSight skill 不读取 raw transcripts。
+- Interaction skill 不读取 raw AgentSight DB。
+- 重要 finding 有 evidence、inference 和 next action。
+- 缺失证据不被写成行为不存在。
+- 隐私模式明确。

--- a/docs/design/market/README.md
+++ b/docs/design/market/README.md
@@ -53,6 +53,10 @@
 
   对外博客草稿：挑战“agent observability = prompt/tool trace”的默认理解，主张先观察真实状态变化，再解释 agent 叙事。
 
+- [blog-agent-observability-just-skills.md](blog-agent-observability-just-skills.md)
+
+  对外博客草稿：主张 AI agent observability 不需要再多一个固定 dashboard，而需要按证据边界拆分的 skills 来生成语义化判断和 artifact。
+
 ## What Everyone Is Doing
 
 市场已经拥挤的方向：

--- a/docs/design/market/blog-agent-observability-just-skills.md
+++ b/docs/design/market/blog-agent-observability-just-skills.md
@@ -1,0 +1,163 @@
+# AI Agent Observability Doesn't Need Yet Another Dashboard. It Needs Skills.
+
+早上九点，reviewer 打开昨晚 agent 跑完的任务。
+
+Agent 的总结很漂亮：
+
+> Fixed the issue, updated tests, and verified the result.
+
+Dashboard 也很完整。它显示 token cost、model latency、tool waterfall、failed spans、shell exit status、prompt 和 response。所有信息都在。
+
+但 reviewer 真正想知道的是一句话：
+
+> 我能不能相信这个 PR？
+
+他开始点 dashboard。先看 longest span，再看 failed command，再看 token spike，再看 file diff。十五分钟后，他知道了很多局部事实，但还没有得到真正的判断：
+
+> 它先跑了完整测试，失败了。后来只跑了一个局部测试，通过了。最后总结成“verified”。这个 PR 不能按完整验证处理。
+
+这个判断不是一个 widget。
+
+它需要读懂目标、命令顺序、失败语义、测试范围、文件变化和最终总结之间的关系。
+
+这就是 AI agent observability 和传统 observability 的分界。
+
+## Dashboard 回答已知问题
+
+Dashboard 很有用。它擅长回答已知问题：
+
+- 今天 token cost 有没有上升？
+- 哪个 model latency 最高？
+- 哪个 tool error rate 异常？
+- 最近一小时 active sessions 有多少？
+- 哪个 endpoint 返回最多 5xx？
+
+这些问题有稳定指标、稳定分组、稳定图表。你可以提前设计页面。
+
+但 agent 行为里最难的问题往往不是这种形态：
+
+- 它是不是偏离了任务？
+- 它是不是重复同一类失败？
+- 它说测试通过，这句话可信吗？
+- 它有没有把失败压缩成成功总结？
+- 它有没有访问 repo 外路径？
+- 它为什么花了这么多钱却没有推进？
+
+这些问题当然需要数据。但它们不是单个指标。
+
+它们需要解释。
+
+## Agent 行为的核心信息是语义性的
+
+传统 observability 把系统压成数字。AI agent observability 还必须理解叙事。
+
+一个 agent run 里最重要的信息经常藏在关系里：
+
+- 用户目标和 agent 实际行为是否一致；
+- tool failure 是否反复出现；
+- final summary 是否遮蔽了失败；
+- validation 是否从 full test 缩小成 partial test；
+- file/process/network side effects 是否超出用户预期；
+- expensive reasoning 是否产生了真实进展。
+
+这类问题不是“多画一张图”就能解决的。
+
+它需要另一个有语义理解能力的 agent 来读 evidence。
+
+## Skills 是分析方法，不是又一个 UI
+
+这里的 skills 不是 dashboard 插件，也不是按钮。
+
+Skills 是 portable analysis playbooks：给 agent 的一组方法，告诉它如何读取 evidence、如何判断 friction、如何标注 inference、如何保护隐私、如何按用户的问题生成合适的输出。
+
+一个好的 `agent-interaction-insights` skill 不会只说“总结这个 trace”。
+
+它会要求 agent：
+
+- 先判断用户真正的问题：usage、friction、trust、risk，还是 report。
+- 再选择 evidence source：Claude/Codex/Gemini logs、OTel、LangSmith、Langfuse、Datadog、plain transcript。
+- 先整理 facts：sessions、messages、LLM calls、tool attempts、validation claims、user corrections。
+- 再生成 findings：失败、loop、summary mismatch、context miss、resource waste。
+- 每个 finding 都要有 evidence。
+- 推断原因时标注 inference。
+- 不要把 missing evidence 写成 behavior did not happen。
+- 默认不泄露 raw prompts、secrets、auth headers。
+
+最后，用户想要什么视图，agent 再生成什么视图：
+
+- concise findings
+- inventory table
+- PR comment
+- incident brief
+- team memo
+- self-contained HTML artifact
+
+Dashboard 变成输出之一，而不是产品的起点。
+
+## 为什么是两个 Skills
+
+你可以把这个过程拆成三个阶段：
+
+```text
+inventory -> friction analysis -> artifact
+```
+
+架构上很干净。但产品上不一定对。
+
+用户不会说“请先运行 inventory skill，再运行 friction skill，最后运行 artifact skill”。用户会说：
+
+> 看看我的 agent 最近表现怎么样，哪里不对，生成个报告。
+
+所以第一版不应该是三个 pipeline skills。
+
+但一个什么都读的大 skill 也不对。它会同时读取对话和系统 DB，既增加隐私面，也模糊 AgentSight 的独特价值。
+
+更好的拆法是按 evidence boundary，而不是按 pipeline stage：
+
+```text
+agent-interaction-insights
+  读对话和 trace，理解用户交互、loop、summary trust、validation claims
+
+agentsight-system-friction
+  读 AgentSight/system evidence，理解进程、文件、网络、资源和 side effects
+```
+
+这两个 skills 可以组合，但不应该都读 raw conversation。AgentSight skill 输出 system findings 和 join keys；interaction skill 负责把这些 system findings 和用户目标、最终总结、对话过程放在一起理解。
+
+## AgentSight 应该做什么
+
+AgentSight 不应该急着做第 N 个 dashboard。
+
+更有价值的是提供高质量 evidence：
+
+- 真实进程树；
+- shell command 和 exit status；
+- 文件读写和删除；
+- 网络目标；
+- CPU/RSS/IO；
+- LLM/tool/session 关联；
+- 可导出的 snapshot。
+
+然后让 `agentsight-system-friction` 把这些 evidence 变成系统 findings，再让 `agent-interaction-insights` 在需要时把系统 findings 和对话语义合并。
+
+这会让 AgentSight 的定位更清楚：
+
+> AgentSight provides system evidence. Skills turn evidence into insight.
+
+当某些输出稳定之后，再把它们产品化成 CLI、hosted report 或 dashboard。不要反过来，先定义 dashboard，再让用户把问题塞进去。
+
+## 给 Observability Tool Builders 的建议
+
+如果你在做 AI agent observability，不要只问：
+
+> 还缺哪张图？
+
+也要问：
+
+> 用户拿到 evidence 后，真正要做什么判断？
+
+很多判断不能靠固定 dashboard 预先枚举。它们需要一个能理解语义、证据和上下文的 agent。
+
+所以，下一代 agent observability 的关键组件可能不是又一个 dashboard。
+
+而是一组好的 skills。

--- a/docs/skills/examples/README.md
+++ b/docs/skills/examples/README.md
@@ -1,0 +1,8 @@
+# Skill-Generated Example Dashboards
+
+These files are example outputs generated from the repo-local skills under
+`skills/`. They are static, self-contained HTML examples for reviewing the
+skills' output shape.
+
+- [Agent Interaction Insights Dashboard](interaction-insights-dashboard.html)
+- [AgentSight System Friction Dashboard](agentsight-system-dashboard.html)

--- a/docs/skills/examples/agentsight-system-dashboard.html
+++ b/docs/skills/examples/agentsight-system-dashboard.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>AgentSight 系统摩擦报告</title>
+  <style>
+    :root {
+      --bg: #f5f7fa;
+      --surface: #ffffff;
+      --soft: #eef3f7;
+      --text: #17202a;
+      --muted: #627083;
+      --line: #dbe3ec;
+      --accent: #0f766e;
+      --blue: #2563eb;
+      --amber: #b45309;
+      --red: #b91c1c;
+      --shadow: 0 14px 34px rgba(23, 32, 42, 0.08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      line-height: 1.55;
+    }
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      padding: 12px clamp(18px, 4vw, 52px);
+      background: rgba(255, 255, 255, 0.92);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(12px);
+    }
+    .brand { font-weight: 780; }
+    .brand span { display: block; color: var(--muted); font-size: 12px; font-weight: 500; }
+    nav { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+    nav a, button {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: var(--surface);
+      color: var(--text);
+      padding: 7px 10px;
+      font: inherit;
+      font-size: 13px;
+      text-decoration: none;
+      cursor: pointer;
+    }
+    nav a:hover, button:hover { border-color: var(--accent); color: var(--accent); }
+    header {
+      padding: clamp(28px, 5vw, 64px) clamp(18px, 4vw, 52px) 30px;
+      background: linear-gradient(180deg, #fff 0%, var(--bg) 100%);
+      border-bottom: 1px solid var(--line);
+    }
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+      gap: clamp(22px, 4vw, 40px);
+      max-width: 1240px;
+      margin: 0 auto;
+      align-items: start;
+    }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-weight: 780; font-size: 13px; }
+    h1 { margin: 0; max-width: 980px; font-size: clamp(30px, 4vw, 52px); line-height: 1.08; letter-spacing: 0; }
+    h2 { margin: 0 0 12px; font-size: clamp(21px, 2vw, 28px); letter-spacing: 0; }
+    h3 { margin: 0 0 8px; font-size: 17px; letter-spacing: 0; }
+    p { margin: 0; }
+    .lead { margin-top: 18px; max-width: 820px; color: #374151; font-size: clamp(16px, 1.5vw, 19px); }
+    .contract {
+      margin-top: 18px;
+      padding: 14px 16px;
+      border-left: 4px solid var(--accent);
+      background: #e8f7f3;
+      color: #1f4e49;
+      font-weight: 680;
+    }
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+    .verdict { padding: 18px; }
+    .verdict .label { color: var(--muted); font-size: 13px; font-weight: 700; }
+    .verdict .value { margin-top: 6px; color: var(--red); font-size: 28px; font-weight: 820; line-height: 1.1; }
+    .verdict ul { margin: 14px 0 0; padding-left: 18px; color: #374151; }
+    main { max-width: 1240px; margin: 0 auto; padding: 28px clamp(18px, 4vw, 52px) 54px; }
+    section { margin-top: 28px; }
+    .grid { display: grid; gap: 14px; }
+    .cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .metric { padding: 16px; }
+    .metric .num { margin-top: 8px; font-size: 30px; line-height: 1; font-weight: 820; }
+    .metric .desc { margin-top: 8px; color: var(--muted); font-size: 13px; }
+    .actions { display: grid; gap: 12px; }
+    .action {
+      display: grid;
+      grid-template-columns: 74px minmax(0, 1fr) minmax(220px, 0.52fr);
+      gap: 14px;
+      padding: 16px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+    .prio {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 32px;
+      border-radius: 7px;
+      color: #fff;
+      font-weight: 800;
+    }
+    .p0 { background: var(--red); }
+    .p1 { background: var(--amber); }
+    .p2 { background: var(--blue); }
+    .evidence { color: var(--muted); font-size: 13px; }
+    .module { padding: 16px; }
+    .module strong { display: block; margin-bottom: 6px; }
+    .bar { height: 9px; border-radius: 999px; background: #e5ebf2; overflow: hidden; margin-top: 12px; }
+    .bar i { display: block; height: 100%; background: var(--accent); }
+    .bar .red { background: var(--red); }
+    .bar .amber { background: var(--amber); }
+    .bar .blue { background: var(--blue); }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); }
+    table { width: 100%; border-collapse: collapse; min-width: 760px; }
+    th, td { padding: 11px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: var(--soft); color: #334155; font-size: 13px; }
+    tr:last-child td { border-bottom: 0; }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 3px 9px;
+      font-size: 12px;
+      font-weight: 760;
+      background: var(--soft);
+    }
+    .high { color: var(--red); background: #fee2e2; }
+    .medium { color: var(--amber); background: #fef3c7; }
+    .info { color: var(--blue); background: #dbeafe; }
+    .note { color: var(--muted); font-size: 14px; }
+    .callout { padding: 16px; border-left: 4px solid var(--blue); background: #eef5ff; border-radius: 8px; }
+    .footer { margin-top: 32px; color: var(--muted); font-size: 13px; }
+    @media (max-width: 900px) {
+      .hero, .cols-4, .cols-3, .cols-2, .action { grid-template-columns: 1fr; }
+      .topbar { position: static; }
+      nav { justify-content: flex-start; }
+    }
+  </style>
+</head>
+<body>
+  <div class="topbar">
+    <div class="brand">AgentSight 系统摩擦报告<span>真实 monitor 聚合摘要 · 团队内分享口径</span></div>
+    <nav aria-label="报告导航">
+      <a href="#actions">立即动作</a>
+      <a href="#overview">系统概览</a>
+      <a href="#improvements">下一轮改进</a>
+      <a href="#evidence">证据边界</a>
+      <a href="#appendix">附录</a>
+      <button type="button" id="copySummary">复制摘要</button>
+    </nav>
+  </div>
+
+  <header>
+    <div class="hero">
+      <div>
+        <p class="eyebrow">Operating decision</p>
+        <h1>下一轮本地 agent 应该少占资源、少留后台状态，并留下足够证据。</h1>
+        <p class="lead">
+          本报告使用 2026-06-16 11:08 至 2026-06-21 21:48 PDT 的 AgentSight monitor 聚合摘要。
+          本报告根据现有系统影响判断：哪些命令、服务、网络绑定、状态文件和采集字段应该在下一轮直接改掉。
+        </p>
+        <div class="contract">
+          读者/决策契约：面向 agent owner、operator 与安全审阅者，决定下一轮本地 agent 应改变哪些运行习惯和自动化规则，减少等待、资源占用、遗留进程和事后追查成本。
+        </div>
+      </div>
+      <aside class="panel verdict">
+        <div class="label">执行判断</div>
+        <div class="value">改完再继续</div>
+        <ul>
+          <li>重编译、虚拟机和本地模型先加 CPU/RSS/IO/wall-time 预算。</li>
+          <li>本地 app-server 和长运行任务需要租约、owner 摘要和退出清理。</li>
+          <li>默认本地服务绑定 localhost 或 Unix socket，减少不必要暴露面。</li>
+          <li>交付级运行保留命令、退出码、文件/网络摘要和复现线索。</li>
+        </ul>
+      </aside>
+    </div>
+  </header>
+
+  <main>
+    <section id="actions">
+      <h2>立即动作</h2>
+      <div class="actions">
+        <article class="action">
+          <div><span class="prio p0">P0</span></div>
+          <div>
+            <h3>给重编译、虚拟机和本地模型加资源预算</h3>
+            <p>最高 RSS 采样窗口约 23.84 GiB；最高 CPU 2 秒窗口约 88.16 秒。下一轮应先跑窄范围命令，给重任务加 wall-time、RSS、IO 和重试预算。</p>
+          </div>
+          <p class="evidence">证据：构建/测试、虚拟机、本地模型和 app-server 是主要 CPU/RSS/写入热点。</p>
+        </article>
+        <article class="action">
+          <div><span class="prio p0">P0</span></div>
+          <div>
+            <h3>让长运行服务自动到期或交接</h3>
+            <p>本地 app-server 类别有 100 个会话，且存在超过 24 小时的长运行样本。下一轮应给服务启动命令加租约、退出清理和 owner/log 摘要。</p>
+          </div>
+          <p class="evidence">证据：本地 app-server 是主要写入来源；长运行样本状态仍为 monitor 聚合视角的 running。</p>
+        </article>
+        <article class="action">
+          <div><span class="prio p1">P1</span></div>
+          <div>
+            <h3>把默认网络绑定收窄到本机</h3>
+            <p>网络聚合包含全接口监听类别和外部 SSH 类别。下一轮默认服务绑定 localhost 或 Unix socket；确实需要外部连接时记录目的类别和持续时间。</p>
+          </div>
+          <p class="evidence">证据：全接口监听类别计数 1,076；外部 SSH 类别计数 265。</p>
+        </article>
+        <article class="action">
+          <div><span class="prio p1">P1</span></div>
+          <div>
+            <h3>把 agent 状态和日志改成生命周期对象</h3>
+            <p>agent 状态或监控文件是最大文件目标类别。下一轮结束时自动归档会话记录、轮转日志、清理临时锁，并把仍在运行的后台服务列出来。</p>
+          </div>
+          <p class="evidence">证据：agent 状态或监控文件计数 82,128；本地 app-server 类别 100 个会话。</p>
+        </article>
+        <article class="action">
+          <div><span class="prio p2">P2</span></div>
+          <div>
+            <h3>给交付级运行补齐复现证据</h3>
+            <p>monitor 聚合足以指出系统影响，但不能证明完整因果。涉及交付、客户环境或工作区外影响时，应保留命令、退出码、文件/网络摘要和复现脚本线索。</p>
+          </div>
+          <p class="evidence">证据：本页不包含原始对话、请求正文、文件内容或逐事件时间线。</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="overview">
+      <h2>系统概览</h2>
+      <div class="grid cols-4">
+        <div class="panel metric">
+          <div class="note">跟踪会话</div>
+          <div class="num">287</div>
+          <div class="desc">197 个 coding agent 类别，90 个 review agent 类别。</div>
+        </div>
+        <div class="panel metric">
+          <div class="note">采样窗口</div>
+          <div class="num">258,176</div>
+          <div class="desc">monitor window 是定期聚合样本，不等于完整事件数。</div>
+        </div>
+        <div class="panel metric">
+          <div class="note">最高 RSS</div>
+          <div class="num">23.84 GiB</div>
+          <div class="desc">重任务窗口需要资源预算和并发限制。</div>
+        </div>
+        <div class="panel metric">
+          <div class="note">最高 CPU</div>
+          <div class="num">88.16s/2s</div>
+          <div class="desc">2 秒窗口内累计 CPU 时间，说明多核并行压力。</div>
+        </div>
+      </div>
+
+      <div class="grid cols-3" style="margin-top:14px;">
+        <div class="panel module">
+          <strong>服务生命周期</strong>
+          <p>本地 app-server 与长运行样本需要租约、退出清理和 owner/log 摘要。</p>
+          <div class="bar"><i class="red" style="width: 86%"></i></div>
+        </div>
+        <div class="panel module">
+          <strong>资源压力</strong>
+          <p>构建/测试、虚拟机、本地模型和 app-server 是 CPU/RSS/写入热点。</p>
+          <div class="bar"><i class="amber" style="width: 84%"></i></div>
+        </div>
+        <div class="panel module">
+          <strong>采集置信度</strong>
+          <p>聚合摘要足以指导下一轮改进；精确归因需要更完整的命令、退出码和文件/网络摘要。</p>
+          <div class="bar"><i class="blue" style="width: 64%"></i></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="improvements">
+      <h2>下一轮改进</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>控制项</th>
+              <th>当前信号</th>
+              <th>下一轮规则</th>
+              <th>完成标准</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="pill high">重任务</span></td>
+              <td>最高 RSS 约 23.84 GiB；CPU 峰值约 88.16s/2s。</td>
+              <td>先跑窄范围命令；重编译、虚拟机和本地模型加 wall-time、RSS、IO、重试预算。</td>
+              <td>超预算后输出资源摘要，并降级到更窄的复跑命令。</td>
+            </tr>
+            <tr>
+              <td><span class="pill high">服务</span></td>
+              <td>本地 app-server 类别 100 个会话；存在超过 24 小时的长运行样本。</td>
+              <td>服务启动命令带租约、退出清理、owner 摘要和日志位置。</td>
+              <td>任务结束后后台服务要么退出，要么留下 owner、端口、日志和到期时间。</td>
+            </tr>
+            <tr>
+              <td><span class="pill medium">网络</span></td>
+              <td>外部 HTTPS、localhost、全接口监听、外部 SSH 均出现。</td>
+              <td>默认服务绑定 localhost 或 Unix socket；外部连接记录目的类别和持续时间。</td>
+              <td>下一轮全接口监听下降，外部 SSH 有明确任务窗口。</td>
+            </tr>
+            <tr>
+              <td><span class="pill medium">状态文件</span></td>
+              <td>agent 状态/monitor 文件是最大目标类别。</td>
+              <td>把状态、日志、临时锁和监控输出纳入任务结束清理。</td>
+              <td>会话结束后完成日志轮转、会话归档、临时锁清理和剩余后台服务摘要。</td>
+            </tr>
+            <tr>
+              <td><span class="pill info">复现证据</span></td>
+              <td>monitor 只提供聚合窗口，不提供完整逐事件因果链。</td>
+              <td>交付级运行保留命令、退出码、关键文件/网络摘要和复现脚本线索。</td>
+              <td>能回答哪个步骤触发了资源峰值、监听、文件写入或外部连接。</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="evidence">
+      <h2>证据摘要</h2>
+      <div class="grid cols-2">
+        <div class="panel module">
+          <h3>进程与资源热点</h3>
+          <ul>
+            <li>构建/测试工作负载累计 CPU 最高，单类进程最大 RSS 约 13.72 GiB。</li>
+            <li>虚拟机工作负载累计 CPU 约 2,626 秒，最大 RSS 约 13.32 GiB。</li>
+            <li>本地模型工作负载累计 CPU 约 1,293 秒，最大 RSS 约 11.93 GiB。</li>
+            <li>本地 app-server 类别累计写入约 73.0 GiB，是写入压力主来源。</li>
+          </ul>
+        </div>
+        <div class="panel module">
+          <h3>文件与网络类别</h3>
+          <ul>
+            <li>文件目标：agent 状态/monitor 82,128；终端设备 12,914；开发环境日志 10,758。</li>
+            <li>网络目标：外部 HTTPS 53,508；localhost 服务 7,138；全接口监听 1,076；外部 SSH 265。</li>
+            <li>这些类别足以指导下一轮改进，但不能说明每个请求的业务意图。</li>
+          </ul>
+        </div>
+      </div>
+      <div class="callout" style="margin-top:14px;">
+        <strong>如何解读 running：</strong>
+        聚合摘要中会话状态显示为 running，表示 monitor 视角下的跟踪状态；关闭进程前仍应做一次当前进程复核，避免把历史聚合样本当作此刻仍存活的事实。
+      </div>
+    </section>
+
+    <section id="appendix">
+      <h2>附录：来源、隐私与边界</h2>
+      <div class="table-wrap">
+        <table>
+          <tbody>
+            <tr>
+              <th>来源类型</th>
+              <td>AgentSight monitor 聚合摘要，来自本机最新周级监控数据库。</td>
+            </tr>
+            <tr>
+              <th>时间范围</th>
+              <td>2026-06-16 11:08:38 至 2026-06-21 21:48:35 PDT。</td>
+            </tr>
+            <tr>
+              <th>输入规模</th>
+              <td>287 个跟踪会话、258,176 个采样窗口、43,533 个进程样本、115,463 个文件样本、25,253 个网络样本。</td>
+            </tr>
+            <tr>
+              <th>隐私口径</th>
+              <td>团队内分享；页面展示类别、计数、时间窗口和资源量，不展示原始行、本地路径、完整命令、主机 IP 或请求正文。</td>
+            </tr>
+            <tr>
+              <th>证据限制</th>
+              <td>monitor 聚合无法证明完整因果、用户意图或未采样短命令。需要合并、部署或客户交付级判断时，应保留更完整的命令和系统影响记录。</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="footer">自包含 HTML 报告；无外部资源、无运行时网络请求、无后端依赖。</p>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const summary = "AgentSight 系统摩擦结论：下一轮本地 agent 应优先改重任务预算、长运行服务清理、默认网络绑定、状态日志生命周期和交付级复现证据。关键证据：287 个跟踪会话、258,176 个采样窗口、最高 RSS 23.84 GiB、最高 CPU 88.16s/2s、本地 app-server 100 个会话、全接口监听类别 1,076。";
+      const button = document.getElementById("copySummary");
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(summary);
+          button.textContent = "已复制";
+        } catch (err) {
+          button.textContent = "复制失败";
+        }
+        window.setTimeout(() => { button.textContent = "复制摘要"; }, 1600);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/docs/skills/examples/interaction-insights-dashboard.html
+++ b/docs/skills/examples/interaction-insights-dashboard.html
@@ -1,0 +1,396 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agent 协作改进报告</title>
+  <style>
+    :root {
+      --bg: #f6f7f9;
+      --surface: #ffffff;
+      --soft: #eef3f7;
+      --text: #17202a;
+      --muted: #627083;
+      --line: #dbe3ec;
+      --accent: #0f766e;
+      --blue: #2563eb;
+      --amber: #b45309;
+      --red: #b91c1c;
+      --green: #15803d;
+      --shadow: 0 14px 34px rgba(23, 32, 42, 0.08);
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", "PingFang SC", "Microsoft YaHei", sans-serif;
+      line-height: 1.55;
+    }
+    .topbar {
+      position: sticky;
+      top: 0;
+      z-index: 10;
+      display: flex;
+      justify-content: space-between;
+      gap: 18px;
+      padding: 12px clamp(18px, 4vw, 52px);
+      background: rgba(255, 255, 255, 0.92);
+      border-bottom: 1px solid var(--line);
+      backdrop-filter: blur(12px);
+    }
+    .brand { font-weight: 780; }
+    .brand span { display: block; color: var(--muted); font-size: 12px; font-weight: 500; }
+    nav { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; }
+    nav a, button {
+      border: 1px solid var(--line);
+      border-radius: 7px;
+      background: var(--surface);
+      color: var(--text);
+      padding: 7px 10px;
+      font: inherit;
+      font-size: 13px;
+      text-decoration: none;
+      cursor: pointer;
+    }
+    nav a:hover, button:hover { border-color: var(--accent); color: var(--accent); }
+    header {
+      padding: clamp(28px, 5vw, 64px) clamp(18px, 4vw, 52px) 30px;
+      background: linear-gradient(180deg, #fff 0%, var(--bg) 100%);
+      border-bottom: 1px solid var(--line);
+    }
+    .hero {
+      display: grid;
+      grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.65fr);
+      gap: clamp(22px, 4vw, 40px);
+      max-width: 1240px;
+      margin: 0 auto;
+      align-items: start;
+    }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-weight: 780; font-size: 13px; }
+    h1 { margin: 0; max-width: 980px; font-size: clamp(30px, 4vw, 52px); line-height: 1.08; letter-spacing: 0; }
+    h2 { margin: 0 0 12px; font-size: clamp(21px, 2vw, 28px); letter-spacing: 0; }
+    h3 { margin: 0 0 8px; font-size: 17px; letter-spacing: 0; }
+    p { margin: 0; }
+    .lead { margin-top: 18px; max-width: 820px; color: #374151; font-size: clamp(16px, 1.5vw, 19px); }
+    .contract {
+      margin-top: 18px;
+      padding: 14px 16px;
+      border-left: 4px solid var(--accent);
+      background: #e8f7f3;
+      color: #1f4e49;
+      font-weight: 680;
+    }
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+    }
+    .verdict { padding: 18px; }
+    .verdict .label { color: var(--muted); font-size: 13px; font-weight: 700; }
+    .verdict .value { margin-top: 6px; color: var(--amber); font-size: 28px; font-weight: 820; line-height: 1.1; }
+    .verdict ul { margin: 14px 0 0; padding-left: 18px; color: #374151; }
+    main { max-width: 1240px; margin: 0 auto; padding: 28px clamp(18px, 4vw, 52px) 54px; }
+    section { margin-top: 28px; }
+    .grid { display: grid; gap: 14px; }
+    .cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+    .cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .metric { padding: 16px; }
+    .metric .num { margin-top: 8px; font-size: 30px; line-height: 1; font-weight: 820; }
+    .metric .desc { margin-top: 8px; color: var(--muted); font-size: 13px; }
+    .actions { display: grid; gap: 12px; }
+    .action {
+      display: grid;
+      grid-template-columns: 62px minmax(0, 1fr) minmax(220px, 0.5fr);
+      gap: 14px;
+      padding: 16px;
+      background: var(--surface);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+    .rank {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 38px;
+      height: 38px;
+      border-radius: 8px;
+      color: #fff;
+      background: var(--accent);
+      font-weight: 820;
+    }
+    .evidence { color: var(--muted); font-size: 13px; }
+    .module { padding: 16px; }
+    .module strong { display: block; margin-bottom: 6px; }
+    .bar { height: 9px; border-radius: 999px; background: #e5ebf2; overflow: hidden; margin-top: 12px; }
+    .bar i { display: block; height: 100%; background: var(--accent); }
+    .bar .red { background: var(--red); }
+    .bar .amber { background: var(--amber); }
+    .bar .blue { background: var(--blue); }
+    .table-wrap { overflow-x: auto; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); }
+    table { width: 100%; border-collapse: collapse; min-width: 760px; }
+    th, td { padding: 11px 12px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    th { background: var(--soft); color: #334155; font-size: 13px; }
+    tr:last-child td { border-bottom: 0; }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      border-radius: 999px;
+      padding: 3px 9px;
+      font-size: 12px;
+      font-weight: 760;
+      background: var(--soft);
+    }
+    .high { color: var(--red); background: #fee2e2; }
+    .medium { color: var(--amber); background: #fef3c7; }
+    .info { color: var(--blue); background: #dbeafe; }
+    .note { color: var(--muted); font-size: 14px; }
+    .callout { padding: 16px; border-left: 4px solid var(--blue); background: #eef5ff; border-radius: 8px; }
+    .footer { margin-top: 32px; color: var(--muted); font-size: 13px; }
+    @media (max-width: 900px) {
+      .hero, .cols-4, .cols-3, .cols-2, .action { grid-template-columns: 1fr; }
+      .topbar { position: static; }
+      nav { justify-content: flex-start; }
+    }
+  </style>
+</head>
+<body>
+  <div class="topbar">
+    <div class="brand">Agent 协作改进报告<span>近期本地 agent 会话摘要 · 团队内分享口径</span></div>
+    <nav aria-label="报告导航">
+      <a href="#changes">改进动作</a>
+      <a href="#overview">决策概览</a>
+      <a href="#evidence">证据</a>
+      <a href="#appendix">边界</a>
+      <button type="button" id="copySummary">复制摘要</button>
+    </nav>
+  </div>
+
+  <header>
+    <div class="hero">
+      <div>
+        <p class="eyebrow">Interaction decision</p>
+        <h1>下一批 agent 任务可以继续交给 agent，但要先加协作契约和验证门槛。</h1>
+        <p class="lead">
+          本报告基于 8 个近期非本任务的本地 coding/debugging 会话摘要，观察消息流、工具调用、纠正信号和验证痕迹。
+          目标是帮助 agent owner 决定：下一次怎样减少返工、提高总结可信度，并更早发现需要人工 checkpoint 的任务。
+        </p>
+        <div class="contract">
+          读者/决策契约：面向 agent owner 和 team lead，判断哪些协作规则、验证要求和任务分流策略应在下一轮 agent run 前更新。
+        </div>
+      </div>
+      <aside class="panel verdict">
+        <div class="label">执行判断</div>
+        <div class="value">可继续，但要加门槛</div>
+        <ul>
+          <li>长会话和高工具调用任务先写清交付判断。</li>
+          <li>连续纠正后暂停执行，重新确认目标和非目标。</li>
+          <li>最终总结必须列出已运行、未运行和推断项。</li>
+          <li>工具失败或重复尝试超过阈值时进入 checkpoint。</li>
+        </ul>
+      </aside>
+    </div>
+  </header>
+
+  <main>
+    <section id="changes">
+      <h2>下一轮最该改的 5 件事</h2>
+      <div class="actions">
+        <article class="action">
+          <div><span class="rank">1</span></div>
+          <div>
+            <h3>开局写清“这次要做什么判断”</h3>
+            <p>每个任务开始时先确认交付判断：能否合并、能否放行、是否需要复跑、还是只需要定位问题。这样可以减少 agent 把探索、实现和审查混在一起。</p>
+          </div>
+          <p class="evidence">证据：8 个会话中有 360 条用户消息和 270 次工具调用，长会话更容易出现目标漂移和后续纠正。</p>
+        </article>
+        <article class="action">
+          <div><span class="rank" style="background: var(--amber);">2</span></div>
+          <div>
+            <h3>把连续纠正设为 checkpoint 信号</h3>
+            <p>当用户连续重设范围、否定方向或要求重做时，agent 应停下来压缩当前理解，而不是继续扩大编辑或重复运行命令。</p>
+          </div>
+          <p class="evidence">证据：摘要里出现 74 个纠正/重设类信号，集中在长会话和工具密集会话。</p>
+        </article>
+        <article class="action">
+          <div><span class="rank" style="background: var(--blue);">3</span></div>
+          <div>
+            <h3>把验证结果写成可审查状态</h3>
+            <p>最终总结不要只说“完成”或“已验证”。应列出检查项、状态、范围和缺口，让 reviewer 能直接判断还差什么。</p>
+          </div>
+          <p class="evidence">证据：工具结果里有大量错误样式信号；没有统一状态模板时，用户需要重新追问真实验证范围。</p>
+        </article>
+        <article class="action">
+          <div><span class="rank" style="background: var(--green);">4</span></div>
+          <div>
+            <h3>工具计划从“全量尝试”改成“窄验证优先”</h3>
+            <p>对 build/test/debug 类任务，先运行最小复现和局部检查；只有在局部通过后再扩大范围，避免 Bash/Edit/Read 循环放大。</p>
+          </div>
+          <p class="evidence">证据：工具类别以 Bash、Read、Edit 为主，长会话中工具调用密度明显更高。</p>
+        </article>
+        <article class="action">
+          <div><span class="rank" style="background: var(--red);">5</span></div>
+          <div>
+            <h3>把高风险任务路由到更强采集</h3>
+            <p>当任务涉及文件边界、网络访问、权限变化或客户交付，交互日志只能解释协作过程，不能证明系统副作用。此时应补充系统级证据。</p>
+          </div>
+          <p class="evidence">证据：本报告没有读取文件内容、网络 payload 或进程级因果链；系统副作用需要独立证据。</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="overview">
+      <h2>决策概览</h2>
+      <div class="grid cols-4">
+        <div class="panel metric">
+          <div class="note">会话样本</div>
+          <div class="num">8</div>
+          <div class="desc">近期非本任务 coding/debugging 会话。</div>
+        </div>
+        <div class="panel metric">
+          <div class="note">用户消息</div>
+          <div class="num">360</div>
+          <div class="desc">用于观察范围重设、批准、纠正和追问。</div>
+        </div>
+        <div class="panel metric">
+          <div class="note">工具调用</div>
+          <div class="num">270</div>
+          <div class="desc">以 Bash、Read、Edit 为主。</div>
+        </div>
+        <div class="panel metric">
+          <div class="note">纠正信号</div>
+          <div class="num">74</div>
+          <div class="desc">按关键词和消息角色粗略归类，需人工复核。</div>
+        </div>
+      </div>
+
+      <div class="grid cols-3" style="margin-top:14px;">
+        <div class="panel module">
+          <strong>协作清晰度</strong>
+          <p>长会话需要更强的读者/交付判断，否则容易在实现和验证之间来回切换。</p>
+          <div class="bar"><i class="amber" style="width: 72%"></i></div>
+        </div>
+        <div class="panel module">
+          <strong>验证可信度</strong>
+          <p>检查状态需要从自然语言总结变成可审查清单。</p>
+          <div class="bar"><i class="blue" style="width: 66%"></i></div>
+        </div>
+        <div class="panel module">
+          <strong>返工风险</strong>
+          <p>多轮纠正和工具密集任务应触发 checkpoint。</p>
+          <div class="bar"><i class="red" style="width: 78%"></i></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="evidence">
+      <h2>证据与推断</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>观察项</th>
+              <th>摘要证据</th>
+              <th>解释</th>
+              <th>下一步</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="pill high">长会话</span></td>
+              <td>最长样本约 6 小时；另有多个 20-50 分钟级任务。</td>
+              <td>长会话容易把定位、实现、验证、总结混在一起。</td>
+              <td>超过时间或工具阈值时重写目标和剩余风险。</td>
+            </tr>
+            <tr>
+              <td><span class="pill medium">工具密集</span></td>
+              <td>工具调用 270 次；主要类别为 shell、读取和编辑。</td>
+              <td>适合设置窄验证优先和重试预算。</td>
+              <td>第一次失败后记录假设，第二次失败后缩小范围。</td>
+            </tr>
+            <tr>
+              <td><span class="pill medium">纠正信号</span></td>
+              <td>纠正/重设类信号 74 个，集中在复杂会话。</td>
+              <td>用户可能在不断修正 agent 的目标模型。</td>
+              <td>连续纠正后暂停执行并确认当前理解。</td>
+            </tr>
+            <tr>
+              <td><span class="pill info">证据缺口</span></td>
+              <td>未读取原始全文、文件 diff、网络内容或进程因果链。</td>
+              <td>本报告能解释协作摩擦，不能证明系统副作用。</td>
+              <td>高风险运行需要系统级报告配合。</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>下一轮执行清单</h2>
+      <div class="grid cols-2">
+        <div class="panel module">
+          <h3>任务开始前</h3>
+          <ul>
+            <li>写明本次帮助谁做什么决定。</li>
+            <li>列出允许修改的范围和需要保留的证据。</li>
+            <li>为长任务设置时间、工具调用和重试阈值。</li>
+          </ul>
+        </div>
+        <div class="panel module">
+          <h3>任务结束前</h3>
+          <ul>
+            <li>把已运行、未运行、失败、推断分开写。</li>
+            <li>给 reviewer 一个可执行的剩余风险清单。</li>
+            <li>需要系统副作用证明时，补系统级采集。</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="appendix">
+      <h2>附录：来源、隐私与边界</h2>
+      <div class="table-wrap">
+        <table>
+          <tbody>
+            <tr>
+              <th>来源类型</th>
+              <td>近期本地 agent 会话摘要，过滤掉当前 AgentSight 示例生成任务。</td>
+            </tr>
+            <tr>
+              <th>提取字段</th>
+              <td>消息数量、工具调用类别、纠正/重设信号、错误样式信号、会话时间范围。</td>
+            </tr>
+            <tr>
+              <th>隐私口径</th>
+              <td>团队内分享；页面使用类别、计数和时间范围，不展示原始提示、回复正文、本地路径或命令正文。</td>
+            </tr>
+            <tr>
+              <th>证据限制</th>
+              <td>纠正和错误信号是启发式分类；最终原因需要结合具体任务上下文复核。</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="footer">自包含 HTML 报告；无外部资源、无运行时网络请求、无后端依赖。</p>
+    </section>
+  </main>
+
+  <script>
+    (function () {
+      const summary = "Agent 协作改进结论：下一批 agent 任务可以继续，但要先加协作契约、连续纠正 checkpoint、验证状态模板、窄验证优先和高风险系统级采集。证据来自 8 个近期本地会话摘要：360 条用户消息、270 次工具调用、74 个纠正/重设信号。";
+      const button = document.getElementById("copySummary");
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(summary);
+          button.textContent = "已复制";
+        } catch (err) {
+          button.textContent = "复制失败";
+        }
+        window.setTimeout(() => { button.textContent = "复制摘要"; }, 1600);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,39 @@
+# Agent Behavior Analysis Skills
+
+This directory contains repo-local skills for analyzing AI agent behavior from
+local logs, observability traces, and AgentSight evidence. These are prototypes
+for a shareable skills pack, not AgentSight runtime code.
+
+## Skills
+
+- `agent-interaction-insights`: analyze user-agent interaction behavior from
+  transcripts, local agent logs, and observability traces. Use it to reduce
+  user corrections, improve summary trust, stop retry loops, and decide what
+  should change in prompts, AGENTS.md/CLAUDE.md, skills, evals, or workflows.
+- `agentsight-system-friction`: analyze AgentSight system evidence. Use it to
+  improve heavy-command budgets, retry behavior, service lifecycle cleanup,
+  network binding, file/log hygiene, and next-run capture quality.
+
+## Design Principles
+
+- Split by evidence boundary, not by pipeline stage: semantic interaction vs
+  system-level AgentSight facts.
+- Treat AgentSight as a specialized strong evidence source, not a requirement
+  for generic interaction analysis.
+- Prefer evidence-backed findings over fixed dashboard layouts.
+- Generate user-facing decision reports and dashboard layers on demand from
+  the user's question; keep source manifests, ids, and handoff JSON in
+  appendices unless the user asks for debug output.
+- Use `agent-interaction-insights` for conversation-level analysis and
+  `agentsight-system-friction` for OS/runtime analysis; combine them through
+  the handoff contract when both matter.
+- Do not include raw prompts, responses, auth headers, or secrets by default.
+- Add scripts only after an adapter pattern repeats and needs deterministic
+  behavior.
+
+## Local Testing
+
+These skills are stored in the repository so they can be reviewed and iterated
+with the rest of the design docs. For local tests, point a client at this
+directory or copy only the skill under test into that client's supported skills
+location.

--- a/skills/agent-interaction-insights/SKILL.md
+++ b/skills/agent-interaction-insights/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: agent-interaction-insights
+description: Analyze agent transcripts, OTel GenAI spans, LangSmith/Langfuse/Datadog exports, or Claude/Codex/Gemini logs to recommend collaboration improvements—reduce corrections, improve trust, stop loops, compare agent fit—and generate decision-oriented, reader-safe HTML reports.
+---
+
+# Agent Interaction Insights
+
+## Goal
+
+Turn agent conversation and trace evidence into concrete next-run improvements: prompts, AGENTS.md/CLAUDE.md, workflow, validation rules, tool policy, or task routing. Lead with what should change; use evidence to justify the change. Default reports should read like decision material for an agent owner.
+
+## Workflow
+
+0. Privacy mode: Default to `team-share`. Read `references/privacy-modes.md` before extracting prompt/response/path/command/header/secret-adjacent data. For HTML reports and examples, use reader-safe summaries: short task/claim summaries, field categories, time ranges, counts, statuses, and analysis boundaries. Exact local identifiers belong only in private-debug work requested by the user.
+
+1. Classify the question:
+   - `improve-collaboration`: reduce corrections, clarify framing, improve AGENTS.md/CLAUDE.md.
+   - `improve-trust`: make summaries and validation claims reliable.
+   - `reduce-waste`: stop loops, retry churn, token/time waste.
+   - `improve-workflow`: decide which instructions, checks, evals, policies, or workflow gates should change.
+   - `compare-fit`: compare agents, models, prompts, or task classes.
+
+2. Route evidence to reference docs:
+   - Sources: `references/data-source-routing.md`
+   - Improvement classes: `references/improvement-classes.md`
+   - Evidence model: `references/common-evidence-model.md`
+   - Friction taxonomy: `references/friction-taxonomy.md`
+   - System summary input: `references/handoff-contract.md`
+   - Output shapes: `references/report-shapes.md`
+   - Examples: `references/example-patterns.md`
+
+   If the user provides both interaction logs and AgentSight/system data, analyze only interaction evidence here. Consume already summarized system findings as compact context; route raw AgentSight data to `agentsight-system-friction`.
+
+3. Build facts:
+   - Map records into sessions, messages, LLM calls, tool attempts, validation claims, and user signals.
+   - Extract minimal fields; distinguish observed from inferred.
+   - Note when transcripts cannot prove process/file/network side effects.
+
+4. Recommend improvements:
+   - Lead with 3-7 changes ranked by expected leverage.
+   - Each: target, change, evidence, expected benefit, confidence, next action.
+   - Include findings as supporting evidence. Mark causal explanations as inference.
+
+5. Shape output:
+   - Quick questions: what to change next + compact evidence.
+   - Full analysis or shareable output: self-contained HTML report. Name the reader and their decision before writing. Put decision, top changes, and strongest evidence in the first screen. Put source/privacy/capture details in a short appendix using plain language.
+   - PR handoff: PR comment or checklist.
+   - System side effects: recommend `agentsight-system-friction` when AgentSight data is available.
+
+## Output Contract
+
+Always include:
+
+- evidence source and time range when available
+- the user's likely decision question
+- observed facts vs inferences
+- evidence gaps
+- privacy mode used, phrased for the reader rather than as schema labels
+- whether raw logs were read and what field categories were extracted
+
+Use redacted summaries by default.
+
+For HTML reports, translate internal terms before writing: "system summary" for cross-boundary evidence, "single-page report" for the output, "analysis boundary" for scope, and category labels for local identifiers.
+
+## Example Requests
+
+```text
+Analyze my last 20 Claude and Codex sessions. Where did the agents waste time and where should I improve AGENTS.md?
+```
+
+```text
+Use this Langfuse export to tell me whether the agent really validated the PR.
+```
+
+```text
+Generate a self-contained HTML report from these agent interaction findings, without raw prompts.
+```

--- a/skills/agent-interaction-insights/agents/openai.yaml
+++ b/skills/agent-interaction-insights/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Agent Interaction Insights"
+  short_description: "Create decision reports from agent logs"
+  default_prompt: "Use $agent-interaction-insights to analyze these AI agent sessions and create a user-facing decision report with the top improvements."

--- a/skills/agent-interaction-insights/references/common-evidence-model.md
+++ b/skills/agent-interaction-insights/references/common-evidence-model.md
@@ -1,0 +1,46 @@
+# Common Evidence Model
+
+Use this as a normalization target. Treat unavailable fields as coverage gaps.
+
+## AgentSession
+
+- `id`: source session id, trace id, or inferred stable id
+- `agent`: Claude Code, Codex, Gemini CLI, custom agent, unknown
+- `project`: cwd, repo, service, workspace, or inferred project
+- `start_time`, `end_time`, `duration`
+- `status`: success, failed, interrupted, partial, unknown
+- `summary_claim`: final agent claim when available
+
+## LlmCall
+
+- `provider`, `model`
+- `input_tokens`, `output_tokens`, `total_tokens`, `cost`
+- `latency`, `status`, `error`
+- `span_id`, `trace_id`, or source row id
+
+## ToolCall
+
+- `tool`: shell, file edit, read, search, browser, MCP tool, custom tool
+- `input_summary`, `output_summary`
+- `status`, `exit_code`, `duration`
+- `target_summary`: command, file, endpoint, issue, PR, or resource id summary when safe
+
+## UserSignal
+
+- correction, interruption, approval, denial, retry request, scope change
+- timestamp and source excerpt summary when available
+
+## ValidationClaim
+
+- claimed check, observed check, scope, status, and source ids
+- use this to compare "verified" or "tests passed" claims with visible evidence
+
+## ExternalSystemFinding
+
+- optional summarized finding from `agentsight-system-friction`
+- include id, severity, claim, and evidence summary
+- do not expand raw AgentSight DB rows here
+
+## Evidence Quality
+
+Use `observed` for fields directly present in the source. Use `inferred` for reconstructed fields. Use `missing` when the source cannot observe a behavior.

--- a/skills/agent-interaction-insights/references/data-source-routing.md
+++ b/skills/agent-interaction-insights/references/data-source-routing.md
@@ -1,0 +1,33 @@
+# Data Source Routing
+
+Choose the source that can answer the user's decision question with the least private data.
+
+## Local Agent Logs
+
+- Claude Code: `~/.claude/projects/**/*.jsonl`, `~/.claude/usage-data/session-meta/*.json`.
+- Codex: `~/.codex/sessions/**/*.jsonl`.
+- Gemini CLI: use exported logs or `agent-session`-derived data when available.
+
+Prefer pre-summarized exports when available. If raw JSONL is necessary, extract only the fields required for the question: timestamps, model/tool category, status, short task/claim summaries, validation claims, user correction markers, and internal session ids when correlation is required. Use full prompt/response text only for private-debug analysis requested by the user.
+
+Use local logs for task intent, transcript flow, model/tool usage, user corrections, and final summaries. State that transcript-only evidence usually cannot prove OS side effects.
+
+## Observability Platforms
+
+- OpenTelemetry GenAI: map `gen_ai.*` spans to LLM calls and tool/agent spans.
+- LangSmith/Langfuse: map traces, runs, observations, scores, feedback, and costs.
+- Datadog MCP: treat MCP results as queried trace facts and preserve links or ids.
+
+Use platform traces for app-reported calls, tools, evals, feedback, latency, cost, and errors. Use system findings for OS-level side effects.
+
+## Plain Transcripts
+
+Extract task, tool calls, commands, visible failures, corrections, and final claims. Label structured fields as inferred.
+
+## Summarized System Findings
+
+Use summarized system findings from `agentsight-system-friction` as external evidence. Correlate internally by session/time when available, and render only redacted command/path/host/session categories in reader-facing output.
+
+## AgentSight Boundary
+
+Use `agentsight-system-friction` for AgentSight record DBs, monitor DBs, and system snapshots. If the user provides already summarized AgentSight findings, treat them as supporting evidence and cite them as external system findings.

--- a/skills/agent-interaction-insights/references/example-patterns.md
+++ b/skills/agent-interaction-insights/references/example-patterns.md
@@ -1,0 +1,71 @@
+# Example Patterns
+
+Use these examples as field-shape hints.
+
+## Usage Inventory
+
+Input:
+
+```json
+{"session_id":"s1","cwd":"/repo","model":"claude-sonnet","total_tokens":42000}
+```
+
+Output:
+
+- Session `s1` belongs to project `/repo`.
+- Token total is session-level; per-call timing and tool status are unavailable.
+- System side effects need external system findings.
+
+## OTel GenAI Span
+
+Input:
+
+```json
+{"name":"chat","attributes":{"gen_ai.system":"anthropic","gen_ai.request.model":"claude-sonnet","gen_ai.usage.input_tokens":1200}}
+```
+
+Output:
+
+- `LlmCall.provider`: `gen_ai.system`
+- `LlmCall.model`: `gen_ai.request.model`
+- `LlmCall.tokens.input`: `gen_ai.usage.input_tokens`
+- `AgentSession.id`: trace id or the strongest available session id
+
+## Summary Mismatch
+
+Input:
+
+```json
+{"final_summary":"all tests passed","observed_check":{"command":"cargo test","exit_code":101}}
+```
+
+Finding:
+
+- `severity`: high
+- `claim`: final summary conflicts with observed validation
+- `evidence`: command and exit code
+- `next_action`: require exact validation commands and statuses in summaries
+
+## Findings To HTML Report
+
+Input:
+
+```json
+[{"severity":"high","claim":"Final summary said tests passed, but cargo test failed","evidence":"cargo test exit_code=101"}]
+```
+
+Output shape: Markdown or HTML with high-severity findings first, then evidence tables, then gaps. Use short redacted prompt summaries by default.
+
+## Collaboration Improvement Report
+
+Input:
+
+```json
+{"reader":"agent owner","decision":"reduce user corrections in the next similar run","finding":"agent implemented pages before confirming the desired output shape"}
+```
+
+Output:
+
+- Lead with the next-run collaboration changes.
+- Explain the user-facing friction in plain language.
+- Put technical source details in a short appendix.

--- a/skills/agent-interaction-insights/references/friction-taxonomy.md
+++ b/skills/agent-interaction-insights/references/friction-taxonomy.md
@@ -1,0 +1,37 @@
+# Friction Taxonomy
+
+Use the smallest category that explains the evidence.
+
+## Categories
+
+- `tool_failure`: tool returned error, timeout, malformed input, permission denial as reported in transcript or trace evidence. Use `agentsight-system-friction` for OS-level exit codes, process crashes, or resource consumption details.
+- `command_failure`: shell/tool command was reported as non-zero, crashed, timed out, or used wrong cwd/env in transcript or trace evidence. Use `agentsight-system-friction` to verify OS-level process facts.
+- `test_failure`: build/test/lint/check failed or was narrowed after failure.
+- `loop_retry`: repeated similar command, tool call, edit, read, or prompt pattern.
+- `context_miss`: missed relevant file, instruction, prior result, or project rule.
+- `goal_drift`: work moved away from the user's stated objective.
+- `summary_mismatch`: final summary conflicts with observed evidence.
+- `resource_waste`: high tokens, latency, repeated tool attempts, or cost without clear interaction progress. Use `agentsight-system-friction` for CPU/RSS/IO/wall-time waste.
+- `evidence_gap`: question cannot be answered from available data.
+
+## Severity
+
+- `high`: affects trust, merge, deployment, review, or recovery decision.
+- `medium`: caused delay, rework, cost, or incomplete validation.
+- `low`: useful optimization or hygiene issue.
+- `info`: context or evidence limitation.
+
+Examples:
+
+- `high`: final summary claims validation passed but visible checks failed; merge or review decision depends on the finding.
+- `medium`: repeated failed command, avoidable expensive retries, or missing validation after code edits.
+- `low`: inefficient file reads, redundant searches, or minor instruction hygiene.
+- `info`: missing timestamps, no transcript coverage, or source format cannot prove side effects.
+
+## Finding Template
+
+- `severity`: high, medium, low, or info
+- `claim`: concrete statement
+- `evidence`: counts, statuses, timestamps, and redacted categories for ids, paths, commands, tools, or agents
+- `inference`: likely cause, clearly labeled
+- `next_action`: focused recommendation

--- a/skills/agent-interaction-insights/references/handoff-contract.md
+++ b/skills/agent-interaction-insights/references/handoff-contract.md
@@ -1,0 +1,28 @@
+# System Summary Input
+
+Use this when consuming already summarized system findings from
+`agentsight-system-friction`. Route raw AgentSight DBs and raw system rows to
+`agentsight-system-friction`.
+
+## Shape
+
+A system summary should contain:
+
+- severity
+- plain-language claim
+- redacted evidence summary
+- optional correlation hints such as time range, tool category, command category,
+  path category, host category, or session category
+- privacy mode
+- whether raw data is included
+
+Use exact local identifiers only internally for correlation or in private-debug
+output requested by the user.
+
+## Use
+
+- Treat the system summary as observed system evidence.
+- Use interaction evidence for user intent, corrections, trust, and workflow.
+- If exact system details are needed, ask for a system-friction analysis.
+- In HTML reports, render system summaries as normal prose or bullets, not as
+  machine-readable schema blocks.

--- a/skills/agent-interaction-insights/references/improvement-classes.md
+++ b/skills/agent-interaction-insights/references/improvement-classes.md
@@ -1,0 +1,50 @@
+# Interaction Improvement Classes
+
+Start from the user's improvement decision, then use evidence to justify changes.
+
+## 1. Reduce User Corrections
+
+Questions:
+
+- Where did the user need to restate scope, privacy, validation, or output expectations?
+- Which instructions should move into AGENTS.md, CLAUDE.md, a checklist, or a workflow gate?
+
+Outputs: correction heatmap, instruction backlog, stop-and-ask conditions.
+
+## 2. Improve Summary Trust
+
+Questions:
+
+- Did final summaries distinguish done, checked, unrun, failed, and inferred?
+- Did validation claims include exact command, scope, status, and timestamp?
+- Did the agent expose sensitive details or unsupported claims in summaries?
+
+Outputs: validation funnel, claim-evidence matrix, summary template changes.
+
+## 3. Reduce Loop And Retry Waste
+
+Questions:
+
+- Which retries repeated the same failed hypothesis?
+- Which tool attempts should have stopped earlier or narrowed scope?
+
+Outputs: retry matrix, retry budget, before-rerun checklist.
+
+## 4. Improve Instructions And Workflow Design
+
+Questions:
+
+- Which repeated behavior should become an instruction, deterministic tool path, eval, or policy?
+- Which instructions were too vague or too easy to ignore?
+
+Outputs: workflow backlog, candidate evals, policy changes, task framing changes.
+
+## 5. Compare Agent Fit
+
+Questions:
+
+- Which tasks are safe for autonomy, which need checkpoints, and which should use deterministic tools?
+- How do agents, models, prompts, or tool policies differ by correction rate, validation trust, and retry waste?
+- Which model variants or agent configurations produce the best trust/cost tradeoff for each task class?
+
+Outputs: task-fit matrix, before/after comparison, adoption recommendation.

--- a/skills/agent-interaction-insights/references/privacy-modes.md
+++ b/skills/agent-interaction-insights/references/privacy-modes.md
@@ -1,0 +1,26 @@
+# Privacy Modes
+
+Use the least revealing mode that answers the question. Name the mode in the output.
+
+## private-debug
+
+Use for local troubleshooting. Exact local identifiers and command snippets may be used when they are necessary to solve the local problem and the user requested private debugging.
+
+## team-share
+
+Use for internal reports. Summarize prompts, responses, and command output. Prefer counts, statuses, durations, short task/claim summaries, and reader-safe categories.
+
+## public-share
+
+Use aggregate evidence only. Prefer anonymous categories, coarse time windows, counts, and outcome summaries.
+
+## Sensitive Findings
+
+Report secret access as a class and path pattern, not a value:
+
+- good: `read cloud credential file under ~/.aws/...`
+- bad: printing key material or token contents
+
+## Missing Evidence
+
+Do not write "the agent did not do X" when the source cannot observe X. Write "this source did not provide evidence of X" instead.

--- a/skills/agent-interaction-insights/references/report-shapes.md
+++ b/skills/agent-interaction-insights/references/report-shapes.md
@@ -1,0 +1,84 @@
+# Report Shapes
+
+Choose the smallest shape that answers the user's question.
+
+Routing:
+
+- Immediate answer → Concise Findings
+- Code-review handoff → PR Review Comment
+- Recovery context → Incident Brief
+- Full analysis or shareable output → Decision HTML Report (default); text-only when requested
+- Management update → Team Brief
+
+## Concise Findings
+
+Use for quick analysis. Structure:
+
+1. Decision question.
+2. What should change next.
+3. 3-7 recommendations ordered by expected leverage.
+4. Supporting evidence and confidence.
+5. Evidence gaps.
+
+## Inventory Table
+
+Use when the user asks what happened across sessions. Include sessions by project, agent, model, status, duration, tokens/cost, and tool counts when available.
+
+## PR Review Comment
+
+Use for code-review handoff. Structure:
+
+1. Trust verdict or caveat.
+2. Validation evidence: checks run and statuses.
+3. File/process/network side-effect notes.
+4. Reviewer checklist.
+
+## Incident Brief
+
+Use for recovery. Structure:
+
+1. What changed.
+2. Timeline of relevant actions.
+3. Suspected cause, marked as inference.
+4. Recovery or rollback targets.
+5. Evidence gaps.
+
+## Decision HTML Report
+
+Use for full analysis or shareable output. Build a self-contained single file (inline CSS/JS, no backend, no fetch, no external assets).
+
+Reader: decision owner, reviewer, team lead, or agent owner. Translate evidence into decision language and avoid exposing the report-generation process.
+
+Before writing:
+
+1. Write a one-sentence reader/decision contract.
+2. First viewport: executive decision, top 3-5 changes, highest-confidence evidence in plain language.
+3. Technical details in an appendix using reader-safe categories.
+
+Section order:
+
+1. Executive decision: what to trust, review, or change.
+2. Next changes: 3-5 improvements with owner and confidence.
+3. Decision overview: 3-5 modules matching the decision question.
+4. Evidence in plain language: sources, observations, inferences, gaps.
+5. Workflow backlog: instructions/policies to change before the next run.
+6. Detailed findings: only as needed.
+7. Appendix: source type, field categories, privacy notes, and evidence gaps.
+
+Decision modules (pick 3-5):
+
+- Trust verdict
+- Validation coverage
+- Correction hotspots
+- Retry waste
+- Task-fit matrix
+- Instruction backlog
+- Evidence coverage
+
+Interactive controls may filter findings or copy a reader-facing summary using inline data.
+
+For reader-facing HTML, use plain labels rather than schema names. Write "system summary" for external system evidence, "single-page report" for the output, "analysis boundary" for scope, and category labels for local identifiers.
+
+## Team Brief
+
+Use for non-interactive sharing. Keep it concise, avoid raw content, and focus on decisions: trust, cost, risk, follow-up.

--- a/skills/agentsight-system-friction/SKILL.md
+++ b/skills/agentsight-system-friction/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: agentsight-system-friction
+description: "Analyze AgentSight record snapshots, SQLite sessions, monitor DBs, and process/file/network/resource evidence to recommend concrete operational improvements to existing agent runs—timeouts, resource budgets, retry behavior, service lifecycle cleanup, network binding, file/log hygiene, and capture quality—and generate decision-oriented, reader-safe system HTML reports."
+---
+
+# AgentSight System Friction
+
+## Goal
+
+Use AgentSight evidence to recommend operational improvements for agent runs: resource budgets, retry behavior, service lifecycle, cleanup/recovery, network binding, file/log hygiene, tool/MCP behavior checks, and capture quality. Use system metadata, not raw conversation payloads. Default reports should help an owner improve the next run using changes to existing commands, configs, hooks, and workflows; they should not expose the local machine's private identifiers.
+
+## Workflow
+
+0. Privacy mode: Default to `team-share`. Read `references/privacy-modes.md` before including paths, commands, hosts, headers, or secret-adjacent details. For HTML reports and examples, use reader-safe summaries: path categories, command categories, host categories, port classes, session categories, resource windows, source types, counts, durations, and operating decisions. Exact local identifiers belong only in private-debug work requested by the user.
+
+1. Route evidence to reference docs:
+   - Sources and limits: `references/agentsight-sources.md`
+   - Evidence model: `references/system-evidence-model.md`
+   - Improvement classes: `references/operational-improvement-classes.md`
+   - Friction taxonomy: `references/system-friction-taxonomy.md`
+   - Correlation summary: `references/handoff-contract.md`
+   - Output shapes: `references/report-shapes.md`
+   - Examples: `references/example-patterns.md`
+
+2. Build system facts:
+   - Summarize session/process correlation, command exits, long-running processes, file activity, network endpoints, resource outliers.
+   - Prefer timestamps, statuses, counts, durations, and categories over LLM payload columns.
+   - Distinguish monitor aggregates from record-level evidence.
+   - Preserve join keys internally for later correlation, but render category labels in reader-facing HTML by default.
+   - If user intent is needed, state that it requires `agent-interaction-insights` or a user-provided summary.
+
+   If the user provides both system data and raw interaction logs, analyze only system evidence here. Route raw conversation data to `agent-interaction-insights`.
+
+3. Recommend operational changes:
+   - Lead with 3-7 changes ranked by expected next-run improvement: less time, memory, disk churn, network exposure, cleanup burden, or uncertainty.
+   - Prefer changes that fit the user's existing workflow: command timeouts, retry budgets, narrow-first reruns, cache/reuse rules, service leases, shutdown hooks, localhost binding, log rotation, redacted summaries, and capture fields.
+   - Each: observed system effect, likely cause if inferable, concrete change, expected next-run benefit, confidence, success condition.
+   - Include findings as supporting evidence. Use interaction summaries for user intent.
+
+4. Shape output:
+   - Quick diagnosis: what command, workflow, lifecycle, network, cleanup, or capture rule should change + compact evidence.
+   - Full analysis or shareable output: self-contained HTML report. Name the reader and their operating decision before writing. Put verdict, top actions, and strongest evidence in the first screen. Technical details go in an appendix.
+   - Incident recovery: cleanup and rollback changes, not just timeline.
+   - Policy/MCP verification: pass/fail/unknown behavior + concrete workflow or configuration changes.
+   - Conversation-level context needed: emit a compact system summary and recommend pairing with `agent-interaction-insights`.
+
+## Output Contract
+
+Always include:
+
+- AgentSight source type: record snapshot, saved SQLite session, monitor DB, report export, or live/local summary
+- time range and session categories when available
+- observed system facts vs inferred causes
+- correlation notes for optional interaction analysis
+- evidence gaps and collection limits
+- privacy mode used
+- whether raw data is included, phrased for the reader rather than as schema labels
+- the low-friction improvement path: budget, timeout, retry rule, service cleanup, network binding, file/log lifecycle, or capture field
+
+Use redacted summaries by default.
+
+For HTML reports, render local evidence as operating categories: source type, time window, session category, command category, path category, host category, port class, resource window, and capture gap. Put machine-readable correlation data only in private-debug output or a separate file requested by the user.
+
+## Example Requests
+
+```text
+Analyze this AgentSight monitor DB for long-running processes and resource-heavy agent sessions.
+```
+
+```text
+Use this AgentSight report export to tell me whether the agent touched files outside the workspace or contacted unexpected hosts.
+```
+
+```text
+Create a system-level incident brief from this AgentSight record snapshot, with cleanup actions first.
+```

--- a/skills/agentsight-system-friction/agents/openai.yaml
+++ b/skills/agentsight-system-friction/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "AgentSight System Friction"
+  short_description: "Create ops decisions from system evidence"
+  default_prompt: "Use $agentsight-system-friction to analyze this AgentSight evidence and create a user-facing operating decision report with the top workflow, resource, cleanup, network, and capture improvements."

--- a/skills/agentsight-system-friction/references/agentsight-sources.md
+++ b/skills/agentsight-system-friction/references/agentsight-sources.md
@@ -1,0 +1,29 @@
+# AgentSight Sources
+
+Use AgentSight/system evidence in this skill. Route raw Claude/Codex/Gemini transcripts to `agent-interaction-insights`. If AgentSight exports contain LLM request/response payloads, use metadata/join keys instead.
+
+## Record Snapshot
+
+Use exported record snapshots for the strongest per-run evidence:
+
+```text
+agentsight report export --db <db> -o snapshot.json
+```
+
+Record snapshots may include LLM call rows, audit rows, process nodes, stdio, file, network, and resource facts depending on capture mode. Use LLM row ids, timestamps, statuses, model names, and token counts only when needed for correlation; do not inspect prompt/response bodies in this skill.
+
+## Saved SQLite Session
+
+Use saved sessions when the user provides a DB path or asks about a specific recorded run. Prefer structured export when available; inspect table layout only when needed.
+
+## Monitor DB
+
+Use `~/.agentsight/monitor/monitor-*.db` for sampled, long-running monitor evidence. Treat it as aggregate or windowed evidence, not a complete trace.
+
+## Live Or Local Summary
+
+Use command output or user-provided summaries as system facts only if they include AgentSight source context. Ask for a DB/export when the claim needs stronger evidence.
+
+## Collection Limits
+
+State which capture modes were present: process, stdio, SSL/HTTP, file, network, resource, native session correlation. Missing capture mode means missing evidence, not absence of behavior.

--- a/skills/agentsight-system-friction/references/example-patterns.md
+++ b/skills/agentsight-system-friction/references/example-patterns.md
@@ -1,0 +1,72 @@
+# Example Patterns
+
+Use these examples as field-shape hints.
+
+## Long-Running Process
+
+Input:
+
+```json
+{"session_id":"s1","pid":1234,"process":"npm run dev","duration_minutes":127,"still_running":true}
+```
+
+Finding:
+
+- `severity`: medium, or high if it blocks ports/resources
+- `claim`: agent left a process running after the task window
+- `evidence`: session category, command category, duration; keep exact ids/pids internal unless private-debug is requested
+- `next_action`: give the service a lease and shutdown hook; preserve a short owner/log summary if it stays active
+
+## File Scope Risk
+
+Input:
+
+```json
+{"session_id":"s2","operation":"read","path":"/home/user/.aws/credentials"}
+```
+
+Finding:
+
+- `severity`: high
+- `claim`: agent accessed secret-adjacent material outside the workspace
+- `evidence`: path pattern only, not file contents
+- `next_action`: mask secret-adjacent paths by default and emit a rotation recommendation if exposure is confirmed; correlate with interaction intent
+
+## Resource Waste
+
+Input:
+
+```json
+{"session_id":"s3","command":"cargo test","exit_code":101,"count":5,"wall_minutes":28}
+```
+
+Finding:
+
+- `severity`: medium
+- `claim`: repeated failing command consumed time without a successful system result
+- `evidence`: command summary, exit code, repeat count, duration
+- `next_action`: inspect the first failure, rerun the narrowest relevant command, and stop repeated full reruns after the retry budget is spent
+
+## Correlate With Interaction Findings
+
+Output a redacted correlation summary instead of reading transcripts:
+
+```json
+{"severity":"medium","time_range":"10:22-10:39","command_category":"test command","result":"failed"}
+```
+
+The interaction skill can use this summary to compare against user goals or final claims.
+
+## User-Facing System Report
+
+Input:
+
+```json
+{"reader":"agent owner","decision":"decide what to change before the next agent run","finding":"resource peaks, long-running services, network listeners, and state file growth appear in monitor evidence"}
+```
+
+Output:
+
+- Lead with the 3-5 concrete workflow changes most likely to improve the next run.
+- Explain resource pressure, service lifecycle, network exposure, cleanup, and capture confidence in plain operator language before showing tables.
+- Put technical source details in a short appendix.

--- a/skills/agentsight-system-friction/references/handoff-contract.md
+++ b/skills/agentsight-system-friction/references/handoff-contract.md
@@ -1,0 +1,32 @@
+# Correlation Summary
+
+Use this to pass system findings to `agent-interaction-insights` without opening
+raw AgentSight data.
+
+## Shape
+
+A correlation summary should contain:
+
+- severity
+- plain-language system claim
+- redacted evidence summary
+- optional correlation hints such as time range, tool category, command category,
+  path category, host category, or session category
+- privacy mode
+- whether raw data is included
+
+For reader-facing HTML, write this as prose or bullets. Use exact join keys only
+internally or in private-debug output requested by the user.
+
+## Use
+
+- Keep evidence summaries compact and redacted.
+- Render shareable HTML with operating categories, short evidence summaries, and
+  capture gaps.
+- If user intent is needed, hand this summary to `agent-interaction-insights`.
+
+## Optional Interaction Summary Input
+
+If the user supplies an already summarized interaction finding, use it only as
+context for ranking system findings. Route raw transcripts to
+`agent-interaction-insights`.

--- a/skills/agentsight-system-friction/references/operational-improvement-classes.md
+++ b/skills/agentsight-system-friction/references/operational-improvement-classes.md
@@ -1,0 +1,51 @@
+# Operational Improvement Classes
+
+Start from the observed system effect and the concrete change to the user's existing workflow. Use AgentSight system evidence to justify the change.
+
+## 1. Reduce Blast Radius Without Slowing The User
+
+Questions:
+
+- Which paths, hosts, commands, ports, or process types caused avoidable risk, noise, or cleanup work?
+- Which existing command wrapper, config, or hook should set default cwd, environment, path masking, localhost binding, or TTL?
+- Did the run access home, secret-adjacent, external network, or workspace-external resources?
+- Did containerized or sandboxed agents stay inside the expected namespace and mount/network boundaries?
+
+Outputs: path impact board, network binding changes, service lease changes, secret-adjacent handling.
+
+## 2. Reduce System Waste
+
+Questions:
+
+- Which repeated commands, wait states, CPU/RSS/IO outliers, or long windows produced little progress?
+- Which tests or commands need timeout, retry budget, narrow-first strategy, caching, or automatic downgrade?
+
+Outputs: resource heatmap, repeated command board, timeout candidates, rerun budget, cache candidates.
+
+## 3. Lower Cleanup And Recovery Cost
+
+Questions:
+
+- Which processes, listeners, temp files, or workspace mutations need lifecycle management?
+- What should be cleaned automatically at task end, and what should be rollback-ready?
+
+Outputs: cleanup queue, process lifetime board, temp file lifecycle board, rollback targets.
+
+## 4. Verify Tool, MCP, Or Runtime Policy Claims
+
+Questions:
+
+- Did a tool claiming read-only, no-network, workspace-local, or no-secret-access actually behave that way?
+- Which controls are pass, fail, or unknown from available capture modes?
+
+Outputs: dynamic verification matrix, behavior verdict board, workflow or configuration changes.
+
+## 5. Improve Next-Run Evidence Quality
+
+Questions:
+
+- Which capture modes, join keys, schemas, or export fields were missing?
+- What should be captured next time so interaction and system reports correlate cleanly?
+- Were AgentSight sessions joinable with agent-native session ids, process ids, and timestamps?
+
+Outputs: capture quality board, evidence gap map, join-key coverage board, export field changes.

--- a/skills/agentsight-system-friction/references/privacy-modes.md
+++ b/skills/agentsight-system-friction/references/privacy-modes.md
@@ -1,0 +1,22 @@
+# Privacy Modes
+
+Use the least revealing mode that answers the system question. Name the mode in the output.
+
+## private-debug
+
+Exact local identifiers, command snippets, and hosts may be used when they are necessary to solve the local problem and the user requested private debugging.
+
+## team-share
+
+Summarize commands and path patterns. Prefer statuses, counts, durations, resource magnitudes, source types, and host/path/process/session categories.
+
+## public-share
+
+Use aggregate evidence only. Prefer anonymous categories, coarse time windows, counts, and operating outcomes.
+
+## Sensitive Findings
+
+Report sensitive access as a class and path pattern, not a value:
+
+- good: `read cloud credential file under ~/.aws/...`
+- bad: printing key material, token contents, or auth headers

--- a/skills/agentsight-system-friction/references/report-shapes.md
+++ b/skills/agentsight-system-friction/references/report-shapes.md
@@ -1,0 +1,75 @@
+# Report Shapes
+
+Choose the smallest shape that answers the system question.
+
+Routing:
+
+- Immediate diagnosis → System Findings
+- Recovery or rollback → Incident Brief
+- Tool/MCP/runtime-policy verification → Policy Or MCP Verification
+- Full analysis or shareable output → Decision HTML Report (default); text-only when requested
+
+## System Findings
+
+Use for quick diagnosis:
+
+1. AgentSight source and time range.
+2. What command, workflow, lifecycle, network, cleanup, or capture rule should change next.
+3. 3-7 recommendations ordered by risk, waste, or cleanup reduction.
+4. Evidence table with reader-safe correlation categories.
+5. Capture gaps and next-run instrumentation changes.
+
+## Incident Brief
+
+Use for recovery:
+
+1. What changed on the machine.
+2. Cleanup and rollback targets.
+3. Timeline of process/file/network/resource events.
+4. Suspected system cause, marked as inference.
+5. Prevention changes: timeout, resource budget, cleanup hook, network binding, or capture field.
+
+## Policy Or MCP Verification
+
+Use for tool, plugin, MCP, or runtime-policy checks:
+
+1. Claimed policy.
+2. Observed system behavior.
+3. Pass/fail/unknown verdict per observed behavior.
+4. Evidence rows and capture gaps.
+
+## Decision HTML Report
+
+Use for full system analysis or shareable output. Build a self-contained single file (no backend, no fetch, no external assets, findings first, technical details summarized at the end).
+
+Reader: agent owner, operator, security reviewer, or team lead. Translate AgentSight rows into operating decisions.
+
+Before writing:
+
+1. Write a one-sentence reader/decision contract.
+2. First viewport: operating verdict, top 3-5 actions, highest-confidence evidence in plain language.
+3. Technical details in an appendix using reader-safe categories.
+
+Section order:
+
+1. Executive decision: what should change before the next run.
+2. Immediate actions: timeout, budget, retry, cleanup, binding, logging, or capture changes with done conditions.
+3. System overview: 3-5 modules matching the system question.
+4. Operational changes: command budgets, service lifecycle, network binding, file/log hygiene, capture fields.
+5. Evidence in plain language: facts, inferences, monitor vs record limits.
+6. Detailed evidence tables with category labels rather than exact private identifiers.
+7. Appendix: source summary, capture coverage, privacy notes, and optional human-readable correlation summary.
+
+Operating modules (pick 3-5):
+
+- Operating verdict
+- Resource pressure
+- System impact
+- Cleanup queue
+- Network exposure
+- Capture confidence
+- Operational backlog
+
+Interactive controls may filter findings or copy a reader-facing system summary using inline data.
+
+For reader-facing HTML, convert local identifiers to categories such as "private project directory", "long-running local service", "external HTTPS target", "workspace-external path", or "resource peak window".

--- a/skills/agentsight-system-friction/references/system-evidence-model.md
+++ b/skills/agentsight-system-friction/references/system-evidence-model.md
@@ -1,0 +1,36 @@
+# System Evidence Model
+
+Normalize AgentSight evidence into these records. Keep exact join keys internally for correlation; render reader-facing reports with category labels unless private-debug output is requested.
+
+## SessionProcess
+
+- `session_id`, `agent`, `project`, `time_range`
+- `pid`, `ppid`, `process_name`, `command_summary`
+- `start_time`, `end_time`, `duration`, `exit_status`
+
+## CommandEffect
+
+- `session_id`, `pid`, `command_summary`
+- `cwd_summary`, `exit_code`, `duration`, `status`
+- `stdout_summary`, `stderr_summary` when safe
+
+## FileEffect
+
+- `session_id`, `pid`, `path_pattern`
+- `operation`: read, write, create, delete, rename, chmod, unknown
+- `workspace_relation`: inside workspace, outside workspace, home, system, unknown
+
+## NetworkEffect
+
+- `session_id`, `pid`, `host`, `port`, `protocol`
+- `direction`, `request_class`, `status`
+- never include raw auth headers or full HTTP bodies by default
+
+## ResourceEffect
+
+- `session_id`, `pid`, `cpu`, `rss`, `io`, `duration`
+- sample window and aggregation method when available
+
+## Join Keys
+
+Preserve available `session_id`, `trace_id`, timestamps, pid, command hash/summary, and source row ids in working notes or machine-readable private-debug output when correlation is needed. For HTML reports, convert them to reader-safe labels such as session category, time window, command category, path category, host category, or resource window category.

--- a/skills/agentsight-system-friction/references/system-friction-taxonomy.md
+++ b/skills/agentsight-system-friction/references/system-friction-taxonomy.md
@@ -1,0 +1,30 @@
+# System Friction Taxonomy
+
+Use the smallest category that explains the system evidence.
+
+## Categories
+
+- `process_failure`: command exited non-zero, crashed, timed out, wrong cwd/env.
+- `long_running_process`: process remained alive longer than expected or after task end.
+- `file_scope_risk`: file activity outside workspace, unexpected deletes, broad writes, or secret-adjacent paths.
+- `network_scope_risk`: unexpected host, protocol, port, or request class.
+- `resource_waste`: high CPU, RSS, IO, wall time, or repeated expensive command.
+- `capture_gap`: AgentSight source lacks the capture mode needed for the claim.
+- `correlation_gap`: system event cannot be confidently attached to a session or agent.
+
+## Severity
+
+- `high`: affects trust, safety, data exposure, merge/deploy decision, or incident recovery.
+- `medium`: caused delay, cleanup, high cost, resource pressure, or incomplete validation.
+- `low`: useful optimization or hygiene issue.
+- `info`: evidence limitation or context needed for correlation.
+
+## Finding Template
+
+- `severity`: high, medium, low, or info
+- `claim`: concrete system-level statement
+- `evidence`: statuses, timestamps, samples, durations, resource numbers, and redacted categories for sessions, processes, commands, paths, and hosts
+- `inference`: limited to system cause unless interaction evidence is supplied
+- `next_action`: cleanup, verify, rerun with capture mode, or correlate with interaction summary
+
+Use `agent-interaction-insights` when user intent, final summary trust, or conversation-level corrections are needed to interpret a system finding.


### PR DESCRIPTION
## Summary

- Add repo-local `agent-interaction-insights` and `agentsight-system-friction` skills with evidence-boundary-specific references.
- Add static example HTML reports under `docs/skills/examples/` for interaction insights and system friction analysis.
- Add a design note and blog draft describing the skills-over-fixed-dashboard direction.

## Why

This frames AI agent observability as evidence-backed, task-specific analysis rather than another fixed dashboard. The interaction skill focuses on conversation and trace semantics; the AgentSight system skill focuses on process, file, network, resource, cleanup, and capture evidence.

## Validation

- `python3 /home/yunwei37/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agentsight-system-friction`
- `python3 /home/yunwei37/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agent-interaction-insights`
- `git diff --cached --check`
- Scanned the system skill and example page for stale approval/profile/permission-bypass wording after the latest revision.
