### PR TITLE
Add an interactive record workflow to `agentsight top`.

### DIFF
--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -69,6 +69,8 @@ pub(crate) fn run_saved_top_tui(
     )
 }
 
+const TUI_RECORD_SHUTDOWN_WAIT: Duration = Duration::from_secs(2);
+
 struct LiveTopTerminalGuard;
 
 impl LiveTopTerminalGuard {
@@ -180,54 +182,30 @@ where
             continue;
         }
 
-        if let Some(prompt) = &mut record_prompt {
-            if prompt.command.is_empty()
-                && record_task.as_ref().is_some_and(|task| !task.is_finished())
-            {
-                match key.code {
-                    KeyCode::Esc => record_prompt = None,
-                    KeyCode::Char('s') => {
-                        if let Some(task) = &mut record_task {
-                            task.stop();
-                            crate::push_tui_diagnostic("record stop requested");
-                        }
-                        record_prompt = None;
-                    }
-                    _ => {}
+        if record_prompt.is_some() {
+            match handle_record_prompt_key(
+                &mut record_prompt,
+                record_task.as_ref().is_some_and(|task| !task.is_finished()),
+                key.code,
+                key.modifiers,
+            ) {
+                RecordPromptAction::Start(command) => {
+                    crate::push_tui_diagnostic(&format!(
+                        "record started: pid {} -> {}",
+                        command.pid, command.db_path
+                    ));
+                    record_task = Some(TuiRecordTask::spawn(
+                        command,
+                        crate::cmd_trace::DEFAULT_SERVER_LISTEN.to_string(),
+                    ));
                 }
-                continue;
-            }
-            match key.code {
-                KeyCode::Esc => record_prompt = None,
-                KeyCode::Enter => match parse_tui_record_command(&prompt.command) {
-                    Ok(command) => {
-                        if record_task.as_ref().is_some_and(|task| !task.is_finished()) {
-                            prompt.error = Some("a record task is already running".to_string());
-                        } else {
-                            crate::push_tui_diagnostic(&format!(
-                                "record started: pid {} -> {}",
-                                command.pid, command.db_path
-                            ));
-                            record_task = Some(TuiRecordTask::spawn(
-                                command,
-                                crate::cmd_trace::DEFAULT_SERVER_LISTEN.to_string(),
-                            ));
-                            record_prompt = None;
-                        }
-                    }
-                    Err(error) => prompt.error = Some(error),
-                },
-                KeyCode::Backspace => {
-                    prompt.command.pop();
-                    prompt.error = None;
-                }
-                KeyCode::Char(ch) => {
-                    if !key.modifiers.contains(KeyModifiers::CONTROL) {
-                        prompt.command.push(ch);
-                        prompt.error = None;
+                RecordPromptAction::StopRunning => {
+                    if let Some(task) = &mut record_task {
+                        task.stop();
+                        crate::push_tui_diagnostic("record stop requested");
                     }
                 }
-                _ => {}
+                RecordPromptAction::None => {}
             }
             continue;
         }
@@ -240,40 +218,18 @@ where
             KeyCode::Char('p') => paused = !paused,
             KeyCode::Char('r') => force_refresh = true,
             KeyCode::Char('R') => {
-                if !allow_record {
-                    crate::push_tui_diagnostic(
-                        "record from top is only available for live sessions",
-                    );
-                    continue;
-                }
-                if let Some(task) = &record_task
-                    && !task.is_finished()
-                {
-                    show_help = false;
-                    show_diagnostics = false;
-                    record_prompt = Some(RecordPrompt {
-                        command: String::new(),
-                        error: Some(
-                            "record already running; press s in this dialog to stop".to_string(),
-                        ),
-                    });
-                    continue;
-                }
-                match current_top
-                    .as_ref()
-                    .and_then(|top| top.rows.get(selected))
-                    .map(|row| default_record_command_for_row(Some(row), 7395))
-                    .unwrap_or_else(|| default_record_command_for_row(None, 7395))
-                {
-                    Ok(command) => {
+                match open_record_prompt_for_selection(
+                    allow_record,
+                    current_top.as_ref(),
+                    selected,
+                    record_task.as_ref().is_some_and(|task| !task.is_finished()),
+                ) {
+                    RecordOpenAction::Open(prompt) => {
                         show_help = false;
                         show_diagnostics = false;
-                        record_prompt = Some(RecordPrompt {
-                            command: command.display_command(),
-                            error: None,
-                        });
+                        record_prompt = Some(prompt);
                     }
-                    Err(error) => crate::push_tui_diagnostic(&error),
+                    RecordOpenAction::Diagnostic(message) => crate::push_tui_diagnostic(&message),
                 }
             }
             KeyCode::Char('s') => {
@@ -316,17 +272,119 @@ where
         }
     }
 
-    if let Some(mut task) = record_task {
-        task.stop();
+    if let Some(task) = record_task {
+        task.shutdown_blocking(TUI_RECORD_SHUTDOWN_WAIT);
     }
 
     Ok(())
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct RecordPrompt {
     command: String,
     error: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RecordPromptAction {
+    None,
+    Start(crate::cmd_tui_record::TuiRecordCommand),
+    StopRunning,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum RecordOpenAction {
+    Open(RecordPrompt),
+    Diagnostic(String),
+}
+
+fn open_record_prompt_for_selection(
+    allow_record: bool,
+    current_top: Option<&AgentTopOutput<'_>>,
+    selected: usize,
+    record_running: bool,
+) -> RecordOpenAction {
+    if !allow_record {
+        return RecordOpenAction::Diagnostic(
+            "record from top is only available for live sessions".to_string(),
+        );
+    }
+    if record_running {
+        return RecordOpenAction::Open(RecordPrompt {
+            command: String::new(),
+            error: Some("record already running; press s in this dialog to stop".to_string()),
+        });
+    }
+    match current_top
+        .and_then(|top| top.rows.get(selected))
+        .map(|row| default_record_command_for_row(Some(row), 7395))
+        .unwrap_or_else(|| default_record_command_for_row(None, 7395))
+    {
+        Ok(command) => RecordOpenAction::Open(RecordPrompt {
+            command: command.display_command(),
+            error: None,
+        }),
+        Err(error) => RecordOpenAction::Diagnostic(error),
+    }
+}
+
+fn handle_record_prompt_key(
+    prompt: &mut Option<RecordPrompt>,
+    record_running: bool,
+    key_code: KeyCode,
+    modifiers: KeyModifiers,
+) -> RecordPromptAction {
+    let Some(current) = prompt else {
+        return RecordPromptAction::None;
+    };
+    if current.command.is_empty() && record_running {
+        return match key_code {
+            KeyCode::Esc => {
+                *prompt = None;
+                RecordPromptAction::None
+            }
+            KeyCode::Char('s') => {
+                *prompt = None;
+                RecordPromptAction::StopRunning
+            }
+            _ => RecordPromptAction::None,
+        };
+    }
+
+    match key_code {
+        KeyCode::Esc => {
+            *prompt = None;
+            RecordPromptAction::None
+        }
+        KeyCode::Enter => match parse_tui_record_command(&current.command) {
+            Ok(command) => {
+                if record_running {
+                    current.error = Some("a record task is already running".to_string());
+                    RecordPromptAction::None
+                } else {
+                    *prompt = None;
+                    RecordPromptAction::Start(command)
+                }
+            }
+            Err(error) => {
+                current.error = Some(error);
+                RecordPromptAction::None
+            }
+        },
+        KeyCode::Backspace => {
+            current.command.pop();
+            current.error = None;
+            RecordPromptAction::None
+        }
+        KeyCode::Char(ch) => {
+            if !modifiers.contains(KeyModifiers::CONTROL) {
+                current.command.push(ch);
+                current.error = None;
+            }
+            RecordPromptAction::None
+        }
+        _ => RecordPromptAction::None,
+    }
 }
 
 fn record_status_line(status: &TuiRecordStatus) -> String {
@@ -395,10 +453,14 @@ fn next_sort_key(current: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{RecordPrompt, record_running_lines, record_status_line};
+    use super::{
+        RecordOpenAction, RecordPrompt, RecordPromptAction, handle_record_prompt_key,
+        open_record_prompt_for_selection, record_running_lines, record_status_line,
+    };
     use crate::cmd_tui_record::TuiRecordStatus;
     use crate::output::tui::{tui_diagnostic_lines, tui_status_line};
     use crate::output::{AgentTopOutput, AgentTopRow};
+    use crossterm::event::{KeyCode, KeyModifiers};
 
     #[test]
     fn record_status_and_running_lines_include_target_db_and_server() {
@@ -432,6 +494,78 @@ mod tests {
         assert!(prompt.command.contains("record -p 42"));
     }
 
+    #[test]
+    fn record_r_with_selected_pid_opens_prompt_with_default_command() {
+        let top = AgentTopOutput {
+            mode: "live sessions",
+            db: None,
+            duration_s: 0.0,
+            view_events: 0,
+            llm_calls: 0,
+            total_tokens: 0,
+            rows: vec![AgentTopRow {
+                pid: Some(42),
+                ..AgentTopRow::default()
+            }],
+            sections: Vec::new(),
+            failures: Vec::new(),
+            notes: Vec::new(),
+        };
+
+        let action = open_record_prompt_for_selection(true, Some(&top), 0, false);
+
+        let RecordOpenAction::Open(prompt) = action else {
+            panic!("expected record prompt");
+        };
+        assert!(prompt.command.contains("record -p 42"));
+        assert!(prompt.command.contains("--db agentsight-"));
+        assert!(prompt.command.contains("--server-port 7395"));
+        assert_eq!(prompt.error, None);
+    }
+
+    #[test]
+    fn record_prompt_esc_closes_without_starting_task() {
+        let mut prompt = Some(RecordPrompt {
+            command: "agentsight record -p 42 --db out.db --server-port 7395".to_string(),
+            error: None,
+        });
+
+        let action = handle_record_prompt_key(&mut prompt, false, KeyCode::Esc, KeyModifiers::NONE);
+
+        assert_eq!(action, RecordPromptAction::None);
+        assert_eq!(prompt, None);
+    }
+
+    #[test]
+    fn record_r_when_task_running_opens_running_dialog() {
+        let action = open_record_prompt_for_selection(true, None, 0, true);
+
+        let RecordOpenAction::Open(prompt) = action else {
+            panic!("expected running prompt");
+        };
+        assert_eq!(prompt.command, "");
+        assert_eq!(
+            prompt.error.as_deref(),
+            Some("record already running; press s in this dialog to stop")
+        );
+    }
+
+    #[test]
+    fn record_enter_when_task_running_prevents_second_task() {
+        let mut prompt = Some(RecordPrompt {
+            command: "agentsight record -p 42 --db out.db --server-port 7395".to_string(),
+            error: None,
+        });
+
+        let action =
+            handle_record_prompt_key(&mut prompt, true, KeyCode::Enter, KeyModifiers::NONE);
+
+        assert_eq!(action, RecordPromptAction::None);
+        assert_eq!(
+            prompt.and_then(|prompt| prompt.error).as_deref(),
+            Some("a record task is already running")
+        );
+    }
     #[test]
     fn tui_status_compacts_source_notes() {
         let top = AgentTopOutput {

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -4,7 +4,12 @@
 use crate::binary_extractor::BinaryExtractor;
 use crate::cmd_perf::load_top_output;
 use crate::cmd_perf_live::{LiveEbpfCapture, start_live_ebpf_capture};
-use crate::output::{AgentTopOutput, TopOptions, draw_live_top_tui, next_view_key};
+use crate::cmd_tui_record::{
+    TuiRecordStatus, TuiRecordTask, default_record_command_for_row, parse_tui_record_command,
+};
+use crate::output::{
+    AgentTopOutput, TopOptions, TopRecordOverlay, draw_live_top_tui, next_view_key,
+};
 use crate::view::live_top::LiveView;
 use crate::view::top::{normalize_sort_key, sort_agent_rows};
 use crossterm::{
@@ -26,14 +31,21 @@ pub(crate) async fn run_live_top_tui(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let capture = start_live_ebpf_capture(binary_extractor, options).await;
     let mut live_view = LiveView::default();
-    let result = run_top_tui_loop(interval_secs, limit, count, options, |display_limit, options| {
-        let capture_snapshot = capture.as_ref().map(LiveEbpfCapture::snapshot);
-        let mut top = live_view.refresh(capture_snapshot.as_ref(), display_limit, options)?;
-        if let Some(note) = capture.as_ref().and_then(|capture| capture.start_note()) {
-            top.notes.push(note.to_string());
-        }
-        Ok(top)
-    });
+    let result = run_top_tui_loop(
+        interval_secs,
+        limit,
+        count,
+        options,
+        true,
+        |display_limit, options| {
+            let capture_snapshot = capture.as_ref().map(LiveEbpfCapture::snapshot);
+            let mut top = live_view.refresh(capture_snapshot.as_ref(), display_limit, options)?;
+            if let Some(note) = capture.as_ref().and_then(|capture| capture.start_note()) {
+                top.notes.push(note.to_string());
+            }
+            Ok(top)
+        },
+    );
     if let Some(capture) = capture {
         capture.stop();
     }
@@ -47,9 +59,14 @@ pub(crate) fn run_saved_top_tui(
     count: Option<u32>,
     options: &TopOptions,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    run_top_tui_loop(interval_secs, limit, count, options, |display_limit, options| {
-        load_top_output(db, display_limit, options)
-    })
+    run_top_tui_loop(
+        interval_secs,
+        limit,
+        count,
+        options,
+        false,
+        |display_limit, options| load_top_output(db, display_limit, options),
+    )
 }
 
 struct LiveTopTerminalGuard;
@@ -76,6 +93,7 @@ fn run_top_tui_loop<'a, F>(
     limit: usize,
     count: Option<u32>,
     options: &TopOptions,
+    allow_record: bool,
     mut refresh: F,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 where
@@ -97,6 +115,8 @@ where
     let mut paused = false;
     let mut show_help = false;
     let mut show_diagnostics = false;
+    let mut record_prompt: Option<RecordPrompt> = None;
+    let mut record_task: Option<TuiRecordTask> = None;
     let mut last_refresh = Instant::now() - interval;
     let mut force_refresh = true;
     let mut refreshes = 0u32;
@@ -118,6 +138,10 @@ where
         let top = current_top
             .as_ref()
             .expect("live top TUI refreshes before first render");
+        let record_status = record_task
+            .as_ref()
+            .map(|task| record_status_line(&task.status()));
+        let record_overlay = record_overlay(&record_prompt, record_task.as_ref());
         terminal.draw(|frame| {
             draw_live_top_tui(
                 frame,
@@ -129,6 +153,8 @@ where
                 show_diagnostics,
                 interval_secs,
                 display_limit,
+                record_status.as_deref(),
+                record_overlay.as_ref(),
             );
         })?;
 
@@ -154,6 +180,58 @@ where
             continue;
         }
 
+        if let Some(prompt) = &mut record_prompt {
+            if prompt.command.is_empty()
+                && record_task.as_ref().is_some_and(|task| !task.is_finished())
+            {
+                match key.code {
+                    KeyCode::Esc => record_prompt = None,
+                    KeyCode::Char('s') => {
+                        if let Some(task) = &mut record_task {
+                            task.stop();
+                            crate::push_tui_diagnostic("record stop requested");
+                        }
+                        record_prompt = None;
+                    }
+                    _ => {}
+                }
+                continue;
+            }
+            match key.code {
+                KeyCode::Esc => record_prompt = None,
+                KeyCode::Enter => match parse_tui_record_command(&prompt.command) {
+                    Ok(command) => {
+                        if record_task.as_ref().is_some_and(|task| !task.is_finished()) {
+                            prompt.error = Some("a record task is already running".to_string());
+                        } else {
+                            crate::push_tui_diagnostic(&format!(
+                                "record started: pid {} -> {}",
+                                command.pid, command.db_path
+                            ));
+                            record_task = Some(TuiRecordTask::spawn(
+                                command,
+                                crate::cmd_trace::DEFAULT_SERVER_LISTEN.to_string(),
+                            ));
+                            record_prompt = None;
+                        }
+                    }
+                    Err(error) => prompt.error = Some(error),
+                },
+                KeyCode::Backspace => {
+                    prompt.command.pop();
+                    prompt.error = None;
+                }
+                KeyCode::Char(ch) => {
+                    if !key.modifiers.contains(KeyModifiers::CONTROL) {
+                        prompt.command.push(ch);
+                        prompt.error = None;
+                    }
+                }
+                _ => {}
+            }
+            continue;
+        }
+
         match key.code {
             KeyCode::Char('q') | KeyCode::Esc => break,
             KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => break,
@@ -161,6 +239,43 @@ where
             KeyCode::Char('e') => show_diagnostics = !show_diagnostics,
             KeyCode::Char('p') => paused = !paused,
             KeyCode::Char('r') => force_refresh = true,
+            KeyCode::Char('R') => {
+                if !allow_record {
+                    crate::push_tui_diagnostic(
+                        "record from top is only available for live sessions",
+                    );
+                    continue;
+                }
+                if let Some(task) = &record_task
+                    && !task.is_finished()
+                {
+                    show_help = false;
+                    show_diagnostics = false;
+                    record_prompt = Some(RecordPrompt {
+                        command: String::new(),
+                        error: Some(
+                            "record already running; press s in this dialog to stop".to_string(),
+                        ),
+                    });
+                    continue;
+                }
+                match current_top
+                    .as_ref()
+                    .and_then(|top| top.rows.get(selected))
+                    .map(|row| default_record_command_for_row(Some(row), 7395))
+                    .unwrap_or_else(|| default_record_command_for_row(None, 7395))
+                {
+                    Ok(command) => {
+                        show_help = false;
+                        show_diagnostics = false;
+                        record_prompt = Some(RecordPrompt {
+                            command: command.display_command(),
+                            error: None,
+                        });
+                    }
+                    Err(error) => crate::push_tui_diagnostic(&error),
+                }
+            }
             KeyCode::Char('s') => {
                 options.sort = next_sort_key(&options.sort);
                 if let Some(top) = &mut current_top {
@@ -201,7 +316,61 @@ where
         }
     }
 
+    if let Some(mut task) = record_task {
+        task.stop();
+    }
+
     Ok(())
+}
+
+#[derive(Debug, Clone)]
+struct RecordPrompt {
+    command: String,
+    error: Option<String>,
+}
+
+fn record_status_line(status: &TuiRecordStatus) -> String {
+    let server = status
+        .server_url
+        .as_deref()
+        .map(|url| format!("  server={url}"))
+        .unwrap_or_default();
+    format!(
+        "{}  db={}  status={}{}",
+        status.target, status.db_path, status.message, server
+    )
+}
+
+fn record_overlay(
+    prompt: &Option<RecordPrompt>,
+    task: Option<&TuiRecordTask>,
+) -> Option<TopRecordOverlay> {
+    if let Some(prompt) = prompt {
+        if prompt.command.is_empty()
+            && let Some(task) = task
+        {
+            return Some(TopRecordOverlay::Running {
+                lines: record_running_lines(&task.status()),
+            });
+        }
+        return Some(TopRecordOverlay::Prompt {
+            command: prompt.command.clone(),
+            error: prompt.error.clone(),
+        });
+    }
+    None
+}
+
+fn record_running_lines(status: &TuiRecordStatus) -> Vec<String> {
+    let mut lines = vec![
+        format!("target: {}", status.target),
+        format!("db: {}", status.db_path),
+        format!("status: {}", status.message),
+    ];
+    if let Some(url) = &status.server_url {
+        lines.push(format!("server: {url}"));
+    }
+    lines
 }
 
 fn clamp_selected(selected: &mut usize, rows: usize) {
@@ -226,8 +395,42 @@ fn next_sort_key(current: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use super::{RecordPrompt, record_running_lines, record_status_line};
+    use crate::cmd_tui_record::TuiRecordStatus;
     use crate::output::tui::{tui_diagnostic_lines, tui_status_line};
     use crate::output::{AgentTopOutput, AgentTopRow};
+
+    #[test]
+    fn record_status_and_running_lines_include_target_db_and_server() {
+        let status = TuiRecordStatus {
+            target: "pid 42".to_string(),
+            db_path: "agentsight-test.db".to_string(),
+            server_url: Some("http://127.0.0.1:7395/".to_string()),
+            message: "recording".to_string(),
+            finished: false,
+        };
+
+        assert_eq!(
+            record_status_line(&status),
+            "pid 42  db=agentsight-test.db  status=recording  server=http://127.0.0.1:7395/"
+        );
+        assert_eq!(
+            record_running_lines(&status),
+            vec![
+                "target: pid 42".to_string(),
+                "db: agentsight-test.db".to_string(),
+                "status: recording".to_string(),
+                "server: http://127.0.0.1:7395/".to_string(),
+            ]
+        );
+
+        let prompt = RecordPrompt {
+            command: "agentsight record -p 42 --db agentsight-test.db --server-port 7395"
+                .to_string(),
+            error: None,
+        };
+        assert!(prompt.command.contains("record -p 42"));
+    }
 
     #[test]
     fn tui_status_compacts_source_notes() {

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -240,6 +240,15 @@ where
                     clamp_selected(&mut selected, top.rows.len());
                 }
             }
+            KeyCode::Char('S') => {
+                if let Some(prompt) = handle_record_stop_shortcut(
+                    record_task.as_ref().is_some_and(|task| !task.is_finished()),
+                ) {
+                    show_help = false;
+                    show_diagnostics = false;
+                    record_prompt = Some(prompt);
+                }
+            }
             KeyCode::Char('v') => options.view = next_view_key(&options.view),
             KeyCode::Char('+') | KeyCode::Char('=') => {
                 display_limit = (display_limit + 1).min(100);
@@ -280,9 +289,21 @@ where
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct RecordPrompt {
-    command: String,
-    error: Option<String>,
+enum RecordPrompt {
+    Start {
+        command: String,
+        error: Option<String>,
+    },
+    StopConfirm,
+}
+
+impl RecordPrompt {
+    fn start(command: String) -> Self {
+        Self::Start {
+            command,
+            error: None,
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -310,22 +331,20 @@ fn open_record_prompt_for_selection(
         );
     }
     if record_running {
-        return RecordOpenAction::Open(RecordPrompt {
-            command: String::new(),
-            error: Some("record already running; press s in this dialog to stop".to_string()),
-        });
+        return RecordOpenAction::Open(RecordPrompt::StopConfirm);
     }
     match current_top
         .and_then(|top| top.rows.get(selected))
         .map(|row| default_record_command_for_row(Some(row), 7395))
         .unwrap_or_else(|| default_record_command_for_row(None, 7395))
     {
-        Ok(command) => RecordOpenAction::Open(RecordPrompt {
-            command: command.display_command(),
-            error: None,
-        }),
+        Ok(command) => RecordOpenAction::Open(RecordPrompt::start(command.display_command())),
         Err(error) => RecordOpenAction::Diagnostic(error),
     }
+}
+
+fn handle_record_stop_shortcut(record_running: bool) -> Option<RecordPrompt> {
+    record_running.then_some(RecordPrompt::StopConfirm)
 }
 
 fn handle_record_prompt_key(
@@ -337,53 +356,57 @@ fn handle_record_prompt_key(
     let Some(current) = prompt else {
         return RecordPromptAction::None;
     };
-    if current.command.is_empty() && record_running {
-        return match key_code {
+
+    match current {
+        RecordPrompt::StopConfirm => match key_code {
             KeyCode::Esc => {
                 *prompt = None;
                 RecordPromptAction::None
             }
-            KeyCode::Char('s') => {
+            KeyCode::Enter | KeyCode::Char('S') => {
                 *prompt = None;
-                RecordPromptAction::StopRunning
-            }
-            _ => RecordPromptAction::None,
-        };
-    }
-
-    match key_code {
-        KeyCode::Esc => {
-            *prompt = None;
-            RecordPromptAction::None
-        }
-        KeyCode::Enter => match parse_tui_record_command(&current.command) {
-            Ok(command) => {
                 if record_running {
-                    current.error = Some("a record task is already running".to_string());
-                    RecordPromptAction::None
+                    RecordPromptAction::StopRunning
                 } else {
-                    *prompt = None;
-                    RecordPromptAction::Start(command)
+                    RecordPromptAction::None
                 }
             }
-            Err(error) => {
-                current.error = Some(error);
+            _ => RecordPromptAction::None,
+        },
+        RecordPrompt::Start { command, error } => match key_code {
+            KeyCode::Esc => {
+                *prompt = None;
                 RecordPromptAction::None
             }
-        },
-        KeyCode::Backspace => {
-            current.command.pop();
-            current.error = None;
-            RecordPromptAction::None
-        }
-        KeyCode::Char(ch) => {
-            if !modifiers.contains(KeyModifiers::CONTROL) {
-                current.command.push(ch);
-                current.error = None;
+            KeyCode::Enter => match parse_tui_record_command(command) {
+                Ok(parsed_command) => {
+                    if record_running {
+                        *error = Some("a record task is already running".to_string());
+                        RecordPromptAction::None
+                    } else {
+                        *prompt = None;
+                        RecordPromptAction::Start(parsed_command)
+                    }
+                }
+                Err(parse_error) => {
+                    *error = Some(parse_error);
+                    RecordPromptAction::None
+                }
+            },
+            KeyCode::Backspace => {
+                command.pop();
+                *error = None;
+                RecordPromptAction::None
             }
-            RecordPromptAction::None
-        }
-        _ => RecordPromptAction::None,
+            KeyCode::Char(ch) => {
+                if !modifiers.contains(KeyModifiers::CONTROL) {
+                    command.push(ch);
+                    *error = None;
+                }
+                RecordPromptAction::None
+            }
+            _ => RecordPromptAction::None,
+        },
     }
 }
 
@@ -404,17 +427,15 @@ fn record_overlay(
     task: Option<&TuiRecordTask>,
 ) -> Option<TopRecordOverlay> {
     if let Some(prompt) = prompt {
-        if prompt.command.is_empty()
-            && let Some(task) = task
-        {
-            return Some(TopRecordOverlay::Running {
+        return match prompt {
+            RecordPrompt::StopConfirm => task.map(|task| TopRecordOverlay::Running {
                 lines: record_running_lines(&task.status()),
-            });
-        }
-        return Some(TopRecordOverlay::Prompt {
-            command: prompt.command.clone(),
-            error: prompt.error.clone(),
-        });
+            }),
+            RecordPrompt::Start { command, error } => Some(TopRecordOverlay::Prompt {
+                command: command.clone(),
+                error: error.clone(),
+            }),
+        };
     }
     None
 }
@@ -455,7 +476,8 @@ fn next_sort_key(current: &str) -> String {
 mod tests {
     use super::{
         RecordOpenAction, RecordPrompt, RecordPromptAction, handle_record_prompt_key,
-        open_record_prompt_for_selection, record_running_lines, record_status_line,
+        handle_record_stop_shortcut, next_sort_key, open_record_prompt_for_selection,
+        record_running_lines, record_status_line,
     };
     use crate::cmd_tui_record::TuiRecordStatus;
     use crate::output::tui::{tui_diagnostic_lines, tui_status_line};
@@ -486,12 +508,13 @@ mod tests {
             ]
         );
 
-        let prompt = RecordPrompt {
-            command: "agentsight record -p 42 --db agentsight-test.db --server-port 7395"
-                .to_string(),
-            error: None,
+        let prompt = RecordPrompt::start(
+            "agentsight record -p 42 --db agentsight-test.db --server-port 7395".to_string(),
+        );
+        let RecordPrompt::Start { command, .. } = prompt else {
+            panic!("expected start prompt");
         };
-        assert!(prompt.command.contains("record -p 42"));
+        assert!(command.contains("record -p 42"));
     }
 
     #[test]
@@ -517,18 +540,20 @@ mod tests {
         let RecordOpenAction::Open(prompt) = action else {
             panic!("expected record prompt");
         };
-        assert!(prompt.command.contains("record -p 42"));
-        assert!(prompt.command.contains("--db agentsight-"));
-        assert!(prompt.command.contains("--server-port 7395"));
-        assert_eq!(prompt.error, None);
+        let RecordPrompt::Start { command, error } = prompt else {
+            panic!("expected start prompt");
+        };
+        assert!(command.contains("record -p 42"));
+        assert!(command.contains("--db agentsight-"));
+        assert!(command.contains("--server-port 7395"));
+        assert_eq!(error, None);
     }
 
     #[test]
     fn record_prompt_esc_closes_without_starting_task() {
-        let mut prompt = Some(RecordPrompt {
-            command: "agentsight record -p 42 --db out.db --server-port 7395".to_string(),
-            error: None,
-        });
+        let mut prompt = Some(RecordPrompt::start(
+            "agentsight record -p 42 --db out.db --server-port 7395".to_string(),
+        ));
 
         let action = handle_record_prompt_key(&mut prompt, false, KeyCode::Esc, KeyModifiers::NONE);
 
@@ -536,6 +561,42 @@ mod tests {
         assert_eq!(prompt, None);
     }
 
+
+    #[test]
+    fn lower_s_remains_sort_shortcut_even_when_recording() {
+        assert_eq!(next_sort_key("cpu"), "rss");
+        assert_eq!(handle_record_stop_shortcut(false), None);
+    }
+
+    #[test]
+    fn record_shift_s_when_task_running_opens_stop_prompt() {
+        assert_eq!(
+            handle_record_stop_shortcut(true),
+            Some(RecordPrompt::StopConfirm)
+        );
+        assert_eq!(handle_record_stop_shortcut(false), None);
+    }
+
+    #[test]
+    fn record_stop_prompt_shift_s_stops_running_task() {
+        let mut prompt = Some(RecordPrompt::StopConfirm);
+
+        let action =
+            handle_record_prompt_key(&mut prompt, true, KeyCode::Char('S'), KeyModifiers::NONE);
+
+        assert_eq!(action, RecordPromptAction::StopRunning);
+        assert_eq!(prompt, None);
+    }
+
+    #[test]
+    fn record_stop_prompt_esc_cancels_without_stopping() {
+        let mut prompt = Some(RecordPrompt::StopConfirm);
+
+        let action = handle_record_prompt_key(&mut prompt, true, KeyCode::Esc, KeyModifiers::NONE);
+
+        assert_eq!(action, RecordPromptAction::None);
+        assert_eq!(prompt, None);
+    }
     #[test]
     fn record_r_when_task_running_opens_running_dialog() {
         let action = open_record_prompt_for_selection(true, None, 0, true);
@@ -543,28 +604,23 @@ mod tests {
         let RecordOpenAction::Open(prompt) = action else {
             panic!("expected running prompt");
         };
-        assert_eq!(prompt.command, "");
-        assert_eq!(
-            prompt.error.as_deref(),
-            Some("record already running; press s in this dialog to stop")
-        );
+        assert_eq!(prompt, RecordPrompt::StopConfirm);
     }
 
     #[test]
     fn record_enter_when_task_running_prevents_second_task() {
-        let mut prompt = Some(RecordPrompt {
-            command: "agentsight record -p 42 --db out.db --server-port 7395".to_string(),
-            error: None,
-        });
+        let mut prompt = Some(RecordPrompt::start(
+            "agentsight record -p 42 --db out.db --server-port 7395".to_string(),
+        ));
 
         let action =
             handle_record_prompt_key(&mut prompt, true, KeyCode::Enter, KeyModifiers::NONE);
 
         assert_eq!(action, RecordPromptAction::None);
-        assert_eq!(
-            prompt.and_then(|prompt| prompt.error).as_deref(),
-            Some("a record task is already running")
-        );
+        let Some(RecordPrompt::Start { error, .. }) = prompt else {
+            panic!("expected start prompt with error");
+        };
+        assert_eq!(error.as_deref(), Some("a record task is already running"));
     }
     #[test]
     fn tui_status_compacts_source_notes() {

--- a/collector/src/cmd_trace.rs
+++ b/collector/src/cmd_trace.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 eunomia-bpf org.
 
 use futures::stream::StreamExt;
+use tokio::sync::oneshot;
 
 use crate::analyzers::{
     AuthHeaderRemover, HTTPDecompressor, HTTPFilter, HTTPParser, MaterializingAnalyzer,
@@ -35,6 +36,12 @@ const DEFAULT_HTTP_FILTER: &str = "request.path_prefix=/v1/rgstr | response.stat
 pub(crate) struct StartedWebServer {
     pub(crate) url: String,
     pub(crate) _handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for StartedWebServer {
+    fn drop(&mut self) {
+        self._handle.abort();
+    }
 }
 
 /// Configuration for exporting GenAI spans to an OpenTelemetry Collector.
@@ -421,6 +428,127 @@ pub(crate) async fn start_web_server_if_enabled(
         url,
         _handle: server_handle,
     }))
+}
+
+async fn start_web_server_silent_if_enabled(
+    enable_server: bool,
+    listen: &str,
+    port: u16,
+    view: SharedMaterializedView,
+    db_path: Option<String>,
+) -> Result<Option<StartedWebServer>, Box<dyn std::error::Error>> {
+    if !enable_server {
+        return Ok(None);
+    }
+
+    let listen = if listen.trim().is_empty() {
+        DEFAULT_SERVER_LISTEN
+    } else {
+        listen.trim()
+    };
+    let addr = format!("{}:{}", listen, port)
+        .parse()
+        .map_err(|e| format!("Invalid server address: {}", e))?;
+    let web_server = WebServer::new_with_db_path(view, db_path)
+        .map_err(|e| format!("Failed to create web server: {}", e))?;
+
+    let host = if listen == "0.0.0.0" || listen == "::" {
+        "127.0.0.1"
+    } else {
+        listen
+    };
+    let url = format!("http://{}:{}/", host, port);
+
+    let server_handle = tokio::spawn(async move {
+        if let Err(e) = web_server.start(addr).await {
+            log::warn!("web server error: {}", e);
+        }
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    if server_handle.is_finished() {
+        return Err(Box::new(std::io::Error::other(
+            "web server exited during startup",
+        )));
+    }
+
+    Ok(Some(StartedWebServer {
+        url,
+        _handle: server_handle,
+    }))
+}
+
+pub(crate) async fn run_trace_silent_until_cancel(
+    binary_extractor: &BinaryExtractor,
+    mut cfg: TraceConfig,
+    mut cancel: oneshot::Receiver<()>,
+) -> Result<Option<String>, RunnerError> {
+    if let Some((_reference, resolved)) =
+        resolve_container_binary_arg(cfg.binary_path.as_deref()).map_err(RunnerError::from)?
+    {
+        cfg.binary_path = Some(resolved);
+    }
+
+    if cfg.ssl && cfg.binary_path.is_none() {
+        let resolved = cfg
+            .comm
+            .as_deref()
+            .filter(|c| !c.contains(','))
+            .and_then(|c| resolve_binary_path(c).ok())
+            .filter(|p| binary_embeds_ssl(p));
+        if let Some(p) = resolved {
+            cfg.binary_path = Some(p);
+        }
+    }
+
+    let enable_server = cfg.server;
+    let server_listen = cfg
+        .server_listen
+        .as_deref()
+        .unwrap_or(DEFAULT_SERVER_LISTEN)
+        .to_string();
+    let server_port = cfg.server_port;
+    let db_path = cfg.db_path.clone();
+
+    prepare_process_seeds(&mut cfg)?;
+    let live_view = MaterializedView::shared_bounded();
+    let mut agent = build_trace_agent_with_view(binary_extractor, &cfg, live_view.clone())?;
+    let server = start_web_server_silent_if_enabled(
+        enable_server,
+        &server_listen,
+        server_port,
+        live_view,
+        db_path,
+    )
+    .await
+    .map_err(|e| RunnerError::from(format!("Failed to start server: {}", e)))?;
+    let server_url = server.as_ref().map(|server| server.url.clone());
+
+    let mut stream = agent.run().await?;
+    let shutdown = crate::shutdown_notify();
+    loop {
+        tokio::select! {
+            maybe_event = stream.next() => {
+                match maybe_event {
+                    Some(event) => {
+                        if let Some(error) = runner_error_from_event(&event) {
+                            return Err(error);
+                        }
+                    }
+                    None => break,
+                }
+            }
+            _ = &mut cancel => {
+                break;
+            }
+            _ = shutdown.notified() => {
+                break;
+            }
+        }
+    }
+    drop(stream);
+    drop(agent);
+    Ok(server_url)
 }
 
 pub(crate) async fn drive_stream_until_shutdown(

--- a/collector/src/cmd_tui_record.rs
+++ b/collector/src/cmd_tui_record.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+use crate::binary_extractor::BinaryExtractor;
+use crate::cmd_trace::{TraceConfig, run_trace_silent_until_cancel};
+use crate::output::AgentTopRow;
+use chrono::Local;
+use std::sync::{Arc, Mutex};
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TuiRecordCommand {
+    pub(crate) pid: u32,
+    pub(crate) binary_path: Option<String>,
+    pub(crate) db_path: String,
+    pub(crate) server: bool,
+    pub(crate) server_port: u16,
+}
+
+impl TuiRecordCommand {
+    pub(crate) fn display_command(&self) -> String {
+        let mut parts = vec![
+            "agentsight".to_string(),
+            "record".to_string(),
+            "-p".to_string(),
+            self.pid.to_string(),
+        ];
+        if let Some(path) = &self.binary_path {
+            parts.extend(["--binary-path".to_string(), path.clone()]);
+        }
+        parts.extend(["--db".to_string(), self.db_path.clone()]);
+        if self.server {
+            parts.extend(["--server-port".to_string(), self.server_port.to_string()]);
+        } else {
+            parts.push("--no-server".to_string());
+        }
+        parts.join(" ")
+    }
+
+    fn trace_config(&self, listen: &str) -> TraceConfig {
+        TraceConfig {
+            pid: Some(self.pid),
+            stdio: true,
+            binary_path: self.binary_path.clone(),
+            db_path: Some(self.db_path.clone()),
+            server: self.server,
+            server_listen: Some(listen.to_string()),
+            server_port: self.server_port,
+            ..TraceConfig::for_record()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TuiRecordStatus {
+    pub(crate) target: String,
+    pub(crate) db_path: String,
+    pub(crate) server_url: Option<String>,
+    pub(crate) message: String,
+    pub(crate) finished: bool,
+}
+
+pub(crate) struct TuiRecordTask {
+    status: Arc<Mutex<TuiRecordStatus>>,
+    cancel: Option<oneshot::Sender<()>>,
+    handle: JoinHandle<()>,
+}
+
+impl TuiRecordTask {
+    pub(crate) fn spawn(command: TuiRecordCommand, listen: String) -> Self {
+        let status = Arc::new(Mutex::new(TuiRecordStatus {
+            target: format!("pid {}", command.pid),
+            db_path: command.db_path.clone(),
+            server_url: None,
+            message: "starting".to_string(),
+            finished: false,
+        }));
+        let task_status = status.clone();
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        if command.server {
+            set_status(&status, |status| {
+                status.server_url = Some(default_server_url(&listen, command.server_port));
+            });
+        }
+        let handle = tokio::spawn(async move {
+            let result = async {
+                let extractor = BinaryExtractor::new()
+                    .await
+                    .map_err(|e| format!("failed to extract eBPF binaries: {e}"))?;
+                set_status(&task_status, |status| {
+                    status.message = "recording".to_string()
+                });
+                run_trace_silent_until_cancel(&extractor, command.trace_config(&listen), cancel_rx)
+                    .await
+                    .map_err(|e| e.to_string())
+            }
+            .await;
+
+            match result {
+                Ok(server_url) => set_status(&task_status, |status| {
+                    if server_url.is_some() {
+                        status.server_url = server_url;
+                    }
+                    status.message = "stopped".to_string();
+                    status.finished = true;
+                }),
+                Err(error) => set_status(&task_status, |status| {
+                    status.message = format!("error: {error}");
+                    status.finished = true;
+                }),
+            }
+        });
+
+        Self {
+            status,
+            cancel: Some(cancel_tx),
+            handle,
+        }
+    }
+
+    pub(crate) fn status(&self) -> TuiRecordStatus {
+        self.status
+            .lock()
+            .map(|status| status.clone())
+            .unwrap_or_else(|_| TuiRecordStatus {
+                target: "record".to_string(),
+                db_path: "-".to_string(),
+                server_url: None,
+                message: "status unavailable".to_string(),
+                finished: true,
+            })
+    }
+
+    pub(crate) fn stop(&mut self) {
+        if let Some(cancel) = self.cancel.take() {
+            let _ = cancel.send(());
+        }
+        set_status(&self.status, |status| {
+            if !status.finished {
+                status.message = "stopping".to_string();
+            }
+        });
+    }
+
+    pub(crate) fn is_finished(&self) -> bool {
+        self.handle.is_finished() || self.status().finished
+    }
+}
+
+impl Drop for TuiRecordTask {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+fn default_server_url(listen: &str, port: u16) -> String {
+    let listen = if listen.trim().is_empty() {
+        crate::cmd_trace::DEFAULT_SERVER_LISTEN
+    } else {
+        listen.trim()
+    };
+    let host = if listen == "0.0.0.0" || listen == "::" {
+        "127.0.0.1"
+    } else {
+        listen
+    };
+    format!("http://{}:{}/", host, port)
+}
+
+fn set_status(status: &Arc<Mutex<TuiRecordStatus>>, update: impl FnOnce(&mut TuiRecordStatus)) {
+    if let Ok(mut status) = status.lock() {
+        update(&mut status);
+    }
+}
+
+pub(crate) fn default_record_command_for_row(
+    row: Option<&AgentTopRow>,
+    server_port: u16,
+) -> Result<TuiRecordCommand, String> {
+    let row = row.ok_or_else(|| "no selected session to record".to_string())?;
+    let pid = row
+        .pid
+        .ok_or_else(|| "selected session has no PID; record requires a live process".to_string())?;
+    Ok(TuiRecordCommand {
+        pid,
+        binary_path: None,
+        db_path: default_tui_record_db_path(),
+        server: true,
+        server_port,
+    })
+}
+
+fn default_tui_record_db_path() -> String {
+    format!("agentsight-{}.db", Local::now().format("%Y%m%d-%H%M%S"))
+}
+
+pub(crate) fn parse_tui_record_command(input: &str) -> Result<TuiRecordCommand, String> {
+    let mut tokens: Vec<&str> = input.split_whitespace().collect();
+    if tokens.first() == Some(&"agentsight") {
+        tokens.remove(0);
+    }
+    if tokens.first() == Some(&"record") {
+        tokens.remove(0);
+    }
+    if tokens.iter().any(|token| *token == "--") {
+        return Err(
+            "TUI record only supports attach options, not `record -- <command>`".to_string(),
+        );
+    }
+
+    let mut pid = None;
+    let mut binary_path = None;
+    let mut db_path = None;
+    let mut server = true;
+    let mut server_port = 7395u16;
+    let mut i = 0usize;
+    while i < tokens.len() {
+        match tokens[i] {
+            "-p" | "--pid" => {
+                i += 1;
+                let value = tokens
+                    .get(i)
+                    .ok_or_else(|| "missing value for --pid".to_string())?;
+                pid = Some(
+                    value
+                        .parse::<u32>()
+                        .map_err(|_| format!("invalid pid: {value}"))?,
+                );
+            }
+            "--binary-path" => {
+                i += 1;
+                let value = tokens
+                    .get(i)
+                    .ok_or_else(|| "missing value for --binary-path".to_string())?;
+                binary_path = Some((*value).to_string());
+            }
+            "--db" => {
+                i += 1;
+                let value = tokens
+                    .get(i)
+                    .ok_or_else(|| "missing value for --db".to_string())?;
+                db_path = Some((*value).to_string());
+            }
+            "--no-server" => server = false,
+            "--server-port" => {
+                i += 1;
+                let value = tokens
+                    .get(i)
+                    .ok_or_else(|| "missing value for --server-port".to_string())?;
+                server_port = value
+                    .parse::<u16>()
+                    .map_err(|_| format!("invalid server port: {value}"))?;
+            }
+            "-c" | "--comm" => {
+                return Err(
+                    "TUI record only supports PID attach; use record -c outside top".to_string(),
+                );
+            }
+            other => return Err(format!("unsupported record option: {other}")),
+        }
+        i += 1;
+    }
+
+    Ok(TuiRecordCommand {
+        pid: pid.ok_or_else(|| "record command requires -p/--pid".to_string())?,
+        binary_path,
+        db_path: db_path.ok_or_else(|| "record command requires --db".to_string())?,
+        server,
+        server_port,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::output::AgentTopRow;
+
+    fn row(pid: Option<u32>) -> AgentTopRow {
+        AgentTopRow {
+            pid,
+            ..AgentTopRow::default()
+        }
+    }
+
+    #[test]
+    fn default_record_command_uses_selected_pid() {
+        let command = default_record_command_for_row(Some(&row(Some(42))), 7395).unwrap();
+        assert_eq!(command.pid, 42);
+        assert!(command.display_command().contains("record -p 42"));
+    }
+
+    #[test]
+    fn default_record_command_rejects_missing_pid() {
+        let error = default_record_command_for_row(Some(&row(None)), 7395).unwrap_err();
+        assert!(error.contains("no PID"));
+    }
+
+    #[test]
+    fn parse_allowed_attach_options() {
+        let command = parse_tui_record_command(
+            "agentsight record -p 42 --binary-path /bin/node --db out.db --no-server --server-port 7400",
+        )
+        .unwrap();
+        assert_eq!(command.pid, 42);
+        assert_eq!(command.binary_path.as_deref(), Some("/bin/node"));
+        assert_eq!(command.db_path, "out.db");
+        assert!(!command.server);
+        assert_eq!(command.server_port, 7400);
+    }
+
+    #[test]
+    fn parse_rejects_comm_and_launch_command() {
+        assert!(parse_tui_record_command("record -c claude --db out.db").is_err());
+        assert!(parse_tui_record_command("record -p 1 --db out.db -- claude").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_missing_values_unknown_options_and_missing_pid() {
+        assert!(parse_tui_record_command("record -p --db out.db").is_err());
+        assert!(parse_tui_record_command("record -p 1 --bogus --db out.db").is_err());
+        assert!(parse_tui_record_command("record --db out.db").is_err());
+    }
+}

--- a/collector/src/cmd_tui_record.rs
+++ b/collector/src/cmd_tui_record.rs
@@ -8,6 +8,7 @@ use chrono::Local;
 use std::sync::{Arc, Mutex};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
+use tokio::time::Duration;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct TuiRecordCommand {
@@ -64,7 +65,7 @@ pub(crate) struct TuiRecordStatus {
 pub(crate) struct TuiRecordTask {
     status: Arc<Mutex<TuiRecordStatus>>,
     cancel: Option<oneshot::Sender<()>>,
-    handle: JoinHandle<()>,
+    handle: Option<JoinHandle<()>>,
 }
 
 impl TuiRecordTask {
@@ -115,7 +116,7 @@ impl TuiRecordTask {
         Self {
             status,
             cancel: Some(cancel_tx),
-            handle,
+            handle: Some(handle),
         }
     }
 
@@ -143,8 +144,52 @@ impl TuiRecordTask {
         });
     }
 
+    pub(crate) async fn shutdown(mut self, wait: Duration) {
+        self.stop();
+        let Some(mut handle) = self.handle.take() else {
+            return;
+        };
+        if handle.is_finished() {
+            let _ = handle.await;
+            return;
+        }
+        let wait = tokio::time::sleep(wait);
+        tokio::pin!(wait);
+        tokio::select! {
+            join_result = &mut handle => {
+                let _ = join_result;
+            }
+            _ = &mut wait => {
+                // The trace task should normally exit after cancellation. Abort on
+                // timeout so top does not leave an orphaned background capture.
+                handle.abort();
+                let _ = handle.await;
+                set_status(&self.status, |status| {
+                    if !status.finished {
+                        status.message = "stopped".to_string();
+                        status.finished = true;
+                    }
+                });
+            }
+        }
+    }
+
+    pub(crate) fn shutdown_blocking(self, wait: Duration) {
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            tokio::task::block_in_place(|| handle.block_on(self.shutdown(wait)));
+        } else if let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            runtime.block_on(self.shutdown(wait));
+        }
+    }
+
     pub(crate) fn is_finished(&self) -> bool {
-        self.handle.is_finished() || self.status().finished
+        self.handle
+            .as_ref()
+            .is_none_or(|handle| handle.is_finished())
+            || self.status().finished
     }
 }
 
@@ -205,7 +250,8 @@ pub(crate) fn parse_tui_record_command(input: &str) -> Result<TuiRecordCommand, 
     }
     if tokens.iter().any(|token| *token == "--") {
         return Err(
-            "TUI record only supports attach options, not `record -- <command>`".to_string(),
+            "TUI record accepts space-separated attach options only, not `record -- <command>`"
+                .to_string(),
         );
     }
 
@@ -254,10 +300,11 @@ pub(crate) fn parse_tui_record_command(input: &str) -> Result<TuiRecordCommand, 
             }
             "-c" | "--comm" => {
                 return Err(
-                    "TUI record only supports PID attach; use record -c outside top".to_string(),
+                    "TUI record accepts PID attach options only; use record -c outside top"
+                        .to_string(),
                 );
             }
-            other => return Err(format!("unsupported record option: {other}")),
+            other => return Err(format!("unsupported attach option: {other}")),
         }
         i += 1;
     }
@@ -275,6 +322,7 @@ pub(crate) fn parse_tui_record_command(input: &str) -> Result<TuiRecordCommand, 
 mod tests {
     use super::*;
     use crate::output::AgentTopRow;
+    use tokio::time::Duration;
 
     fn row(pid: Option<u32>) -> AgentTopRow {
         AgentTopRow {
@@ -320,5 +368,35 @@ mod tests {
         assert!(parse_tui_record_command("record -p --db out.db").is_err());
         assert!(parse_tui_record_command("record -p 1 --bogus --db out.db").is_err());
         assert!(parse_tui_record_command("record --db out.db").is_err());
+    }
+
+    #[tokio::test]
+    async fn shutdown_sends_cancel_and_marks_stopping() {
+        let status = Arc::new(Mutex::new(TuiRecordStatus {
+            target: "pid 42".to_string(),
+            db_path: "out.db".to_string(),
+            server_url: None,
+            message: "recording".to_string(),
+            finished: false,
+        }));
+        let (cancel_tx, cancel_rx) = oneshot::channel();
+        let task_status = status.clone();
+        let handle = tokio::spawn(async move {
+            let _ = cancel_rx.await;
+            set_status(&task_status, |status| {
+                status.finished = true;
+            });
+        });
+        let task = TuiRecordTask {
+            status: status.clone(),
+            cancel: Some(cancel_tx),
+            handle: Some(handle),
+        };
+
+        task.shutdown(Duration::from_millis(100)).await;
+
+        let status = status.lock().unwrap().clone();
+        assert!(status.finished);
+        assert!(matches!(status.message.as_str(), "stopping" | "stopped"));
     }
 }

--- a/collector/src/cmd_tui_record.rs
+++ b/collector/src/cmd_tui_record.rs
@@ -248,7 +248,7 @@ pub(crate) fn parse_tui_record_command(input: &str) -> Result<TuiRecordCommand, 
     if tokens.first() == Some(&"record") {
         tokens.remove(0);
     }
-    if tokens.iter().any(|token| *token == "--") {
+    if tokens.contains(&"--") {
         return Err(
             "TUI record accepts space-separated attach options only, not `record -- <command>`"
                 .to_string(),

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -28,6 +28,7 @@ mod cmd_perf;
 mod cmd_perf_live;
 mod cmd_perf_tui;
 mod cmd_trace;
+mod cmd_tui_record;
 mod event;
 mod json;
 mod model;

--- a/collector/src/output/mod.rs
+++ b/collector/src/output/mod.rs
@@ -5,4 +5,4 @@ pub mod format;
 pub mod tui;
 
 pub(crate) use format::*;
-pub(crate) use tui::{draw_live_top_tui, next_view_key};
+pub(crate) use tui::{TopRecordOverlay, draw_live_top_tui, next_view_key};

--- a/collector/src/output/tui.rs
+++ b/collector/src/output/tui.rs
@@ -351,6 +351,8 @@ fn render_record_overlay(frame: &mut Frame<'_>, overlay: &TopRecordOverlay) {
                         .add_modifier(Modifier::BOLD),
                 )]),
                 Line::from(""),
+                Line::from("Attach options only; values are split on spaces."),
+                Line::from(""),
                 Line::from(command.clone()),
                 Line::from(""),
                 Line::from("Enter start | Esc cancel | Backspace edit"),

--- a/collector/src/output/tui.rs
+++ b/collector/src/output/tui.rs
@@ -11,6 +11,17 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState, Wrap},
 };
 
+#[derive(Debug, Clone)]
+pub(crate) enum TopRecordOverlay {
+    Prompt {
+        command: String,
+        error: Option<String>,
+    },
+    Running {
+        lines: Vec<String>,
+    },
+}
+
 pub(crate) fn draw_live_top_tui(
     frame: &mut Frame<'_>,
     top: &AgentTopOutput<'_>,
@@ -21,6 +32,8 @@ pub(crate) fn draw_live_top_tui(
     show_diagnostics: bool,
     interval_secs: u64,
     display_limit: usize,
+    record_status: Option<&str>,
+    record_overlay: Option<&TopRecordOverlay>,
 ) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -43,9 +56,11 @@ pub(crate) fn draw_live_top_tui(
     );
     render_session_table(frame, chunks[1], top, selected);
     render_session_detail(frame, chunks[2], top, selected, options);
-    render_top_footer(frame, chunks[3], top);
+    render_top_footer(frame, chunks[3], top, record_status);
 
-    if show_help {
+    if let Some(record_overlay) = record_overlay {
+        render_record_overlay(frame, record_overlay);
+    } else if show_help {
         render_top_help(frame);
     } else if show_diagnostics {
         render_top_diagnostics(frame, top);
@@ -195,18 +210,28 @@ fn render_session_detail(
     );
 }
 
-fn render_top_footer(frame: &mut Frame<'_>, area: Rect, top: &AgentTopOutput<'_>) {
+fn render_top_footer(
+    frame: &mut Frame<'_>,
+    area: Rect,
+    top: &AgentTopOutput<'_>,
+    record_status: Option<&str>,
+) {
     let mut lines = vec![Line::from(vec![
         Span::styled("keys ", label_style()),
         Span::raw(
-            "q quit | up/down select | s sort | v view | p pause | r refresh | +/- rows | e errors | ? help",
+            "q quit | up/down select | s sort | v view | p pause | r refresh | R record PID | +/- rows | e errors | ? help",
         ),
     ])];
     lines.push(Line::from(vec![
         Span::styled("status ", label_style()),
         Span::raw(tui_status_line(top)),
     ]));
-    if let Some(message) = tui_diagnostic_lines(top, 1).into_iter().next() {
+    if let Some(record_status) = record_status {
+        lines.push(Line::from(vec![
+            Span::styled("record ", label_style()),
+            Span::raw(record_status.to_string()),
+        ]));
+    } else if let Some(message) = tui_diagnostic_lines(top, 1).into_iter().next() {
         lines.push(Line::from(vec![
             Span::styled("diagnostic ", label_style()),
             Span::raw(message),
@@ -301,12 +326,63 @@ fn render_top_help(frame: &mut Frame<'_>) {
         Line::from("v              cycle detail view: all, processes, files, network, models"),
         Line::from("p              pause or resume refresh"),
         Line::from("r              refresh now"),
+        Line::from("R              record selected PID"),
         Line::from("+/-            change row limit"),
         Line::from("?              close this help"),
     ];
     frame.render_widget(
         Paragraph::new(lines)
             .block(Block::default().title("help").borders(Borders::ALL))
+            .wrap(Wrap { trim: true }),
+        area,
+    );
+}
+
+fn render_record_overlay(frame: &mut Frame<'_>, overlay: &TopRecordOverlay) {
+    let area = centered_rect(76, 34, frame.area());
+    frame.render_widget(Clear, area);
+    let (title, lines) = match overlay {
+        TopRecordOverlay::Prompt { command, error } => {
+            let mut lines = vec![
+                Line::from(vec![Span::styled(
+                    "Record selected PID",
+                    Style::default()
+                        .fg(Color::Cyan)
+                        .add_modifier(Modifier::BOLD),
+                )]),
+                Line::from(""),
+                Line::from(command.clone()),
+                Line::from(""),
+                Line::from("Enter start | Esc cancel | Backspace edit"),
+            ];
+            if let Some(error) = error {
+                lines.push(Line::from(""));
+                lines.push(Line::from(vec![
+                    Span::styled("error ", Style::default().fg(Color::Red)),
+                    Span::raw(error.clone()),
+                ]));
+            }
+            ("record", lines)
+        }
+        TopRecordOverlay::Running { lines } => {
+            let mut rendered = vec![
+                Line::from(vec![Span::styled(
+                    "Record already running",
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                )]),
+                Line::from(""),
+            ];
+            rendered.extend(lines.iter().cloned().map(Line::from));
+            rendered.push(Line::from(""));
+            rendered.push(Line::from("s stop | Esc cancel"));
+            ("record", rendered)
+        }
+    };
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().title(title).borders(Borders::ALL))
             .wrap(Wrap { trim: true }),
         area,
     );

--- a/collector/src/output/tui.rs
+++ b/collector/src/output/tui.rs
@@ -216,11 +216,16 @@ fn render_top_footer(
     top: &AgentTopOutput<'_>,
     record_status: Option<&str>,
 ) {
+    let stop_hint = if record_status.is_some() {
+        " | S stop record"
+    } else {
+        ""
+    };
     let mut lines = vec![Line::from(vec![
         Span::styled("keys ", label_style()),
-        Span::raw(
-            "q quit | up/down select | s sort | v view | p pause | r refresh | R record PID | +/- rows | e errors | ? help",
-        ),
+        Span::raw(format!(
+            "q quit | up/down select | s sort{stop_hint} | v view | p pause | r refresh | R record PID | +/- rows | e errors | ? help",
+        )),
     ])];
     lines.push(Line::from(vec![
         Span::styled("status ", label_style()),
@@ -323,6 +328,7 @@ fn render_top_help(frame: &mut Frame<'_>) {
         Line::from("q or Esc       exit"),
         Line::from("up/down, k/j   select a session"),
         Line::from("s              cycle sort: cpu, rss, tokens, execs, fail, files, net, agent"),
+        Line::from("S              when recording, prompt stop record"),
         Line::from("v              cycle detail view: all, processes, files, network, models"),
         Line::from("p              pause or resume refresh"),
         Line::from("r              refresh now"),
@@ -378,7 +384,7 @@ fn render_record_overlay(frame: &mut Frame<'_>, overlay: &TopRecordOverlay) {
             ];
             rendered.extend(lines.iter().cloned().map(Line::from));
             rendered.push(Line::from(""));
-            rendered.push(Line::from("s stop | Esc cancel"));
+            rendered.push(Line::from("Enter/S stop | Esc cancel"));
             ("record", rendered)
         }
     };


### PR DESCRIPTION
#97 
Add an interactive record workflow to `agentsight top`.

  This PR lets users start recording the selected live session directly from the TUI with `R`, continue watching the live top view while recording runs in the background, and stop the
  active record task through an explicit confirmation prompt with `S`.

  Key behavior:

  - `R` opens an editable attach-only record command preview for the selected live PID.
  - The default preview command is:

    ```bash
    agentsight record -p <pid> --db agentsight-YYYYMMDD-HHMMSS.db --server-port 7395

  - The preview parser intentionally supports attach options only:
      - -p / --pid
      - --binary-path
      - --db
      - --no-server
      - --server-port

  - It rejects -c / --comm, unknown flags, missing values, missing PID, and record -- <command>.
  - Only one background record task can run at a time.
  - The TUI shows record target, DB path, status, and server URL while recording.
  - s remains the existing sort shortcut.
  - S opens a stop-record confirmation prompt when recording is active.
  - In the stop prompt, S or Enter stops recording, and Esc cancels.
  - Exiting the TUI gracefully cancels any active background record task.

  Fixes # (issue)

  ## Type of change

  - [x] New feature (non-breaking change which adds functionality)

  ## How Has This Been Tested?

  - [x] cd collector && cargo test
  - [x] cd collector && cargo build --release

  Added/updated tests cover:

  - Default record command generation for selected rows.
  - Missing PID rejection.
  - Parser success for allowed attach options.
  - Parser rejection for comm attach, launch command, missing values, unknown options, and missing PID.
  - R opens the default prompt.
  - Esc closes prompt without starting record.
  - Already-running record prevents starting a second task.
  - Lowercase s remains the sort shortcut.
  - Uppercase S opens the stop prompt.
  - Stop prompt accepts S / Enter and cancels on Esc.
  - Graceful shutdown sends cancel and updates status.

  Test Configuration:

  - Toolchain: Rust/Cargo, local Linux development environment

  ## Checklist

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] My changes generate no new warnings
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New and existing unit tests pass locally with my changes
  - [x] I have checked my code and corrected any misspellings