### PR TITLE
Keep agentsight top TUI as the default

### DIFF
--- a/collector/src/cmd_perf.rs
+++ b/collector/src/cmd_perf.rs
@@ -50,6 +50,15 @@ pub(crate) fn run_top_query(
     Ok(())
 }
 
+pub(crate) fn load_top_output<'a>(
+    db: &'a str,
+    limit: usize,
+    options: &TopOptions,
+) -> Result<AgentTopOutput<'a>, Box<dyn std::error::Error + Send + Sync>> {
+    let (snapshot, resources) = load_snapshot_and_resources(db)?;
+    Ok(build_session_top(db, &snapshot, &resources, limit.clamp(1, 50), options))
+}
+
 fn build_session_top<'a>(
     db: &'a str,
     snapshot: &Snapshot,

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 eunomia-bpf org.
 
 use crate::binary_extractor::BinaryExtractor;
+use crate::cmd_perf::load_top_output;
 use crate::cmd_perf_live::{LiveEbpfCapture, start_live_ebpf_capture};
 use crate::output::{AgentTopOutput, TopOptions, draw_live_top_tui, next_view_key};
 use crate::view::live_top::LiveView;
@@ -20,14 +21,35 @@ pub(crate) async fn run_live_top_tui(
     binary_extractor: &BinaryExtractor,
     interval_secs: u64,
     limit: usize,
+    count: Option<u32>,
     options: &TopOptions,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let capture = start_live_ebpf_capture(binary_extractor, options).await;
-    let result = run_live_top_tui_loop(interval_secs, limit, options, capture.as_ref());
+    let mut live_view = LiveView::default();
+    let result = run_top_tui_loop(interval_secs, limit, count, options, |display_limit, options| {
+        let capture_snapshot = capture.as_ref().map(LiveEbpfCapture::snapshot);
+        let mut top = live_view.refresh(capture_snapshot.as_ref(), display_limit, options)?;
+        if let Some(note) = capture.as_ref().and_then(|capture| capture.start_note()) {
+            top.notes.push(note.to_string());
+        }
+        Ok(top)
+    });
     if let Some(capture) = capture {
         capture.stop();
     }
     result
+}
+
+pub(crate) fn run_saved_top_tui(
+    db: &str,
+    interval_secs: u64,
+    limit: usize,
+    count: Option<u32>,
+    options: &TopOptions,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    run_top_tui_loop(interval_secs, limit, count, options, |display_limit, options| {
+        load_top_output(db, display_limit, options)
+    })
 }
 
 struct LiveTopTerminalGuard;
@@ -49,12 +71,19 @@ impl Drop for LiveTopTerminalGuard {
     }
 }
 
