### PR TITLE
Fix release smoke checks and publish agentpprof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,18 @@ jobs:
         cd collector
         cargo test --verbose
 
+    - name: Build agentpprof
+      run: |
+        cargo build --manifest-path agentpprof/Cargo.toml --verbose
+
+    - name: Run agentpprof clippy (deny warnings)
+      run: |
+        cargo clippy --manifest-path agentpprof/Cargo.toml --all-targets -- -D warnings
+
+    - name: Run agentpprof tests
+      run: |
+        cargo test --manifest-path agentpprof/Cargo.toml --verbose
+
     # Rebuild the C unit tests under AddressSanitizer and run them. Done last and
     # after `make clean` so the ASan objects don't replace the BPF binaries that
     # the Rust collector build embeds above.
@@ -211,6 +223,8 @@ jobs:
             echo "::notice::Git tag ${TAG} already exists; trying next patch version."
           elif crates_io_version_exists "agentsight" "$VERSION"; then
             echo "::notice::crates.io agentsight ${VERSION} already exists; trying next patch version."
+          elif crates_io_version_exists "agentpprof" "$VERSION"; then
+            echo "::notice::crates.io agentpprof ${VERSION} already exists; trying next patch version."
           else
             break
           fi
@@ -233,15 +247,20 @@ jobs:
 
         sed -i "s/^version = \".*\"/version = \"$AGENT_SESSION_VERSION\"/" agent-session/Cargo.toml
         sed -i "s/agent-session = { version = \"[^\"]*\", path = \"..\\/agent-session\" }/agent-session = { version = \"$AGENT_SESSION_VERSION\", path = \"..\\/agent-session\" }/" collector/Cargo.toml
+        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" agentpprof/Cargo.toml
+        sed -i "s/agent-session = { version = \"[^\"]*\", path = \"..\\/agent-session\" }/agent-session = { version = \"$AGENT_SESSION_VERSION\", path = \"..\\/agent-session\" }/" agentpprof/Cargo.toml
         cd collector
         cargo generate-lockfile
         cd ..
+        cargo generate-lockfile --manifest-path agentpprof/Cargo.toml
 
         echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
         echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
         echo "agent_session_version=${AGENT_SESSION_VERSION}" >> "$GITHUB_OUTPUT"
+        echo "agentpprof_version=${VERSION}" >> "$GITHUB_OUTPUT"
         echo "Using release version v${VERSION}"
         echo "Using agent-session version ${AGENT_SESSION_VERSION}"
+        echo "Using agentpprof version ${VERSION}"
 
     - name: Setup Node.js
       uses: actions/setup-node@v3
@@ -256,7 +275,9 @@ jobs:
           make git clang llvm pkg-config build-essential
 
     - name: Build package
-      run: make build
+      run: |
+        make build
+        cargo build --release --manifest-path agentpprof/Cargo.toml
 
     - name: Commit release snapshot
       id: commit_release
@@ -270,7 +291,7 @@ jobs:
         # build.rs vendors generated BPF/frontend assets into collector/vendor.
         # Commit the full release snapshot before tagging or publishing so the
         # GitHub release, crates.io package, and master source agree.
-        git add agent-session/Cargo.toml collector/Cargo.toml collector/Cargo.lock collector/vendor
+        git add agent-session/Cargo.toml collector/Cargo.toml collector/Cargo.lock collector/vendor agentpprof/Cargo.toml agentpprof/Cargo.lock
         if git diff --cached --quiet; then
           echo "Release snapshot already matches ${VERSION}; no commit needed."
         else
@@ -278,9 +299,9 @@ jobs:
           git push origin "HEAD:${GITHUB_REF#refs/heads/}"
         fi
 
-        if [ -n "$(git status --porcelain --untracked-files=all -- agent-session collector)" ]; then
+        if [ -n "$(git status --porcelain --untracked-files=all -- agent-session collector agentpprof)" ]; then
           echo "::error::release snapshot has uncommitted files after commit."
-          git status --short --untracked-files=all -- agent-session collector
+          git status --short --untracked-files=all -- agent-session collector agentpprof
           exit 1
         fi
 
@@ -297,6 +318,8 @@ jobs:
         grep -q "^version = \"$VERSION_NO_V\"" collector/Cargo.toml
         grep -q "^version = \"${{ steps.set_version.outputs.agent_session_version }}\"" agent-session/Cargo.toml
         grep -q "agent-session = { version = \"${{ steps.set_version.outputs.agent_session_version }}\", path = \"../agent-session\" }" collector/Cargo.toml
