### PR TITLE
[codex] report token falls back to local sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ sudo agentsight record -- claude             # record a command
 agentsight report                            # high-level run summary (default)
 agentsight report list                       # recorded sessions in this directory
 agentsight report prompts --json             # full LLM request/response JSON
-agentsight report token                      # token usage from latest session in this directory
+agentsight report token                      # token usage from latest DB, or local agent sessions
+agentsight report token --group-by dir       # token usage by session/process working directory
 agentsight report audit --json               # process spawns, file opens, API calls
 agentsight report serve                      # open the web UI for the latest session in this directory
 agentsight report export -o snapshot.json    # export for web dashboard
@@ -199,7 +200,7 @@ A: eBPF probes need root privileges, so AgentSight may prompt for `sudo`. With `
 A: Our evaluation reports less than 3% CPU overhead for typical traced agent workloads.
 
 **Q: Where does captured data go?**
-A: `record` stores sessions as `agentsight-*.db` files in the current directory by default, and `report` reads the latest matching file from that directory unless you pass `--db`. `monitor` stores its weekly background DBs under `~/.agentsight/monitor`, and `top` is read-only unless you explicitly pass `--db` to inspect a saved session. Use `agentsight report`, `agentsight report list`, `agentsight report audit --json`, and `agentsight report token` to inspect prior runs. Captured data can include prompts, responses, paths, headers, and network targets, so treat logs and DBs as sensitive.
+A: `record` stores sessions as `agentsight-*.db` files in the current directory by default, and `report` reads the latest matching file from that directory unless you pass `--db`. When no default DB exists, report commands warn and fall back to local Claude/Codex/Gemini agent sessions where available. `monitor` stores its weekly background DBs under `~/.agentsight/monitor`, and `top` is read-only unless you explicitly pass `--db` to inspect a saved session. Use `agentsight report`, `agentsight report list`, `agentsight report audit --json`, and `agentsight report token` to inspect prior runs. Captured data can include prompts, responses, paths, headers, and network targets, so treat logs and DBs as sensitive.
 
 **Q: Why doesn't AgentSight capture traffic from Claude Code, Node.js, or Gemini CLI?**
 A: These applications statically link their SSL library (BoringSSL for Claude/Bun, OpenSSL for **all** Node.js — both NVM and system installs) into their own binary instead of using system `libssl.so`, so there's nothing for sslsniff to hook by default. AgentSight handles this for you: `record -- <command>` always discovers the binary, and `record -c node` now auto-discovers the Node binary too. For Claude attach mode, pass `--binary-path`. See the "Zero-Config: record" and "Monitoring Node.js AI Tools" sections.

--- a/collector/src/cli_db.rs
+++ b/collector/src/cli_db.rs
@@ -37,11 +37,11 @@ pub(crate) fn load_agentsight_view(
 }
 
 pub(crate) fn run_token_query(
-    db: &str,
+    db: Option<&str>,
     group_by: &str,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let view = load_agentsight_view(Some(db))?;
+    let view = load_agentsight_view(db)?;
     let rows = view.token_summary(group_by);
     if json {
         print_json(&rows)?;
@@ -52,12 +52,12 @@ pub(crate) fn run_token_query(
 }
 
 pub(crate) fn run_audit_query(
-    db: &str,
+    db: Option<&str>,
     audit_type: Option<&str>,
     limit: usize,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let view = load_agentsight_view(Some(db))?;
+    let view = load_agentsight_view(db)?;
     let rows = view.audit_rows(audit_type, limit);
     if json {
         print_json(&rows)?;
@@ -68,11 +68,11 @@ pub(crate) fn run_audit_query(
 }
 
 pub(crate) fn run_prompts_query(
-    db: &str,
+    db: Option<&str>,
     limit: usize,
     json: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let view = load_agentsight_view(Some(db))?;
+    let view = load_agentsight_view(db)?;
     let rows = view.llm_call_rows(limit);
     if json {
         print_json(&rows)?;
@@ -83,11 +83,11 @@ pub(crate) fn run_prompts_query(
 }
 
 pub(crate) fn run_export(
-    db: &str,
+    db: Option<&str>,
     output: &str,
     audit_limit: usize,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let view = load_agentsight_view(Some(db))?;
+    let view = load_agentsight_view(db)?;
     let snapshot = view.export_snapshot(SnapshotOptions { audit_limit });
     let json = serde_json::to_vec_pretty(&snapshot)?;
     if output == "-" {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -58,8 +58,8 @@ use cmd_trace::{
     OtelConfig, TraceConfig, convert_runner_error, run_trace, start_web_server_if_enabled,
 };
 use output::TopOptions;
-use output::print_record_session_db_error;
-use sources::session_db::{resolve_db_or_latest, run_db_list};
+use output::{print_record_session_db_error, print_report_local_sessions_warning};
+use sources::session_db::{latest_session_db, run_db_list};
 
 static SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
 static SHUTDOWN_NOTIFY: OnceLock<Arc<Notify>> = OnceLock::new();
@@ -271,10 +271,10 @@ enum Commands {
     /// Query and report on recorded sessions: summary, tokens, audit, prompts, export, list.
     /// Defaults to summary when no subcommand is given.
     Report {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
-        /// Read agent-native Claude/Codex/Gemini sessions (for summary)
+        /// Read agent-native Claude/Codex/Gemini sessions instead of a saved DB
         #[arg(long)]
         local: bool,
         #[command(subcommand)]
@@ -289,28 +289,28 @@ enum Commands {
 enum ReportCommands {
     /// Session summary: what the agent did, tokens, processes, files
     Summary {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
         /// Read agent-native Claude/Codex/Gemini sessions
         #[arg(long)]
         local: bool,
     },
-    /// Query token usage from a SQLite database
+    /// Query token usage from a saved DB or local agent sessions
     Token {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
-        /// Grouping key: model, provider, comm, pid
+        /// Grouping key: model, provider, comm, pid, dir (aliases: cwd, directory)
         #[arg(long, default_value = "model")]
         group_by: String,
         /// Emit JSON output
         #[arg(long)]
         json: bool,
     },
-    /// Query audit events from a SQLite database
+    /// Query audit events from a saved DB or local agent sessions
     Audit {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
         /// Audit type: llm, process, file
@@ -325,7 +325,7 @@ enum ReportCommands {
     },
     /// Show captured LLM prompts and responses when observable
     Prompts {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
         /// Maximum rows
@@ -335,9 +335,9 @@ enum ReportCommands {
         #[arg(long)]
         json: bool,
     },
-    /// Export a web/demo snapshot from a SQLite database
+    /// Export a web/demo snapshot from a saved DB or local agent sessions
     Export {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
         /// Output snapshot path, or '-' for stdout
@@ -347,9 +347,9 @@ enum ReportCommands {
         #[arg(long, default_value = "10000")]
         audit_limit: usize,
     },
-    /// Serve the web UI for a saved SQLite session
+    /// Serve the web UI for a saved SQLite session or local agent sessions
     Serve {
-        /// SQLite database path (defaults to latest agentsight-*.db in the current directory)
+        /// SQLite database path (defaults to latest agentsight-*.db, then local agent sessions)
         #[arg(long)]
         db: Option<String>,
         /// Server port for the web UI
@@ -590,9 +590,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                     Some(ReportCommands::Summary { db: d, local: l }) => (d, l),
                     _ => (db, local),
                 };
-                let resolved = (!*local_ref)
-                    .then(|| resolve_db_or_latest(db_ref))
-                    .transpose()?;
+                let resolved = report_db_or_local(db_ref, *local_ref);
                 run_db_summary(resolved.as_deref())?;
             }
             Some(ReportCommands::Token {
@@ -601,8 +599,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 json,
             }) => {
                 let effective = d.as_ref().or(db.as_ref()).cloned();
-                let db = resolve_db_or_latest(&effective)?;
-                run_token_query(&db, group_by, *json)?;
+                let db = report_db_or_local(&effective, *local);
+                run_token_query(db.as_deref(), group_by, *json)?;
             }
             Some(ReportCommands::Audit {
                 db: d,
@@ -611,13 +609,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 json,
             }) => {
                 let effective = d.as_ref().or(db.as_ref()).cloned();
-                let db = resolve_db_or_latest(&effective)?;
-                run_audit_query(&db, audit_type.as_deref(), *limit, *json)?;
+                let db = report_db_or_local(&effective, *local);
+                run_audit_query(db.as_deref(), audit_type.as_deref(), *limit, *json)?;
             }
             Some(ReportCommands::Prompts { db: d, limit, json }) => {
                 let effective = d.as_ref().or(db.as_ref()).cloned();
-                let db = resolve_db_or_latest(&effective)?;
-                run_prompts_query(&db, *limit, *json)?;
+                let db = report_db_or_local(&effective, *local);
+                run_prompts_query(db.as_deref(), *limit, *json)?;
             }
             Some(ReportCommands::Export {
                 db: d,
@@ -625,13 +623,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 audit_limit,
             }) => {
                 let effective = d.as_ref().or(db.as_ref()).cloned();
-                let db = resolve_db_or_latest(&effective)?;
-                run_export(&db, output, *audit_limit)?;
+                let db = report_db_or_local(&effective, *local);
+                run_export(db.as_deref(), output, *audit_limit)?;
             }
             Some(ReportCommands::Serve { db: d, server_port }) => {
                 let effective = d.as_ref().or(db.as_ref()).cloned();
-                let db = resolve_db_or_latest(&effective)?;
-                run_report_serve(&db, &cli.listen, *server_port).await?;
+                let db = report_db_or_local(&effective, *local);
+                run_report_serve(db.as_deref(), &cli.listen, *server_port).await?;
             }
             Some(ReportCommands::List) => run_db_list()?,
         },
@@ -696,18 +694,32 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 }
 
 async fn run_report_serve(
-    db: &str,
+    db: Option<&str>,
     listen: &str,
     server_port: u16,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let view = view::MaterializedView::shared_bounded();
     let _server_handle =
-        start_web_server_if_enabled(true, listen, server_port, view, Some(db.to_string()))
+        start_web_server_if_enabled(true, listen, server_port, view, db.map(str::to_string))
             .await
             .map_err(|e| std::io::Error::other(e.to_string()))?;
 
     shutdown_notify().notified().await;
     Ok(())
+}
+
+fn report_db_or_local(db: &Option<String>, force_local: bool) -> Option<String> {
+    if force_local {
+        return None;
+    }
+    if let Some(db) = db {
+        return Some(db.clone());
+    }
+    let latest = latest_session_db();
+    if latest.is_none() {
+        print_report_local_sessions_warning();
+    }
+    latest
 }
 
 async fn run_with_extractor(

--- a/collector/src/model.rs
+++ b/collector/src/model.rs
@@ -18,6 +18,7 @@ pub struct TokenSummary {
     pub cache_read_tokens: i64,
     pub total_tokens: i64,
     pub calls: i64,
+    pub sessions: i64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -529,22 +529,29 @@ pub(crate) fn print_exported_snapshot(output: &str) {
     println!("Exported snapshot to {output}");
 }
 
+pub(crate) fn print_report_local_sessions_warning() {
+    eprintln!(
+        "Warning: No agentsight-*.db session database found in the current directory; using local agent sessions."
+    );
+}
+
 pub(crate) fn print_token_summary(group_by: &str, rows: &[TokenSummary]) {
     println!("Token usage grouped by {group_by}");
     println!(
-        "{:<32} {:>12} {:>12} {:>12} {:>12} {:>12} {:>8}",
-        "group", "input", "output", "cache_new", "cache_read", "total", "calls"
+        "{:<32} {:>12} {:>12} {:>12} {:>12} {:>12} {:>8} {:>8}",
+        "group", "input", "output", "cache_new", "cache_read", "total", "calls", "sessions"
     );
     for row in rows {
         println!(
-            "{:<32} {:>12} {:>12} {:>12} {:>12} {:>12} {:>8}",
+            "{:<32} {:>12} {:>12} {:>12} {:>12} {:>12} {:>8} {:>8}",
             truncate(&row.group, 32),
             row.input_tokens,
             row.output_tokens,
             row.cache_creation_tokens,
             row.cache_read_tokens,
             row.total_tokens,
-            row.calls
+            row.calls,
+            row.sessions
         );
     }
 }

--- a/collector/src/sources/session_db.rs
+++ b/collector/src/sources/session_db.rs
@@ -25,17 +25,6 @@ fn is_default_record_db(path: &std::path::Path) -> bool {
             .is_some_and(|name| name.starts_with("agentsight-"))
 }
 
-pub(crate) fn resolve_db_or_latest(
-    db: &Option<String>,
-) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-    if let Some(db) = db {
-        return Ok(db.clone());
-    }
-    latest_session_db().ok_or_else(|| {
-        "No agentsight-*.db session database found in the current directory. Run `agentsight record` first, or pass --db.".into()
-    })
-}
-
 pub(crate) fn latest_session_db() -> Option<String> {
     let dir = sessions_dir().ok()?;
     sorted_session_dbs(&dir)

--- a/collector/src/view/mod.rs
+++ b/collector/src/view/mod.rs
@@ -21,7 +21,7 @@ use crate::model::{
 };
 use chrono::{SecondsFormat, Utc};
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 
 pub(crate) type SharedMaterializedView = Arc<Mutex<MaterializedView>>;
@@ -357,26 +357,29 @@ impl MaterializedView {
     }
 
     pub(crate) fn token_summary(&self, group_by: &str) -> Vec<TokenSummary> {
-        let mut groups: BTreeMap<String, TokenSummary> = BTreeMap::new();
+        let mut groups: BTreeMap<String, TokenSummaryGroup> = BTreeMap::new();
         for token in self.effective_tokens() {
-            let group = token_group(token, group_by);
-            let entry = groups.entry(group.clone()).or_insert(TokenSummary {
-                group,
-                input_tokens: 0,
-                output_tokens: 0,
-                cache_creation_tokens: 0,
-                cache_read_tokens: 0,
-                total_tokens: 0,
-                calls: 0,
-            });
-            entry.input_tokens += token.input_tokens;
-            entry.output_tokens += token.output_tokens;
-            entry.cache_creation_tokens += token.cache_creation_tokens;
-            entry.cache_read_tokens += token.cache_read_tokens;
-            entry.total_tokens += token.total_tokens;
-            entry.calls += 1;
+            let group = self.token_group(token, group_by);
+            let entry = groups
+                .entry(group.clone())
+                .or_insert_with(|| TokenSummaryGroup::new(group));
+            entry.row.input_tokens += token.input_tokens;
+            entry.row.output_tokens += token.output_tokens;
+            entry.row.cache_creation_tokens += token.cache_creation_tokens;
+            entry.row.cache_read_tokens += token.cache_read_tokens;
+            entry.row.total_tokens += token.total_tokens;
+            entry.row.calls += 1;
+            if let Some(session_key) = self.token_session_key(token) {
+                entry.sessions.insert(session_key);
+            }
         }
-        let mut rows = groups.into_values().collect::<Vec<_>>();
+        let mut rows = groups
+            .into_values()
+            .map(|mut group| {
+                group.row.sessions = group.sessions.len() as i64;
+                group.row
+            })
+            .collect::<Vec<_>>();
         sort_token_summary(&mut rows);
         rows
     }
@@ -517,17 +520,91 @@ impl MaterializedView {
             timestamp,
         );
     }
+
+    fn token_group(&self, token: &TokenUsageRow, group_by: &str) -> String {
+        match group_by {
+            "provider" => token.provider.clone(),
+            "comm" => token.comm.clone(),
+            "pid" => token.pid.map(|pid| pid.to_string()),
+            "dir" | "cwd" | "directory" => self.token_working_dir(token),
+            _ => token.model.clone(),
+        }
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+    }
+
+    fn token_working_dir(&self, token: &TokenUsageRow) -> Option<String> {
+        self.token_session_key(token)
+            .and_then(|session_id| self.sessions.get(&session_id).and_then(session_cwd))
+            .or_else(|| self.token_process_cwd(token))
+    }
+
+    fn token_session_key(&self, token: &TokenUsageRow) -> Option<String> {
+        if let Some(session_id) = self
+            .llm_calls
+            .get(&token.llm_call_id)
+            .and_then(|row| row.session_id.as_ref())
+            .filter(|session_id| !session_id.is_empty())
+        {
+            return Some(session_id.clone());
+        }
+
+        self.sessions
+            .keys()
+            .find(|session_id| {
+                let session_id = session_id.as_str();
+                token.llm_call_id == session_id
+                    || token
+                        .llm_call_id
+                        .strip_prefix(session_id)
+                        .is_some_and(|suffix| suffix.starts_with('-'))
+            })
+            .cloned()
+    }
+
+    fn token_process_cwd(&self, token: &TokenUsageRow) -> Option<String> {
+        let pid = token.pid.or_else(|| {
+            self.llm_calls
+                .get(&token.llm_call_id)
+                .and_then(|row| row.pid)
+        })?;
+        self.process_nodes
+            .values()
+            .find(|row| row.pid == pid && row.cwd.as_deref().is_some_and(|cwd| !cwd.is_empty()))
+            .and_then(|row| row.cwd.clone())
+    }
 }
 
-fn token_group(token: &TokenUsageRow, group_by: &str) -> String {
-    match group_by {
-        "provider" => token.provider.clone(),
-        "comm" => token.comm.clone(),
-        "pid" => token.pid.map(|pid| pid.to_string()),
-        _ => token.model.clone(),
+struct TokenSummaryGroup {
+    row: TokenSummary,
+    sessions: BTreeSet<String>,
+}
+
+impl TokenSummaryGroup {
+    fn new(group: String) -> Self {
+        Self {
+            row: TokenSummary {
+                group,
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                total_tokens: 0,
+                calls: 0,
+                sessions: 0,
+            },
+            sessions: BTreeSet::new(),
+        }
     }
-    .filter(|value| !value.is_empty())
-    .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn session_cwd(session: &SessionRow) -> Option<String> {
+    session
+        .attributes
+        .get("cwd")
+        .and_then(Value::as_str)
+        .filter(|cwd| !cwd.is_empty())
+        .map(str::to_string)
 }
 
 fn token_has_higher_priority(candidate: &TokenUsageRow, current: &TokenUsageRow) -> bool {
@@ -621,6 +698,97 @@ mod tests {
         }
     }
 
+    fn session_row(id: &str, cwd: &str) -> SessionRow {
+        SessionRow {
+            id: id.to_string(),
+            agent_type: "codex".to_string(),
+            start_timestamp_ms: 1_000,
+            end_timestamp_ms: Some(2_000),
+            status: "observed".to_string(),
+            model: Some("gpt-5".to_string()),
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            view_source: AGENT_NATIVE_SOURCE.to_string(),
+            confidence: Some(0.95),
+            attributes: json!({ "cwd": cwd }),
+        }
+    }
+
+    fn token_row(
+        id: &str,
+        llm_call_id: &str,
+        model: &str,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_creation_tokens: i64,
+        cache_read_tokens: i64,
+        total_tokens: i64,
+    ) -> TokenUsageRow {
+        TokenUsageRow {
+            id: id.to_string(),
+            llm_call_id: llm_call_id.to_string(),
+            timestamp_ms: 1_500,
+            pid: None,
+            comm: Some("codex".to_string()),
+            provider: None,
+            model: Some(model.to_string()),
+            input_tokens,
+            output_tokens,
+            cache_creation_tokens,
+            cache_read_tokens,
+            total_tokens,
+            source: AGENT_NATIVE_SOURCE.to_string(),
+            view_source: AGENT_NATIVE_SOURCE.to_string(),
+            confidence: Some(0.95),
+        }
+    }
+
+    fn process_node(pid: u32, cwd: &str) -> ProcessNodeRow {
+        ProcessNodeRow {
+            id: format!("process-{pid}"),
+            pid,
+            ppid: None,
+            root_pid: Some(pid),
+            start_timestamp_ms: Some(1_000),
+            end_timestamp_ms: None,
+            comm: Some("agent".to_string()),
+            command: Some("agent".to_string()),
+            argv: Vec::new(),
+            cwd: Some(cwd.to_string()),
+            exit_code: None,
+            status: Some("observed".to_string()),
+            view_source: "process".to_string(),
+            confidence: Some(0.8),
+        }
+    }
+
+    fn llm_call_row(id: &str, pid: u32, session_id: Option<&str>) -> LlmCallRow {
+        LlmCallRow {
+            id: id.to_string(),
+            session_id: session_id.map(str::to_string),
+            conversation_id: None,
+            start_timestamp_ms: 1_100,
+            end_timestamp_ms: Some(1_400),
+            pid: Some(pid),
+            comm: Some("agent".to_string()),
+            provider: Some("anthropic".to_string()),
+            model: Some("claude-sonnet-4".to_string()),
+            call_kind: Some("messages".to_string()),
+            status: "ok".to_string(),
+            error_type: None,
+            finish_reason: None,
+            host: Some("api.anthropic.com".to_string()),
+            path: Some("/v1/messages".to_string()),
+            status_code: Some(200),
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0,
+            request: json!({}),
+            response: json!({}),
+        }
+    }
+
     #[test]
     fn audit_retention_keeps_counters_and_recent_rows() {
         let mut view = MaterializedView::bounded();
@@ -667,6 +835,76 @@ mod tests {
             MAX_RESOURCE_SAMPLES_IN_MEMORY
         );
         assert_eq!(snapshot.resource_samples[0].timestamp_ms, 5);
+    }
+
+    #[test]
+    fn token_summary_groups_agent_native_tokens_by_session_dir() {
+        let mut view = MaterializedView::new();
+        view.upsert_session(&session_row("local:codex:session-1", "/repo/one"));
+        view.apply_token_usage(&token_row(
+            "token-1",
+            "local:codex:session-1-gpt-5",
+            "gpt-5",
+            10,
+            5,
+            2,
+            3,
+            20,
+        ));
+        view.apply_token_usage(&token_row(
+            "token-2",
+            "local:codex:session-1-gpt-4",
+            "gpt-4",
+            7,
+            2,
+            0,
+            1,
+            10,
+        ));
+
+        let rows = view.token_summary("dir");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].group, "/repo/one");
+        assert_eq!(rows[0].input_tokens, 17);
+        assert_eq!(rows[0].output_tokens, 7);
+        assert_eq!(rows[0].cache_creation_tokens, 2);
+        assert_eq!(rows[0].cache_read_tokens, 4);
+        assert_eq!(rows[0].total_tokens, 30);
+        assert_eq!(rows[0].calls, 2);
+        assert_eq!(rows[0].sessions, 1);
+    }
+
+    #[test]
+    fn token_summary_groups_saved_tokens_by_process_dir() {
+        let mut view = MaterializedView::new();
+        view.upsert_process_node(&process_node(42, "/repo/saved"));
+        view.apply_llm_call(&llm_call_row("llm-1", 42, Some("session-1")));
+        view.apply_token_usage(&TokenUsageRow {
+            source: "response_usage".to_string(),
+            view_source: "sqlite".to_string(),
+            ..token_row("token-1", "llm-1", "claude-sonnet-4", 11, 13, 0, 0, 24)
+        });
+
+        let rows = view.token_summary("dir");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].group, "/repo/saved");
+        assert_eq!(rows[0].total_tokens, 24);
+        assert_eq!(rows[0].sessions, 1);
+    }
+
+    #[test]
+    fn token_summary_groups_missing_dir_as_unknown() {
+        let mut view = MaterializedView::new();
+        view.apply_token_usage(&token_row("token-1", "llm-1", "gpt-5", 1, 2, 3, 4, 10));
+
+        let rows = view.token_summary("dir");
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].group, "unknown");
+        assert_eq!(rows[0].total_tokens, 10);
+        assert_eq!(rows[0].sessions, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make `agentsight report` subcommands fall back to local Claude/Codex/Gemini agent sessions when no `agentsight-*.db` exists in the current directory.
- Keep explicit `--db` behavior unchanged, while missing implicit DBs now emit a warning instead of failing.
- Extend token summaries with a `sessions` count and add `--group-by dir` for session/process working-directory token breakdowns.
- Document the fallback behavior and directory grouping in the README.

## Validation

- `cargo test` from `collector/`
- `cargo run --quiet -- report token`
- `cargo run --quiet -- report token --group-by dir`