-fn run_live_top_tui_loop(
+fn run_top_tui_loop<'a, F>(
     interval_secs: u64,
     limit: usize,
+    count: Option<u32>,
     options: &TopOptions,
-    capture: Option<&LiveEbpfCapture>,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    mut refresh: F,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    F: FnMut(
+        usize,
+        &TopOptions,
+    ) -> Result<AgentTopOutput<'a>, Box<dyn std::error::Error + Send + Sync>>,
+{
     let mut options = options.clone();
     let mut display_limit = limit.clamp(1, 100);
     let interval = Duration::from_secs(interval_secs.max(1));
@@ -63,30 +92,27 @@ fn run_live_top_tui_loop(
     let mut terminal = Terminal::new(backend)?;
     terminal.clear()?;
 
-    let mut live_view = LiveView::default();
-    let mut current_top: Option<AgentTopOutput<'static>> = None;
+    let mut current_top: Option<AgentTopOutput<'a>> = None;
     let mut selected = 0usize;
     let mut paused = false;
     let mut show_help = false;
     let mut show_diagnostics = false;
     let mut last_refresh = Instant::now() - interval;
     let mut force_refresh = true;
+    let mut refreshes = 0u32;
 
     loop {
         if force_refresh
             || (!paused && (current_top.is_none() || last_refresh.elapsed() >= interval))
         {
-            let capture_snapshot = capture.map(LiveEbpfCapture::snapshot);
-            let mut top = live_view.refresh(capture_snapshot.as_ref(), display_limit, &options)?;
-            if let Some(note) = capture.and_then(LiveEbpfCapture::start_note) {
-                top.notes.push(note.to_string());
-            }
+            let mut top = refresh(display_limit, &options)?;
             sort_agent_rows(&mut top.rows, &options.sort);
             top.rows.truncate(display_limit);
             clamp_selected(&mut selected, top.rows.len());
             current_top = Some(top);
             last_refresh = Instant::now();
             force_refresh = false;
+            refreshes += 1;
         }
 
         let top = current_top
@@ -106,7 +132,7 @@ fn run_live_top_tui_loop(
             );
         })?;
 
-        if crate::shutdown_requested() {
+        if count.is_some_and(|max| refreshes >= max) || crate::shutdown_requested() {
             break;
         }
 

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -53,7 +53,7 @@ use cmd_monitor::{
 };
 use cmd_perf::run_top_query;
 use cmd_perf_live::run_live_top_query;
-use cmd_perf_tui::run_live_top_tui;
+use cmd_perf_tui::{run_live_top_tui, run_saved_top_tui};
 use cmd_trace::{
     OtelConfig, TraceConfig, convert_runner_error, run_trace, start_web_server_if_enabled,
 };
@@ -128,16 +128,21 @@ fn interactive_terminal_available() -> bool {
     unsafe { libc::isatty(libc::STDIN_FILENO) == 1 && libc::isatty(libc::STDOUT_FILENO) == 1 }
 }
 
-fn command_uses_live_top_tui(cli: &Cli) -> bool {
+fn top_uses_tui(plain: bool, interactive: bool) -> bool {
+    !plain && interactive
+}
+
+fn top_uses_monitor_snapshot(plain: bool, monitor_active: bool) -> bool {
+    plain && monitor_active
+}
+
+fn command_uses_top_tui(cli: &Cli) -> bool {
     matches!(
         &cli.command,
         Commands::Top {
-            db: None,
-            count: None,
-            once: false,
-            plain: false,
+            plain,
             ..
-        } if interactive_terminal_available()
+        } if top_uses_tui(*plain, interactive_terminal_available())
     )
 }
 
@@ -226,10 +231,10 @@ enum Commands {
         /// Number of refreshes before exiting
         #[arg(long)]
         count: Option<u32>,
-        /// Print one snapshot and exit
+        /// Render one refresh and exit
         #[arg(long)]
         once: bool,
-        /// Use plain table output instead of the interactive live TUI
+        /// Use plain table output instead of the interactive TUI
         #[arg(long)]
         plain: bool,
     },
@@ -572,7 +577,7 @@ async fn main() {
 
 async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let cli = Cli::parse();
-    let suppress_terminal_output = command_uses_live_top_tui(&cli);
+    let suppress_terminal_output = command_uses_top_tui(&cli);
     init_logging(suppress_terminal_output);
 
     // Setup signal handler for graceful shutdown
@@ -640,7 +645,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             limit,
             count,
             once,
-            plain: _,
+            plain,
         } => {
             let count = if *once { Some(1) } else { *count };
             let options = TopOptions {
@@ -649,7 +654,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 sort: sort.clone(),
                 view: view.clone(),
             };
-            run_top_query(db, *interval, *limit, count, &options)?;
+            if top_uses_tui(*plain, interactive_terminal_available()) {
+                run_saved_top_tui(db, *interval, *limit, count, &options)?;
+            } else {
+                run_top_query(db, *interval, *limit, count, &options)?;
+            }
         }
         Commands::Top {
             db: None,
@@ -661,8 +670,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             limit,
             count,
             once,
-            plain: _,
-        } if active_monitor_db_path().is_some() => {
+            plain,
+        } if top_uses_monitor_snapshot(*plain, active_monitor_db_path().is_some()) => {
             let count = if *once { Some(1) } else { *count };
             let options = TopOptions {
                 pid: *pid,
@@ -789,8 +798,8 @@ async fn run_with_extractor(
                 sort: sort.clone(),
                 view: view.clone(),
             };
-            if !*plain && count.is_none() && interactive_terminal_available() {
-                run_live_top_tui(binary_extractor, *interval, *limit, &options).await?;
+            if top_uses_tui(*plain, interactive_terminal_available()) {
+                run_live_top_tui(binary_extractor, *interval, *limit, count, &options).await?;
             } else {
                 run_live_top_query(binary_extractor, *interval, *limit, count, &options).await?;
             }
@@ -958,4 +967,27 @@ async fn run_with_extractor(
         _ => unreachable!("handled in run()"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{top_uses_monitor_snapshot, top_uses_tui};
+
+    #[test]
+    fn default_interactive_top_uses_tui() {
+        assert!(top_uses_tui(false, true));
+    }
+
+    #[test]
+    fn only_plain_or_non_tty_disable_tui() {
+        assert!(!top_uses_tui(true, true));
+        assert!(!top_uses_tui(false, false));
+    }
+
+    #[test]
+    fn monitor_snapshot_requires_explicit_plain_mode() {
+        assert!(top_uses_monitor_snapshot(true, true));
+        assert!(!top_uses_monitor_snapshot(false, true));
+        assert!(!top_uses_monitor_snapshot(true, false));
+    }
 }


### PR DESCRIPTION
## Summary

Make `agentsight top` follow normal `top` semantics:

- interactive terminal + no `--plain` uses the TUI by default
- `--plain` is the explicit table-output mode
- `--db` selects the saved-session data source, but no longer forces table output
- `--once` / `--count` are refresh/exit controls, not display-mode selectors
- background monitor data is only used for top output when `--plain` is explicit

## Validation

- `cargo test --manifest-path collector/Cargo.toml`
- `cargo clippy --manifest-path collector/Cargo.toml --all-targets -- -D warnings`
- `cargo run --manifest-path collector/Cargo.toml -- top --plain --once`
- PTY smoke with `script`: `top --once` enters/leaves the alternate screen
- PTY smoke with `script`: `top --db <real agentsight db> --once` enters/leaves the alternate screen

## Review

Claude reviewed `3148f8a` and reported no blockers. Residual notes were limited to optional integration-test coverage for PTY `--db` TUI behavior and minor static-db refresh inefficiency.