+        grep -q "^version = \"$VERSION_NO_V\"" agentpprof/Cargo.toml
+        grep -q "agent-session = { version = \"${{ steps.set_version.outputs.agent_session_version }}\", path = \"../agent-session\" }" agentpprof/Cargo.toml
 
     - name: Smoke test local release binary
       run: |
@@ -307,6 +330,16 @@ jobs:
         for cmd in top monitor record report debug; do
           if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" /tmp/agentsight-local-help.txt; then
             echo "::error::local release binary is missing '$cmd' in agentsight --help"
+            exit 1
+          fi
+        done
+
+        agentpprof/target/release/agentpprof --version
+        agentpprof/target/release/agentpprof --help | tee /tmp/agentpprof-local-help.txt
+
+        for flag in "--output" "--view" "--tagger" "--session-file"; do
+          if ! grep -Fq -- "$flag" /tmp/agentpprof-local-help.txt; then
+            echo "::error::local release binary is missing '$flag' in agentpprof --help"
             exit 1
           fi
         done
@@ -363,11 +396,17 @@ jobs:
         cd collector
         cargo package
 
+    - name: Verify agentpprof Cargo package
+      run: |
+        CARGO_TARGET_DIR=/tmp/agentsight-agentpprof-package \
+          cargo package --manifest-path agentpprof/Cargo.toml
+
     - name: Publish Release
       uses: softprops/action-gh-release@v2
       with:
         files: |
           collector/target/release/agentsight
+          agentpprof/target/release/agentpprof
         prerelease: false
         tag_name: ${{ steps.set_version.outputs.tag }}
         target_commitish: ${{ steps.commit_release.outputs.publish_sha }}
@@ -388,6 +427,11 @@ jobs:
           --pattern agentsight \
           --dir "$smoke_dir" \
           --clobber
+        gh release download "$RELEASE_TAG" \
+          --repo "$GITHUB_REPOSITORY" \
+          --pattern agentpprof \
+          --dir "$smoke_dir" \
+          --clobber
 
         chmod +x "$smoke_dir/agentsight"
         "$smoke_dir/agentsight" --version
@@ -396,6 +440,17 @@ jobs:
         for cmd in top monitor record report debug; do
           if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" "$smoke_dir/help.txt"; then
             echo "::error::release artifact is missing '$cmd' in agentsight --help"
+            exit 1
+          fi
+        done
+
+        chmod +x "$smoke_dir/agentpprof"
+        "$smoke_dir/agentpprof" --version
+        "$smoke_dir/agentpprof" --help | tee "$smoke_dir/agentpprof-help.txt"
+
+        for flag in "--output" "--view" "--tagger" "--session-file"; do
+          if ! grep -Fq -- "$flag" "$smoke_dir/agentpprof-help.txt"; then
+            echo "::error::release artifact is missing '$flag' in agentpprof --help"
             exit 1
           fi
         done
@@ -442,6 +497,51 @@ jobs:
         for cmd in top monitor record report debug; do
           if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" /tmp/agentsight-cargo-install-help.txt; then
             echo "::error::cargo-installed agentsight is missing '$cmd' in --help"
