### PR TITLE
Use sysinfo for process snapshots

### DIFF
--- a/collector/Cargo.lock
+++ b/collector/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "rust-embed",
  "serde",
  "serde_json",
+ "sysinfo",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -320,7 +321,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1031,7 +1032,7 @@ dependencies = [
  "js-sys",
  "log 0.4.33",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -1342,6 +1343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1373,6 +1383,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1413,7 +1442,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1892,6 +1921,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252800745060e7b9ffb7b2badbd8b31cfa4aa2e61af879d0a3bf2a317c20217d"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2279,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core 0.61.2",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,9 +2321,20 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+ "windows-threading",
 ]
 
 [[package]]
@@ -2272,9 +2361,25 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.2",
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-registry"
@@ -2282,9 +2387,18 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2293,7 +2407,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -2302,7 +2425,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2311,7 +2434,16 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -46,6 +46,7 @@ log = "0.4"
 env_logger = "0.10"
 dirs = "6"
 libc = "0.2"
+sysinfo = { version = "0.36.1", default-features = false, features = ["system"] }
 chunked_transfer = "1.5"
 num_cpus = "1.16"
 rusqlite = { version = "0.32", features = ["bundled"] }

--- a/collector/src/cmd_monitor.rs
+++ b/collector/src/cmd_monitor.rs
@@ -432,7 +432,7 @@ fn collect_process_samples(
         let cpu_ms = procfs::process_cpu_ms_delta(proc_info, previous);
         let rss_bytes = proc_info.rss_kb.saturating_mul(1024);
         let key = proc_info.process_key();
-        let (read_bytes, write_bytes) = process_io_delta(proc_info.pid, key, io_state, current_io);
+        let (read_bytes, write_bytes) = process_io_delta(proc_info, key, io_state, current_io);
         out.push(MonitorProcessSample {
             rank_kind: "all",
             pid: proc_info.pid,
@@ -468,14 +468,13 @@ fn aggregate_process_samples(samples: &[MonitorProcessSample]) -> (u64, u64, u64
 }
 
 fn process_io_delta(
-    pid: u32,
+    proc_info: &procfs::ProcInfo,
     key: procfs::ProcessKey,
     io_state: &MonitorIoState,
     current_io: &mut BTreeMap<procfs::ProcessKey, (u64, u64)>,
 ) -> (u64, u64) {
-    let Some((current_read, current_write)) = procfs::read_process_io_bytes(pid) else {
-        return (0, 0);
-    };
+    let current_read = proc_info.read_bytes;
+    let current_write = proc_info.write_bytes;
     current_io.insert(key, (current_read, current_write));
     io_state
         .previous

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -658,7 +658,7 @@ mod tests {
             failures: Vec::new(),
             notes: vec![
                 "agent-native sessions are the primary token/tool source".to_string(),
-                "proc evidence uses /proc for CPU/RSS/process families".to_string(),
+                "proc evidence uses process snapshots for CPU/RSS/process families".to_string(),
                 "live eBPF capture did not start: sudo unavailable".to_string(),
             ],
         };

--- a/collector/src/sources/proc.rs
+++ b/collector/src/sources/proc.rs
@@ -5,6 +5,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fs;
 use std::io;
 use std::path::PathBuf;
+use std::sync::OnceLock;
 use std::time::Instant;
 use sysinfo::{Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
@@ -343,7 +344,12 @@ fn pid_to_u32(pid: Pid) -> u32 {
 }
 
 fn starttime_ticks_from_epoch(start_time_s: u64, boot_time_s: u64) -> u64 {
-    ((start_time_s.saturating_sub(boot_time_s) as f64) * ticks_per_second()).round() as u64
+    let since_boot_s = if start_time_s >= boot_time_s {
+        start_time_s - boot_time_s
+    } else {
+        start_time_s
+    };
+    ((since_boot_s as f64) * ticks_per_second()).round() as u64
 }
 
 pub(crate) fn process_start_timestamp_ms(starttime_ticks: u64) -> Option<u64> {
@@ -367,8 +373,11 @@ pub(crate) fn process_cpu_ms_delta(proc_info: &ProcInfo, previous: Option<&ProcS
 }
 
 fn ticks_per_second() -> f64 {
-    let value = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
-    if value > 0 { value as f64 } else { 100.0 }
+    static TICKS_PER_SECOND: OnceLock<f64> = OnceLock::new();
+    *TICKS_PER_SECOND.get_or_init(|| {
+        let value = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+        if value > 0 { value as f64 } else { 100.0 }
+    })
 }
 
 #[cfg(test)]
@@ -402,6 +411,14 @@ mod tests {
         let _ = child.wait();
 
         assert_eq!(threads, Some(1));
+    }
+
+    #[test]
+    fn starttime_ticks_accepts_epoch_or_boot_relative_seconds() {
+        let ticks = ticks_per_second().round() as u64;
+
+        assert_eq!(starttime_ticks_from_epoch(125, 100), 25 * ticks);
+        assert_eq!(starttime_ticks_from_epoch(25, 100), 25 * ticks);
     }
 
     #[cfg(target_os = "linux")]

--- a/collector/src/sources/proc.rs
+++ b/collector/src/sources/proc.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io;
 use std::path::PathBuf;
 use std::time::Instant;
+use sysinfo::{Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 pub(crate) use agent_session::{ProcessKey, ProcessTree};
 
@@ -35,6 +36,8 @@ pub(crate) struct ProcInfo {
     pub(crate) rss_mb: u64,
     pub(crate) vsz_kb: u64,
     pub(crate) threads: u32,
+    pub(crate) read_bytes: u64,
+    pub(crate) write_bytes: u64,
 }
 
 impl ProcInfo {
@@ -72,24 +75,21 @@ impl Default for ProcSnapshot {
 
 impl ProcSnapshot {
     pub(crate) fn collect() -> io::Result<Self> {
-        let page_size = page_size_bytes();
-        let mut procs = BTreeMap::new();
-
-        for entry in fs::read_dir("/proc")? {
-            let Ok(entry) = entry else { continue };
-            let file_name = entry.file_name();
-            let Some(pid) = file_name.to_str().and_then(|name| name.parse::<u32>().ok()) else {
-                continue;
-            };
-            let Some(proc_info) = read_proc_info(pid, page_size) else {
-                continue;
-            };
-            procs.insert(pid, proc_info);
-        }
+        let mut system = System::new();
+        system.refresh_processes_specifics(ProcessesToUpdate::All, true, process_refresh_kind());
+        let boot_time_s = System::boot_time();
+        let procs = system
+            .processes()
+            .values()
+            .map(|process| {
+                let info = proc_info_from_sysinfo(process, boot_time_s);
+                (info.pid, info)
+            })
+            .collect();
 
         Ok(Self {
             at: Instant::now(),
-            uptime_s: read_uptime_s().unwrap_or_default(),
+            uptime_s: System::uptime() as f64,
             procs,
         })
     }
@@ -224,33 +224,68 @@ pub(crate) fn process_age_s(proc_info: &ProcInfo, sample: &ProcSnapshot) -> f64 
     (sample.uptime_s - process_start_s).max(0.0)
 }
 
-fn read_proc_info(pid: u32, page_size: u64) -> Option<ProcInfo> {
-    let proc_dir = format!("/proc/{pid}");
-    let stat = fs::read_to_string(format!("{proc_dir}/stat")).ok()?;
-    let (comm, ppid, session_id, ticks, starttime_ticks) = parse_proc_stat(&stat)?;
-    let command = read_cmdline(pid).unwrap_or_else(|| comm.clone());
-    let cwd = read_cwd(pid);
-    let (rss_kb, rss_mb, vsz_kb) = read_statm(pid, page_size).unwrap_or_default();
-    let threads = read_thread_count(pid);
-    Some(ProcInfo {
+fn proc_info_from_sysinfo(process: &Process, boot_time_s: u64) -> ProcInfo {
+    let pid = process.pid().as_u32();
+    let comm = process.name().to_string_lossy().into_owned();
+    let command = process_command(process, &comm);
+    let rss_bytes = process.memory();
+    let disk = process.disk_usage();
+    ProcInfo {
         pid,
-        ppid,
-        session_id,
+        ppid: process.parent().map(pid_to_u32).unwrap_or_default(),
+        session_id: process.session_id().map(pid_to_u32).unwrap_or_default(),
         comm,
         command,
-        cwd,
-        ticks,
-        starttime_ticks,
-        rss_kb,
-        rss_mb,
-        vsz_kb,
-        threads,
-    })
+        cwd: process.cwd().map(PathBuf::from),
+        ticks: cpu_ms_to_ticks(process.accumulated_cpu_time()),
+        starttime_ticks: platform_starttime_ticks(pid)
+            .unwrap_or_else(|| starttime_ticks_from_epoch(process.start_time(), boot_time_s)),
+        rss_kb: bytes_to_kb(rss_bytes),
+        rss_mb: bytes_to_mb(rss_bytes),
+        vsz_kb: bytes_to_kb(process.virtual_memory()),
+        threads: process.tasks().map(|tasks| tasks.len() as u32).unwrap_or(1),
+        read_bytes: disk.total_read_bytes,
+        write_bytes: disk.total_written_bytes,
+    }
+}
+
+fn process_refresh_kind() -> ProcessRefreshKind {
+    ProcessRefreshKind::nothing()
+        .with_memory()
+        .with_cpu()
+        .with_disk_usage()
+        .with_cmd(UpdateKind::Always)
+        .with_cwd(UpdateKind::Always)
+        .with_tasks()
+}
+
+fn process_command(process: &Process, fallback: &str) -> String {
+    let command = process
+        .cmd()
+        .iter()
+        .map(|arg| arg.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join(" ");
+    if command.is_empty() {
+        fallback.to_string()
+    } else {
+        command
+    }
 }
 
 pub(crate) fn process_starttime_ticks(pid: u32) -> Option<u64> {
-    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
-    parse_proc_stat(&stat).map(|(_, _, _, _, starttime_ticks)| starttime_ticks)
+    platform_starttime_ticks(pid).or_else(|| {
+        let sys_pid = Pid::from_u32(pid);
+        let mut system = System::new();
+        system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[sys_pid]),
+            true,
+            ProcessRefreshKind::nothing(),
+        );
+        system
+            .process(sys_pid)
+            .map(|process| starttime_ticks_from_epoch(process.start_time(), System::boot_time()))
+    })
 }
 
 pub(crate) fn scan_proc_fd_paths(pid: u32) -> BTreeSet<PathBuf> {
@@ -267,52 +302,21 @@ pub(crate) fn scan_proc_fd_paths(pid: u32) -> BTreeSet<PathBuf> {
     out
 }
 
-fn parse_proc_stat(stat: &str) -> Option<(String, u32, u32, u64, u64)> {
-    let open = stat.find('(')?;
+#[cfg(target_os = "linux")]
+fn platform_starttime_ticks(pid: u32) -> Option<u64> {
+    let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+    parse_proc_starttime_ticks(&stat)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn platform_starttime_ticks(_pid: u32) -> Option<u64> {
+    None
+}
+
+#[cfg(target_os = "linux")]
+fn parse_proc_starttime_ticks(stat: &str) -> Option<u64> {
     let close = stat.rfind(')')?;
-    let comm = stat[open + 1..close].to_string();
-    let fields: Vec<&str> = stat[close + 1..].split_whitespace().collect();
-    let ppid = fields.get(1)?.parse().ok()?;
-    let session_id = fields.get(3)?.parse().ok()?;
-    let utime: u64 = fields.get(11)?.parse().ok()?;
-    let stime: u64 = fields.get(12)?.parse().ok()?;
-    let starttime_ticks = fields.get(19)?.parse().ok()?;
-    Some((
-        comm,
-        ppid,
-        session_id,
-        utime.saturating_add(stime),
-        starttime_ticks,
-    ))
-}
-
-fn read_cmdline(pid: u32) -> Option<String> {
-    let bytes = fs::read(format!("/proc/{pid}/cmdline")).ok()?;
-    let command = bytes
-        .split(|byte| *byte == 0)
-        .filter_map(|part| std::str::from_utf8(part).ok())
-        .filter(|part| !part.is_empty())
-        .collect::<Vec<_>>()
-        .join(" ");
-    (!command.is_empty()).then_some(command)
-}
-
-fn read_cwd(pid: u32) -> Option<PathBuf> {
-    fs::read_link(format!("/proc/{pid}/cwd")).ok()
-}
-
-fn read_statm(pid: u32, page_size: u64) -> Option<(u64, u64, u64)> {
-    let statm = fs::read_to_string(format!("/proc/{pid}/statm")).ok()?;
-    let mut fields = statm.split_whitespace();
-    let vsz_pages: u64 = fields.next()?.parse().ok()?;
-    let rss_pages: u64 = fields.next()?.parse().ok()?;
-    let rss_bytes = rss_pages.saturating_mul(page_size);
-    let vsz_bytes = vsz_pages.saturating_mul(page_size);
-    Some((
-        bytes_to_kb(rss_bytes),
-        bytes_to_mb(rss_bytes),
-        bytes_to_kb(vsz_bytes),
-    ))
+    stat[close + 1..].split_whitespace().nth(19)?.parse().ok()
 }
 
 fn bytes_to_kb(bytes: u64) -> u64 {
@@ -327,13 +331,16 @@ fn bytes_to_mb(bytes: u64) -> u64 {
     }
 }
 
-fn read_uptime_s() -> Option<f64> {
-    fs::read_to_string("/proc/uptime")
-        .ok()?
-        .split_whitespace()
-        .next()?
-        .parse()
-        .ok()
+fn cpu_ms_to_ticks(cpu_ms: u64) -> u64 {
+    ((cpu_ms as f64 / 1000.0) * ticks_per_second()).round() as u64
+}
+
+fn pid_to_u32(pid: Pid) -> u32 {
+    pid.as_u32()
+}
+
+fn starttime_ticks_from_epoch(start_time_s: u64, boot_time_s: u64) -> u64 {
+    ((start_time_s.saturating_sub(boot_time_s) as f64) * ticks_per_second()).round() as u64
 }
 
 pub(crate) fn process_start_timestamp_ms(starttime_ticks: u64) -> Option<u64> {
@@ -356,46 +363,32 @@ pub(crate) fn process_cpu_ms_delta(proc_info: &ProcInfo, previous: Option<&ProcS
     ((delta_ticks as f64 / ticks_per_second()) * 1000.0).round() as u64
 }
 
-fn page_size_bytes() -> u64 {
-    let value = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
-    if value > 0 { value as u64 } else { 4096 }
-}
-
 fn ticks_per_second() -> f64 {
     let value = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
     if value > 0 { value as f64 } else { 100.0 }
 }
 
-fn read_thread_count(pid: u32) -> u32 {
-    fs::read_dir(format!("/proc/{pid}/task"))
-        .map(|entries| entries.count() as u32)
-        .unwrap_or(1)
-}
-
-pub(crate) fn read_process_io_bytes(pid: u32) -> Option<(u64, u64)> {
-    let io = fs::read_to_string(format!("/proc/{pid}/io")).ok()?;
-    let mut read_bytes = 0;
-    let mut write_bytes = 0;
-    for line in io.lines() {
-        if let Some(value) = line.strip_prefix("read_bytes:") {
-            read_bytes = value.trim().parse().ok()?;
-        } else if let Some(value) = line.strip_prefix("write_bytes:") {
-            write_bytes = value.trim().parse().ok()?;
-        }
-    }
-    Some((read_bytes, write_bytes))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
 
+    #[test]
+    fn snapshot_collects_current_process() {
+        let snapshot = ProcSnapshot::collect().unwrap();
+        let current = snapshot.procs.get(&std::process::id()).unwrap();
+
+        assert_eq!(current.pid, std::process::id());
+        assert!(current.starttime_ticks > 0);
+        assert!(current.threads > 0);
+        assert!(!current.comm.is_empty() || !current.command.is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
     #[test]
     fn proc_fd_scan_finds_open_file_path() {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("fd-evidence.txt");
-        let _file = File::create(&path).unwrap();
+        let _file = std::fs::File::create(&path).unwrap();
 
         let paths = scan_proc_fd_paths(std::process::id());
         assert!(paths.contains(&path));

--- a/collector/src/sources/proc.rs
+++ b/collector/src/sources/proc.rs
@@ -243,7 +243,10 @@ fn proc_info_from_sysinfo(process: &Process, boot_time_s: u64) -> ProcInfo {
         rss_kb: bytes_to_kb(rss_bytes),
         rss_mb: bytes_to_mb(rss_bytes),
         vsz_kb: bytes_to_kb(process.virtual_memory()),
-        threads: process.tasks().map(|tasks| tasks.len() as u32).unwrap_or(1),
+        threads: process
+            .tasks()
+            .map(|tasks| (tasks.len() as u32).saturating_add(1))
+            .unwrap_or(1),
         read_bytes: disk.total_read_bytes,
         write_bytes: disk.total_written_bytes,
     }
@@ -381,6 +384,24 @@ mod tests {
         assert!(current.starttime_ticks > 0);
         assert!(current.threads > 0);
         assert!(!current.comm.is_empty() || !current.command.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn snapshot_counts_single_thread_process() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("5")
+            .spawn()
+            .unwrap();
+        let snapshot = ProcSnapshot::collect().unwrap();
+        let threads = snapshot
+            .procs
+            .get(&child.id())
+            .map(|proc_info| proc_info.threads);
+        let _ = child.kill();
+        let _ = child.wait();
+
+        assert_eq!(threads, Some(1));
     }
 
     #[cfg(target_os = "linux")]

--- a/collector/src/time.rs
+++ b/collector/src/time.rs
@@ -23,10 +23,15 @@ pub fn get_boot_time_secs() -> i64 {
             return boot_time;
         }
 
-        SystemTime::now()
+        let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
-            .as_secs() as i64
+            .as_secs() as i64;
+        let uptime_secs = i64::try_from(sysinfo::System::uptime())
+            .ok()
+            .filter(|uptime| *uptime > 0)
+            .unwrap_or(1);
+        now_secs.saturating_sub(uptime_secs)
     })
 }
 

--- a/collector/src/time.rs
+++ b/collector/src/time.rs
@@ -6,7 +6,6 @@
 //! All timestamps in the system are standardized to milliseconds since UNIX epoch
 //! for consistency and ease of use in the frontend.
 
-use std::fs;
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -15,35 +14,15 @@ static BOOT_TIME_SECS: OnceLock<i64> = OnceLock::new();
 
 /// Get the system boot time in seconds since UNIX epoch
 ///
-/// This reads from /proc/stat (btime field) and caches the result.
-/// Falls back to calculating from /proc/uptime if btime is not available.
+/// This uses the platform process backend and caches the result.
 pub fn get_boot_time_secs() -> i64 {
     *BOOT_TIME_SECS.get_or_init(|| {
-        // Try to read from /proc/stat (most reliable)
-        if let Ok(content) = fs::read_to_string("/proc/stat") {
-            for line in content.lines() {
-                if line.starts_with("btime ")
-                    && let Some(btime_str) = line.split_whitespace().nth(1)
-                    && let Ok(btime) = btime_str.parse::<i64>()
-                {
-                    return btime;
-                }
-            }
-        }
-
-        // Fallback: calculate from uptime
-        if let Ok(uptime_str) = fs::read_to_string("/proc/uptime")
-            && let Some(uptime_secs_str) = uptime_str.split_whitespace().next()
-            && let Ok(uptime_secs) = uptime_secs_str.parse::<f64>()
+        if let Ok(boot_time) = i64::try_from(sysinfo::System::boot_time())
+            && boot_time > 0
         {
-            let now_secs = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_secs() as i64;
-            return now_secs - uptime_secs as i64;
+            return boot_time;
         }
 
-        // Last resort: return current time (will be incorrect but won't crash)
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()

--- a/collector/src/view/live_top.rs
+++ b/collector/src/view/live_top.rs
@@ -345,7 +345,9 @@ impl LiveView {
             notes.push("agent-native sessions are the primary token/tool source".to_string());
         }
         if has_proc {
-            notes.push("proc evidence uses /proc for CPU/RSS/process families".to_string());
+            notes.push(
+                "proc evidence uses process snapshots for CPU/RSS/process families".to_string(),
+            );
         }
         if has_session_file_link {
             notes.push("agent-native sessions bind to live pids after the process touches the matching session path; binding stays until pid exits or a new session path is observed".to_string());


### PR DESCRIPTION
## Summary

- replace the live process snapshot enumeration with `sysinfo` instead of hand-parsing `/proc`
- keep Linux PID start ticks for PID-reuse-safe matching and FD evidence
- carry process IO totals in the snapshot so monitor sampling no longer parses `/proc/<pid>/io`
- switch boot-time fallback to `sysinfo` and update the live top note text

This is PR 2 of the portable top rollout. It intentionally does not change sudo/eBPF behavior or macOS CLI semantics.

## Validation

- `cargo test --manifest-path collector/Cargo.toml`
- `cargo clippy --manifest-path collector/Cargo.toml --all-targets -- -D warnings`
- `cargo run --manifest-path collector/Cargo.toml -- top --plain --once`
