### PR TITLE
[codex] Align agent sessions with OTel GenAI fields

### DIFF
--- a/agent-session/Cargo.lock
+++ b/agent-session/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "agent-session"
-version = "0.3.4"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/agent-session/Cargo.toml
+++ b/agent-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-session"
-version = "0.3.5"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.87"
 description = "Portable session IR, parsers, discovery, and process matching for local AI coding-agent transcripts."

--- a/agent-session/src/lib.rs
+++ b/agent-session/src/lib.rs
@@ -38,5 +38,5 @@ pub use parser::{
 // Re-export process matching types and functions
 pub use process_match::{
     LiveProcessCandidate, ProcessKey, ProcessTree, SessionProcessInput, SessionProcessMatch,
-    SessionProcessMatches, SessionProcessMatcher,
+    SessionProcessMatcher, SessionProcessMatches,
 };

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -190,8 +190,12 @@ fn parse_jsonl(
         let Ok(obj) = serde_json::from_str::<Value>(line) else {
             continue;
         };
-        if let Some(id) = local_session_id(&obj) {
+        let (session_id, conversation_id) = local_session_ids(&obj);
+        if let Some(id) = session_id {
             acc.session_id = id;
+        }
+        if let Some(id) = conversation_id {
+            acc.conversation_id = Some(id);
         }
         if acc.cwd.is_none() {
             acc.cwd = obj
@@ -345,6 +349,7 @@ fn parse_gemini_json(path: &Path, updated: SystemTime, content: &str) -> Option<
     let mut acc = SessionAccumulator::new(AGENT_GEMINI, path, updated);
     if let Some(id) = root.get("sessionId").and_then(Value::as_str) {
         acc.session_id = id.to_string();
+        acc.conversation_id = Some(id.to_string());
     }
     acc.start_timestamp_ms = root
         .get("startTime")
@@ -406,8 +411,9 @@ fn parse_gemini_json(path: &Path, updated: SystemTime, content: &str) -> Option<
 }
 
 struct SessionAccumulator {
-    agent: String,
+    agent_type: String,
     session_id: String,
+    conversation_id: Option<String>,
     path: PathBuf,
     updated: SystemTime,
     start_timestamp_ms: Option<u64>,
@@ -431,8 +437,9 @@ impl SessionAccumulator {
             .unwrap_or("session")
             .to_string();
         Self {
-            agent: agent.to_string(),
+            agent_type: agent.to_string(),
             session_id,
+            conversation_id: None,
             path: normalized.clone(),
             updated,
             start_timestamp_ms: None,
@@ -509,10 +516,11 @@ impl SessionAccumulator {
         {
             return None;
         }
-        let display_id = format!("{}:{}", self.agent, short_session_id(&self.session_id));
+        let display_id = format!("{}:{}", self.agent_type, short_session_id(&self.session_id));
         Some(AgentSession {
-            agent: self.agent,
+            agent_type: self.agent_type,
             session_id: self.session_id,
+            conversation_id: self.conversation_id,
             display_id,
             path: self.path,
             updated: self.updated,
@@ -521,7 +529,7 @@ impl SessionAccumulator {
                 .or_else(|| Some(system_time_ms(self.updated).saturating_sub(self.duration_ms))),
             end_timestamp_ms: self.end_timestamp_ms,
             model: self.model,
-            token_usage,
+            usage: token_usage,
             model_usage: self.model_usage,
             tools: self.tools,
             files: self.files,
@@ -607,22 +615,39 @@ fn add_usage(
     );
 }
 
-fn local_session_id(obj: &Value) -> Option<String> {
-    for key in ["sessionId", "session_id", "conversation_id"] {
-        if let Some(value) = obj.get(key).and_then(Value::as_str)
-            && !value.is_empty()
-        {
-            return Some(value.to_string());
-        }
-    }
-    for pointer in ["/payload/session_id", "/payload/sessionId"] {
-        if let Some(value) = obj.pointer(pointer).and_then(Value::as_str)
-            && !value.is_empty()
-        {
-            return Some(value.to_string());
-        }
-    }
-    None
+fn local_session_ids(obj: &Value) -> (Option<String>, Option<String>) {
+    let session_id = first_json_string(
+        obj,
+        &["sessionId", "session_id"],
+        &["/payload/session_id", "/payload/sessionId"],
+    );
+    let conversation_id = first_json_string(
+        obj,
+        &["conversation_id", "conversationId", "thread_id", "threadId"],
+        &[
+            "/payload/conversation_id",
+            "/payload/conversationId",
+            "/payload/thread_id",
+            "/payload/threadId",
+        ],
+    )
+    .or_else(|| session_id.clone());
+    (
+        session_id.or_else(|| conversation_id.clone()),
+        conversation_id,
+    )
+}
+
+fn first_json_string(obj: &Value, keys: &[&str], pointers: &[&str]) -> Option<String> {
+    keys.iter()
+        .filter_map(|key| obj.get(*key).and_then(Value::as_str))
+        .chain(
+            pointers
+                .iter()
+                .filter_map(|pointer| obj.pointer(pointer).and_then(Value::as_str)),
+        )
+        .find(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 fn strip_codex_exec_option(args: &str) -> Option<&str> {
@@ -774,4 +799,26 @@ fn system_time_ms(value: SystemTime) -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn local_session_ids_keep_distinct_conversation_id() {
+        assert_eq!(
+            local_session_ids(&json!({"sessionId": "run", "conversation_id": "conv"})),
+            (Some("run".to_string()), Some("conv".to_string()))
+        );
+        assert_eq!(
+            local_session_ids(&json!({"payload": {"thread_id": "thread"}})),
+            (Some("thread".to_string()), Some("thread".to_string()))
+        );
+        assert_eq!(
+            local_session_ids(&json!({"payload": {"model": "gpt"}})),
+            (None, None)
+        );
+    }
 }

--- a/agent-session/src/types.rs
+++ b/agent-session/src/types.rs
@@ -44,15 +44,16 @@ impl TokenUsage {
 /// A parsed agent session with metadata, token usage, and tool invocations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSession {
-    pub agent: String,
+    pub agent_type: String,
     pub session_id: String,
+    pub conversation_id: Option<String>,
     pub display_id: String,
     pub path: PathBuf,
     pub updated: SystemTime,
     pub start_timestamp_ms: Option<u64>,
     pub end_timestamp_ms: Option<u64>,
     pub model: Option<String>,
-    pub token_usage: TokenUsage,
+    pub usage: TokenUsage,
     pub model_usage: BTreeMap<String, TokenUsage>,
     pub tools: BTreeMap<String, usize>,
     pub files: BTreeMap<String, usize>,

--- a/agentpprof/Cargo.lock
+++ b/agentpprof/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-session"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/agentpprof/Cargo.toml
+++ b/agentpprof/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities", "development-tools::profiling"]
 
 [dependencies]
 anyhow = "1"
-agent-session = { version = "0.3.5", path = "../agent-session" }
+agent-session = { version = "0.4.0", path = "../agent-session" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 dirs = "6"

--- a/agentpprof/src/session.rs
+++ b/agentpprof/src/session.rs
@@ -294,7 +294,7 @@ fn raw_mentions_project(path: &Path, project_root: &Path) -> bool {
 
 fn record_from_agent_session(session: &AgentSession) -> SessionRecord {
     SessionRecord {
-        source: session.agent.clone(),
+        source: session.agent_type.clone(),
         path: session.path.clone(),
         session_id: session.session_id.clone(),
         cwd: session.cwd.clone().unwrap_or_default(),

--- a/collector/Cargo.lock
+++ b/collector/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "agent-session"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -27,7 +27,7 @@ include = [
 [dependencies]
 async-stream = "0.3"
 async-trait = "0.1"
-agent-session = { version = "0.3.5", path = "../agent-session" }
+agent-session = { version = "0.4.0", path = "../agent-session" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.41", features = ["derive"] }
 futures = "0.3"

--- a/collector/src/sinks/otel.rs
+++ b/collector/src/sinks/otel.rs
@@ -36,6 +36,7 @@ struct SpanInput {
     provider: String,
     server_address: String,
     model: Option<String>,
+    conversation_id: Option<String>,
     max_tokens: Option<i64>,
     temperature: Option<f64>,
     top_p: Option<f64>,
@@ -159,6 +160,9 @@ fn build_otlp_payload(
         attr_str("gen_ai.provider.name", &req.provider),
         attr_str("server.address", &req.server_address),
     ];
+    if let Some(conversation_id) = &req.conversation_id {
+        attributes.push(attr_str("gen_ai.conversation.id", conversation_id));
+    }
     if let Some(model) = &req.model {
         attributes.push(attr_str("gen_ai.request.model", model));
     }
@@ -250,6 +254,7 @@ impl SpanInput {
                 .clone()
                 .unwrap_or_else(|| provider_from_host(host)),
             server_address: host.to_string(),
+            conversation_id: conversation_id_from_request(request),
             model: call.model.clone().or_else(|| {
                 request
                     .get("model")
@@ -300,6 +305,16 @@ impl ViewSink for OtelExporter {
         });
         Ok(())
     }
+}
+
+fn conversation_id_from_request(request: &Value) -> Option<String> {
+    ["conversation_id", "conversationId", "thread_id", "threadId"]
+        .iter()
+        .filter_map(|key| request.get(*key).and_then(Value::as_str))
+        .find(|value| !value.is_empty())
+        .or_else(|| request.pointer("/conversation/id").and_then(Value::as_str))
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
 }
 
 /// POST an OTLP/HTTP JSON trace payload to the collector.
@@ -381,6 +396,7 @@ mod tests {
             provider: "openai".to_string(),
             server_address: "api.openai.com".to_string(),
             model: Some("gpt-4o".to_string()),
+            conversation_id: Some("conv_123".to_string()),
             max_tokens: Some(256),
             temperature: Some(0.7),
             top_p: None,
@@ -423,6 +439,19 @@ mod tests {
             "gpt-4o"
         );
         assert_eq!(
+            find("gen_ai.conversation.id").unwrap()["value"]["stringValue"],
+            "conv_123"
+        );
+        assert_eq!(
+            conversation_id_from_request(&json!({ "conversation": { "id": "conv_123" } }))
+                .as_deref(),
+            Some("conv_123")
+        );
+        assert_eq!(
+            conversation_id_from_request(&json!({ "session_id": "sid_123" })),
+            None
+        );
+        assert_eq!(
             find("gen_ai.request.max_tokens").unwrap()["value"]["intValue"],
             "256"
         );
@@ -446,6 +475,7 @@ mod tests {
             provider: "openai".to_string(),
             server_address: "api.openai.com".to_string(),
             model: Some("gpt-4o".to_string()),
+            conversation_id: None,
             max_tokens: None,
             temperature: None,
             top_p: None,

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -36,7 +36,7 @@ pub(crate) fn snapshot(
 }
 
 fn view_id(session: &LocalSession) -> String {
-    format!("local:{}:{}", session.agent, session.display_id)
+    format!("local:{}:{}", session.agent_type, session.display_id)
 }
 
 pub(crate) fn materialized_view(sessions: &[LocalSession]) -> MaterializedView {
@@ -128,7 +128,10 @@ pub(crate) fn observed_session_prompt_rows(audit_rows: &[AuditEventRow]) -> Vec<
             timestamp_ms: row.timestamp_ms,
             audit_type: "llm".to_string(),
             pid: Some(pid),
-            comm: row.comm.clone().or_else(|| Some(session.agent.clone())),
+            comm: row
+                .comm
+                .clone()
+                .or_else(|| Some(session.agent_type.clone())),
             subject: session.model.clone(),
             action: Some("request".to_string()),
             target: Some(path.to_string_lossy().to_string()),
@@ -138,7 +141,8 @@ pub(crate) fn observed_session_prompt_rows(audit_rows: &[AuditEventRow]) -> Vec<
                 "text_content": prompt,
                 "prompt_source": "local",
                 "session_id": view_id(&session),
-                "agent": session.agent,
+                "conversation_id": session.conversation_id.as_deref(),
+                "agent_type": session.agent_type,
             }),
         });
     }
@@ -167,19 +171,21 @@ fn session_row(session: &LocalSession) -> SessionRow {
     let updated_ms = updated_ms(session);
     SessionRow {
         id: view_id(session),
-        agent_type: session.agent.clone(),
+        agent_type: session.agent_type.clone(),
         start_timestamp_ms: session
             .start_timestamp_ms
             .unwrap_or_else(|| updated_ms.saturating_sub(session.duration_ms)),
         end_timestamp_ms: session.end_timestamp_ms.or(Some(updated_ms)),
         status: "observed".to_string(),
         model: session.model.clone(),
-        input_tokens: session.token_usage.input_tokens,
-        output_tokens: session.token_usage.output_tokens,
-        total_tokens: session.token_usage.total_tokens,
+        input_tokens: session.usage.input_tokens,
+        output_tokens: session.usage.output_tokens,
+        total_tokens: session.usage.total_tokens,
         view_source: AGENT_NATIVE_SOURCE.to_string(),
         confidence: Some(0.95),
         attributes: serde_json::json!({
+            "session_id": session.session_id.clone(),
+            "conversation_id": session.conversation_id.as_deref(),
             "path": session.path.to_string_lossy(),
             "display_id": session.display_id,
             "prompt_preview": session.prompt_preview.clone(),
@@ -201,7 +207,7 @@ fn token_rows(session: &LocalSession) -> Vec<TokenUsageRow> {
             llm_call_id: format!("{session_id}-{model}"),
             timestamp_ms: updated_ms(session),
             pid: None,
-            comm: Some(session.agent.clone()),
+            comm: Some(session.agent_type.clone()),
             provider: None,
             model: Some(model.clone()),
             input_tokens: usage.input_tokens,
@@ -225,7 +231,7 @@ fn tool_rows(session: &LocalSession) -> Vec<ToolCallRow> {
             rows.push(ToolCallRow {
                 id: format!("tool-{session_id}-{}-{index}", sanitize_id(tool)),
                 session_id: Some(session_id.clone()),
-                conversation_id: None,
+                conversation_id: session.conversation_id.clone(),
                 timestamp_ms,
                 tool_name: Some(tool.clone()),
                 tool_call_id: None,
@@ -265,7 +271,7 @@ fn matches_filter(
         return true;
     };
     let filter = filter.to_ascii_lowercase();
-    session.agent.to_ascii_lowercase().contains(&filter)
+    session.agent_type.to_ascii_lowercase().contains(&filter)
         || session
             .prompt_preview
             .as_ref()

--- a/docs/agent-session.md
+++ b/docs/agent-session.md
@@ -20,6 +20,13 @@ session IR for applications such as AgentSight.
 - No UI, report rendering, database schema, or eBPF capture logic.
 - No dependency on AgentSight collector internals.
 
+## OTel Alignment
+
+`agent-session` remains a local IR. Its public fields use OTel-friendly names
+where they fit: `agent_type`, `conversation_id`, and aggregate `usage`.
+AgentSight maps those fields to OTLP only at export time and leaves
+`conversation_id` unset when a native log has no real session/thread id.
+
 ## Release
 
 AgentSight's release workflow publishes `agent-session` before publishing

--- a/docs/otel.md
+++ b/docs/otel.md
@@ -92,6 +92,7 @@ Per the GenAI agent/model span conventions:
 |-----------|--------|
 | `gen_ai.operation.name` | `chat` |
 | `gen_ai.provider.name` | derived from the API host (`openai`, `anthropic`, `gcp.gen_ai`, `azure.ai.openai`, …) |
+| `gen_ai.conversation.id` | real conversation/thread/session id from the provider request body when available; never synthesized |
 | `gen_ai.request.model` | request body `model` |
 | `gen_ai.request.max_tokens` / `temperature` / `top_p` | request body |
 | `gen_ai.response.model` / `gen_ai.response.id` | response body |
@@ -122,7 +123,8 @@ JSON still emit a span with the request attributes and HTTP status.
 
 - OTLP/**HTTP** only (the standard collector receiver). For a remote collector
   behind TLS, run a local collector and let it forward upstream.
-- One span per request/response pair (`chat`); multi-agent workflow spans
-  (`invoke_agent`, `execute_tool`) are not yet emitted — see issue #47.
+- Tool/workflow spans (`execute_tool`, `invoke_agent`, `invoke_workflow`,
+  `plan`) are not emitted yet; native transcript tools may be only aggregated
+  requests, and AgentSight-specific provenance stays in AgentSight rows.
 - The GenAI conventions are still experimental; attribute names track the
   current spec.


### PR DESCRIPTION
## Summary

Align `agent-session` with OTel GenAI naming without turning it into an OTLP schema or adding a parallel telemetry IR.

- rename the canonical `AgentSession` fields from `agent` to `agent_type` and from `token_usage` to `usage`
- release `agent-session` on the `0.4.0` line because those public field renames are breaking for direct field consumers
- add optional `conversation_id`
- keep distinct native `session_id` and `conversation_id` when both are present; only fall back to the native session id when no distinct conversation/thread id exists
- propagate native `conversation_id` into AgentSight session/tool rows when the transcript provided a real id
- add `gen_ai.conversation.id` to existing LLM `chat` spans when the provider request body includes conversation/thread fields
- document the current OTel projection boundaries

Final scope is intentionally small: no parallel telemetry IR, no `agent_name()` display helper, and no `execute_tool` exporter.

## Non-goals / current gaps

- Native transcript tool aggregates are not exported as `gen_ai.operation.name=execute_tool` spans yet, because the imported rows do not always distinguish model tool requests from completed tool executions.
- Native transcript conversation ids are not retroactively correlated into eBPF-captured chat spans unless the provider request body itself carries that id.
- AgentSight-only provenance such as transcript paths, matching evidence, and confidence remains in AgentSight rows and is not emitted on OTLP spans yet.

## Validation

- `cd agent-session && cargo test --locked`
- `cd collector && cargo test --locked sinks::otel`
- `cd collector && cargo test --locked --test export_snapshot_test`
- `cd agentpprof && cargo check --locked`
- `git diff --check`