+            exit 1
+          fi
+        done
+
+    - name: Publish agentpprof crate to crates.io
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      run: |
+        set -euo pipefail
+        if [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+          echo "::error::CARGO_REGISTRY_TOKEN is not set; cannot publish to crates.io."
+          exit 1
+        fi
+
+        cargo publish --manifest-path agentpprof/Cargo.toml
+
+    - name: Smoke test agentpprof cargo install from crates.io
+      env:
+        VERSION: ${{ steps.set_version.outputs.agentpprof_version }}
+      run: |
+        set -euo pipefail
+
+        install_dir="$(mktemp -d)"
+        for attempt in 1 2 3 4 5 6; do
+          if cargo install agentpprof \
+            --version "$VERSION" \
+            --locked \
+            --root "$install_dir"; then
+            break
+          fi
+
+          if [ "$attempt" -eq 6 ]; then
+            echo "::error::cargo install agentpprof ${VERSION} failed after ${attempt} attempts"
+            exit 1
+          fi
+
+          sleep $((attempt * 10))
+        done
+
+        "$install_dir/bin/agentpprof" --version
+        "$install_dir/bin/agentpprof" --help | tee /tmp/agentpprof-cargo-install-help.txt
+
+        for flag in "--output" "--view" "--tagger" "--session-file"; do
+          if ! grep -Fq -- "$flag" /tmp/agentpprof-cargo-install-help.txt; then
+            echo "::error::cargo-installed agentpprof is missing '$flag' in --help"
             exit 1
           fi
         done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
         collector/target/release/agentsight --version
         collector/target/release/agentsight --help | tee /tmp/agentsight-local-help.txt
 
-        for cmd in top record report discover debug; do
+        for cmd in top monitor record report debug; do
           if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" /tmp/agentsight-local-help.txt; then
             echo "::error::local release binary is missing '$cmd' in agentsight --help"
             exit 1
@@ -393,7 +393,7 @@ jobs:
         "$smoke_dir/agentsight" --version
         "$smoke_dir/agentsight" --help | tee "$smoke_dir/help.txt"
 
-        for cmd in top record report discover debug; do
+        for cmd in top monitor record report debug; do
           if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" "$smoke_dir/help.txt"; then
             echo "::error::release artifact is missing '$cmd' in agentsight --help"
             exit 1
@@ -439,7 +439,7 @@ jobs:
         "$install_dir/bin/agentsight" --version
         "$install_dir/bin/agentsight" --help | tee /tmp/agentsight-cargo-install-help.txt
 
-        for cmd in top record report discover debug; do
+        for cmd in top monitor record report debug; do
           if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" /tmp/agentsight-cargo-install-help.txt; then
             echo "::error::cargo-installed agentsight is missing '$cmd' in --help"
             exit 1

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ cargo run --manifest-path agentpprof/Cargo.toml -- \
 go tool pprof -top agent.pb.gz
 ```
 
+The `tasks` view is the best first flamegraph: it aggregates real local
+Codex/Claude AgentSight development sessions by project, agent, session tag,
+prompt tag, and tool/LLM activity.
+
+<div align="center">
+  <img src="https://github.com/eunomia-bpf/agentsight/raw/master/docs/flamegraph/examples/tasks.svg" alt="agentpprof task flamegraph from real AgentSight development sessions" width="1000">
+  <p><em>Offline task profile generated from real local AgentSight coding-agent sessions</em></p>
+</div>
+
 See [agentpprof/README.md](agentpprof/README.md) for CLI details and
 [docs/flamegraph](docs/flamegraph/README.md) for flamegraph examples, view
 selection, and deterministic tagging rules.

--- a/agentpprof/Cargo.toml
+++ b/agentpprof/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities", "development-tools::profiling"]
 
 [dependencies]
 anyhow = "1"
-agent-session = { version = "0.3.3", path = "../agent-session" }
+agent-session = { version = "0.3.4", path = "../agent-session" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6"

--- a/agentpprof/src/main.rs
+++ b/agentpprof/src/main.rs
@@ -22,6 +22,7 @@ const TAG_GRAMMAR: &str =
 
 #[derive(Parser)]
 #[command(name = "agentpprof")]
+#[command(version)]
 #[command(about = "pprof-compatible semantic profiler for local AI coding-agent sessions")]
 struct Cli {
     /// Output file. Use .pb.gz for Go pprof, .folded for folded stacks, .svg for an SVG flamegraph, or .json.

--- a/agentpprof/src/main.rs
+++ b/agentpprof/src/main.rs
@@ -1795,11 +1795,9 @@ fn enrich_claude(
                 });
             }
         }
-        "last-prompt" => {
-            if record.user_requests.is_empty() {
-                if let Some(text) = value.get("lastPrompt").and_then(Value::as_str) {
-                    *current_request = upsert_prompt(record, ts_ms, text);
-                }
+        "last-prompt" if record.user_requests.is_empty() => {
+            if let Some(text) = value.get("lastPrompt").and_then(Value::as_str) {
+                *current_request = upsert_prompt(record, ts_ms, text);
             }
         }
         _ => {}

--- a/docs/agentpprof.md
+++ b/docs/agentpprof.md
@@ -1,0 +1,305 @@
+# agentpprof: pprof-style profiles for AI coding-agent sessions
+
+An AI coding agent can finish a task and leave behind hundreds of events: user
+prompts, model calls, shell commands, file edits, package downloads, test runs,
+and retries. Traditional logs can answer "what happened next?" if you read them
+line by line. They are much weaker at answering the question developers usually
+ask after a long run: where did the agent spend its work, what repeated, and
+which prompts caused the expensive or risky system effects?
+
+`agentpprof` is a profiling tool for that question. It reads local Codex and
+Claude Code session history through the shared `agent-session` parser, projects
+the session into semantic stacks, and writes outputs that existing profiling
+tools already understand: Go pprof protobuf, folded stacks, SVG flamegraphs, and
+redacted JSON.
+
+The profiles are not CPU profiles. A wide frame does not mean the agent used
+more CPU. Width means the chosen view's weight: activity count, system-effect
+count, file-effect count, network-effect count, or model token count. The goal
+is to make an agent session browsable like a performance profile, without
+pretending that every question has the same metric.
+
+## Why a profiler instead of another trace view?
+
+Trace views are good when you already know where to look. If a single command
+failed at 14:03, a timeline can show the surrounding tool calls and model
+messages. Long agent sessions have a different failure mode: there is too much
+trace. The user wants to know whether the agent kept re-reading the same files,
+spent most of its model budget on review, retried tests in a loop, or contacted
+external services during one prompt.
+
+A flamegraph is useful here because it compresses repeated work. The stack says
+which context the event belongs to, and the width says how much weight that
+context accumulated. When many prompts share the same pattern, they merge. When
+one prompt creates a distinct system effect, it remains visible as a branch.
+
+`agentpprof` keeps this model explicit. It does not try to produce one universal
+"agent flamegraph". Instead, it exposes several projections over the same
+session:
+
+| View | Width means | Primary question |
+| --- | ---: | --- |
+| `tasks` | LLM-call plus tool-event count | What semantic work dominated the session? |
+| `system` | tool and system-effect count | Which tool, process, effect, path, or domain chains were heavy? |
+| `tools` | same projection as `system` | Compatibility alias for older examples. |
+| `tokens` | reported or bounded-estimated tokens | Which semantic regions consumed model budget? |
+| `files` | file/path effect count | Which prompts touched which parts of the repository? |
+| `network` | network/domain effect count | Which prompts contacted which domains, and through which process chain? |
+
+Start with `tasks`. When a wide prompt or session looks suspicious, switch to
+`system`, `files`, `network`, or `tokens` to explain the cause.
+
+## Install
+
+After release, install from crates.io:
+
+```bash
+cargo install agentpprof
+```
+
+You can also download the `agentpprof` binary from the AgentSight GitHub
+release artifacts. The AgentSight release pipeline builds and smoke-tests both
+`agentsight` and `agentpprof` from the same release tag.
+
+From a source checkout:
+
+```bash
+cargo run --manifest-path agentpprof/Cargo.toml -- --version
+cargo run --manifest-path agentpprof/Cargo.toml -- -o agent.pb.gz
+```
+
+## First profile
+
+Generate a task profile for the current repository:
+
+```bash
+agentpprof --project-root . --view tasks -o tasks.pb.gz
+```
+
+Open the pprof profile with standard Go tooling:
+
+```bash
+go tool pprof -top tasks.pb.gz
+go tool pprof -http=:0 tasks.pb.gz
+```
+
+Generate a browser-openable flamegraph instead:
+
+```bash
+agentpprof --project-root . --view tasks -o tasks.svg
+```
+
+The extension chooses the output format when `--format` is not provided:
+
+```bash
+agentpprof -o tasks.pb.gz   --view tasks    # pprof protobuf, gzip-compressed
+agentpprof -o system.folded --view system   # folded stack text
+agentpprof -o files.svg     --view files    # standalone SVG flamegraph
+agentpprof -o network.json  --view network  # redacted JSON summary and stacks
+```
+
+The checked-in gallery under `docs/flamegraph/` was generated from real local
+AgentSight development sessions, not toy transcripts. It includes task, system,
+token, file, and network flamegraphs. A task flamegraph looks like this:
+
+![agentpprof task flamegraph](https://github.com/eunomia-bpf/agentsight/raw/master/docs/flamegraph/examples/tasks.svg)
+
+## What data does it read?
+
+`agentpprof` reads agent-native local session history. Today that means Codex
+and Claude Code JSONL session files parsed through the `agent-session` crate.
+It does not load eBPF probes, require root, or record a live process. It is the
+offline profiling side of AgentSight: use `agentsight` to observe live system
+behavior, and use `agentpprof` to aggregate already-recorded agent sessions.
+
+By default, it scans recent local sessions that match `--project-root`:
+
+```bash
+agentpprof --project-root /path/to/repo --view tasks -o tasks.svg
+```
+
+For repeatable analysis, pass explicit session files:
+
+```bash
+agentpprof \
+  --project-root /path/to/repo \
+  --session-file ~/.codex/sessions/.../session.jsonl \
+  --session-file ~/.claude/projects/.../session.jsonl \
+  --view system \
+  -o system.folded
+```
+
+Useful selectors:
+
+```bash
+agentpprof -o tasks.svg --agent codex
+agentpprof -o tasks.svg --session-id 019ec5
+agentpprof -o tasks.svg --session-tag debug
+agentpprof -o tasks.svg --prompt-tag review
+```
+
+## The stack model
+
+A stack is a projection, not a literal call stack. The lower frames provide
+context, and the upper frames describe the activity being counted. The exact
+shape depends on the view.
+
+The `tasks` view emphasizes semantic work:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:debug;kind:tool;call:tool/shell;effect:test;status:ok 1
+project:agentsight;agent:codex;session:release;prompt:debug;kind:llm;call:llm/review;model:gpt-5 1
+```
+
+The `system` view pushes below tool calls into process and effect structure:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:debug;call:tool/shell;process:bash;process:cargo;effect:test;path:collector;status:ok 1
+project:agentsight;agent:codex;session:release;prompt:debug;call:tool/shell;process:bash;process:git;effect:repo;path:repo;status:ok 1
+```
+
+The `files` view makes repository areas the main branch:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:docs;path:docs/flamegraph;effect:write;status:ok 1
+```
+
+The `network` view centers domains:
+
+```text
+project:agentsight;agent:codex;session:release;prompt:publish;domain:crates.io;process:cargo;status:ok 1
+```
+
+The `tokens` view uses model budget as the width:
+
+```text
+project:agentsight;agent:codex;model:gpt-5;kind:input;session:release;prompt:debug;call:llm/review 4200
+project:agentsight;agent:codex;model:gpt-5;kind:output;session:release;prompt:debug;call:llm/review 980
+```
+
+This separation matters. A file flamegraph should not use token width, and a
+token flamegraph should not hide the model dimension. The right projection
+depends on the user's question.
+
+## Tagging
+
+The most important frames are `session:*`, `prompt:*`, and `call:llm/*`. Raw
+prompts are too long and too private to use as flamegraph labels, so
+`agentpprof` maps them to short one-word tags.
+
+The default tagger is deterministic and local:
+
+```bash
+agentpprof -o tasks.svg --tagger regex
+```
+
+It uses built-in keyword rules and produces stable tags such as `debug`,
+`review`, `test`, `docs`, `release`, `profile`, or `design`. This is the safest
+default for CI, public artifacts, and reproducible analysis.
+
+Project-specific rules can be layered on top:
+
+```bash
+agentpprof -o tasks.svg \
+  --tagger regex \
+  --tag-rule prompt:review='(?i)review|diff|regression' \
+  --tag-rule prompt:test='(?i)cargo test|pytest|unit test' \
+  --tag-rule session:release='(?i)release|publish|crates\\.io'
+```
+
+Rules use:
+
+```text
+KIND:TAG=REGEX
+```
+
+`KIND` may be `session`, `prompt`, `llm`, or `all`. `TAG` must be one lowercase
+English word between 3 and 12 letters. Rules are evaluated in command-line
+order before the built-in rules.
+
+For model-produced tags, run a llama.cpp-compatible server and use the LLM
+tagger:
+
+```bash
+llama-server -m /path/to/model.gguf --port 8080
+agentpprof -o tasks.svg --tagger llm --llama-url http://127.0.0.1:8080
+```
+
+LLM tags are cached under the user cache directory by default, for example
+`$XDG_CACHE_HOME/agentpprof/tags.json`. Use `--cache` to choose another file,
+or `--no-cache` to avoid saving new tags.
+
+The model is not asked to validate whether the agent was correct. It only names
+short semantic regions. Correctness and safety still require separate evidence.
+
+## Privacy and redaction
+
+Local agent histories can contain prompts, tool outputs, paths, commands,
+repository names, and model responses. `agentpprof` is conservative by default:
+
+- SVG, pprof, and folded outputs contain stack labels and weights, not raw
+  prompts or model responses.
+- JSON output redacts previews unless `--include-previews` is set.
+- Absolute paths outside the selected project root are grouped into stable
+  buckets such as `external/home`, `external/tmp`, `external/codex`, and
+  `external/claude`.
+- Private-looking domains are collapsed instead of exposing user-specific
+  hostnames.
+
+Use explicit `--session-file` inputs when you need repeatability. Use
+`--include-previews` only for private debugging or already-sanitized sessions.
+
+## Using agentpprof with AgentSight
+
+`agentpprof` and `agentsight` answer related but different questions.
+
+`agentsight` is the live and recorded system observer. It uses eBPF, TLS traffic
+capture, process monitoring, and materialized views to show what an agent does
+at runtime. Use it when you need live visibility, process trees, file effects,
+network destinations, or saved SQLite traces.
+
+`agentpprof` is the semantic profiler for local agent history. Use it when you
+want aggregation: repeated prompts, wide system-effect branches, token-heavy
+semantic regions, or folded stacks that can be compared across sessions.
+
+A practical workflow is:
+
+```bash
+sudo agentsight record -- claude
+agentsight report
+agentpprof --project-root . --view tasks -o tasks.svg
+agentpprof --project-root . --view system -o system.svg
+agentpprof --project-root . --view tokens -o tokens.pb.gz
+```
+
+## CI and release contract
+
+`agentpprof` is part of the AgentSight release surface. The CI pipeline should:
+
+- build, clippy-check, and test `agentpprof` on pull requests;
+- assign `agentpprof` the same release version as `agentsight`;
+- update its `agent-session` dependency to the newly published
+  `agent-session` version;
+- build the release binary and upload it to the GitHub Release;
+- publish the `agentpprof` crate to crates.io;
+- smoke-test `agentpprof --version`, `agentpprof --help`, and
+  `cargo install agentpprof --version <release>`.
+
+This keeps the command usable as an independent tool, not only as an
+AgentSight repository artifact.
+
+## Troubleshooting
+
+If no sessions are found, pass explicit `--session-file` paths and confirm the
+session `cwd` matches `--project-root`.
+
+If labels are too generic, add a few `--tag-rule` entries for the project. Do
+not try to make every prompt unique. Good tags preserve useful semantic
+diversity while merging meaningless long-tail fragments.
+
+If pprof output opens but looks unfamiliar, remember that the sample unit is
+not CPU time. Use `go tool pprof -top` to inspect the widest semantic frames,
+then generate SVG or folded output when you need the full stack shape.
+
+If a public artifact might contain sensitive information, prefer SVG, folded,
+or pprof output, and do not pass `--include-previews`.

--- a/docs/flamegraph/README.md
+++ b/docs/flamegraph/README.md
@@ -5,6 +5,9 @@ semantic profiles. The SVG output is a prefix-merged flamegraph: shared stack
 prefixes are drawn once, and each frame width is the inclusive weight below
 that frame.
 
+For the complete tool guide, release contract, and tagging model, see
+[docs/agentpprof.md](../agentpprof.md).
+
 Read the SVG from bottom to top. The lower frames are broader context such as
 `project`, `agent`, `session`, and `prompt`; upper frames are more specific
 activity such as LLM calls, tools, processes, file effects, network domains,


### PR DESCRIPTION
## Summary
- remove stale `discover` checks from release smoke tests and check the current `top monitor record report debug` command set
- add PR CI coverage for `agentpprof` build, clippy, and tests
- include `agentpprof` in release versioning, GitHub Release artifacts, crates.io publishing, and cargo-install smoke tests
- add a full `docs/agentpprof.md` guide and link it from the flamegraph docs

## Root cause
The failing master CI run reached the release smoke test and then checked `agentsight --help` for the removed `discover` subcommand. While fixing that release path, `agentpprof` was also not part of the release surface: it was not built, uploaded, published, or smoke-tested by CI.

## Validation
- `cargo run --manifest-path collector/Cargo.toml -- --help` command smoke for `top monitor record report debug`
- `cargo run --manifest-path agentpprof/Cargo.toml -- --version`
- `cargo run --manifest-path agentpprof/Cargo.toml -- --help` flag smoke for `--output --view --tagger --session-file`
- `cargo test --manifest-path agentpprof/Cargo.toml`
- `cargo clippy --manifest-path agentpprof/Cargo.toml --all-targets -- -D warnings`
- `git diff --check`

## Note
Local `cargo package --manifest-path agentpprof/Cargo.toml` currently cannot verify because `agent-session 0.3.4` is not published on crates.io yet. The release workflow now publishes `agent-session` before verifying and publishing `agentpprof`, which is the intended release order.
