### PR TITLE
Smoke test top on macOS

### DIFF
--- a/.github/workflows/macos-top.yml
+++ b/.github/workflows/macos-top.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          cache-workspaces: collector -> collector/target
 
       - name: Build collector and run top
         run: script/ci/macos_top_smoke.sh .artifacts/macos-top-output.txt

--- a/.github/workflows/macos-top.yml
+++ b/.github/workflows/macos-top.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-          cache-workspaces: collector -> collector/target
+          cache-workspaces: collector -> target
 
       - name: Build collector and run top
         run: script/ci/macos_top_smoke.sh .artifacts/macos-top-output.txt

--- a/.github/workflows/macos-top.yml
+++ b/.github/workflows/macos-top.yml
@@ -1,0 +1,37 @@
+name: macOS Top Smoke
+
+on:
+  push:
+    branches: ["master", "main"]
+  pull_request:
+    branches: ["master", "main"]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  top:
+    name: Build and Run Top
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Build collector and run top
+        run: script/ci/macos_top_smoke.sh .artifacts/macos-top-output.txt
+
+      - name: Upload top output
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-top-output
+          path: .artifacts/macos-top-output.txt

--- a/collector/src/cmd_perf_live.rs
+++ b/collector/src/cmd_perf_live.rs
@@ -3,6 +3,7 @@
 
 use crate::analyzers::TimestampNormalizer;
 use crate::binary_extractor::BinaryExtractor;
+#[cfg(target_os = "linux")]
 use crate::cmd_exec::sudo_cached;
 use crate::event::Event;
 use crate::model::SnapshotOptions;
@@ -19,8 +20,11 @@ use std::io::{self, Write};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[cfg(any(test, target_os = "linux"))]
 const LIVE_EBPF_ROOT_NOTE: &str = "live eBPF process capture enabled";
+#[cfg(any(test, target_os = "linux"))]
 const LIVE_EBPF_SUDO_NOTE: &str = "live eBPF process capture enabled via sudo";
+#[cfg(any(test, target_os = "linux"))]
 const LIVE_EBPF_UNAVAILABLE_NOTE: &str = "no eBPF: showing process snapshots and agent-native sessions only (run with sudo or configure passwordless sudo for kernel probes)";
 #[cfg(not(target_os = "linux"))]
 const LIVE_EBPF_UNSUPPORTED_NOTE: &str = "no eBPF: live kernel probes are Linux-only; showing process snapshots and agent-native sessions only";
@@ -138,15 +142,16 @@ pub(crate) async fn start_live_ebpf_capture(
     })
 }
 
+#[cfg(not(target_os = "linux"))]
 fn prepare_live_ebpf_privileges() -> Result<Option<String>, String> {
-    #[cfg(not(target_os = "linux"))]
-    {
-        if let Err(err) = ensure_agentsight_state_dir() {
-            log::warn!("could not create ~/.agentsight: {err}");
-        }
-        return Err(LIVE_EBPF_UNSUPPORTED_NOTE.to_string());
+    if let Err(err) = ensure_agentsight_state_dir() {
+        log::warn!("could not create ~/.agentsight: {err}");
     }
+    Err(LIVE_EBPF_UNSUPPORTED_NOTE.to_string())
+}
 
+#[cfg(target_os = "linux")]
+fn prepare_live_ebpf_privileges() -> Result<Option<String>, String> {
     let is_root = unsafe { libc::geteuid() } == 0;
     if !is_root {
         if let Err(err) = ensure_agentsight_state_dir() {
@@ -156,6 +161,7 @@ fn prepare_live_ebpf_privileges() -> Result<Option<String>, String> {
     prepare_live_ebpf_privileges_for(is_root, !is_root && sudo_cached())
 }
 
+#[cfg(any(test, target_os = "linux"))]
 fn prepare_live_ebpf_privileges_for(
     is_root: bool,
     sudo_ready: bool,

--- a/collector/src/cmd_perf_live.rs
+++ b/collector/src/cmd_perf_live.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 const LIVE_EBPF_ROOT_NOTE: &str = "live eBPF process capture enabled";
 const LIVE_EBPF_SUDO_NOTE: &str = "live eBPF process capture enabled via sudo";
 const LIVE_EBPF_UNAVAILABLE_NOTE: &str = "no eBPF: showing process snapshots and agent-native sessions only (run with sudo or configure passwordless sudo for kernel probes)";
+#[cfg(not(target_os = "linux"))]
+const LIVE_EBPF_UNSUPPORTED_NOTE: &str = "no eBPF: live kernel probes are Linux-only; showing process snapshots and agent-native sessions only";
 
 struct LiveCaptureState {
     view: MaterializedView,
@@ -137,6 +139,14 @@ pub(crate) async fn start_live_ebpf_capture(
 }
 
 fn prepare_live_ebpf_privileges() -> Result<Option<String>, String> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        if let Err(err) = ensure_agentsight_state_dir() {
+            log::warn!("could not create ~/.agentsight: {err}");
+        }
+        return Err(LIVE_EBPF_UNSUPPORTED_NOTE.to_string());
+    }
+
     let is_root = unsafe { libc::geteuid() } == 0;
     if !is_root {
         if let Err(err) = ensure_agentsight_state_dir() {
@@ -251,6 +261,15 @@ mod tests {
         assert_eq!(
             prepare_live_ebpf_privileges_for(false, false).unwrap_err(),
             LIVE_EBPF_UNAVAILABLE_NOTE.to_string()
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn live_ebpf_privileges_degrade_on_non_linux() {
+        assert_eq!(
+            prepare_live_ebpf_privileges().unwrap_err(),
+            LIVE_EBPF_UNSUPPORTED_NOTE.to_string()
         );
     }
 

--- a/script/ci/macos_top_smoke.sh
+++ b/script/ci/macos_top_smoke.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_FILE="${1:-$ROOT_DIR/.artifacts/macos-top-output.txt}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "macos_top_smoke.sh requires macOS" >&2
+    exit 2
+fi
+
+mkdir -p "$(dirname "$OUT_FILE")"
+
+cargo build --manifest-path "$ROOT_DIR/collector/Cargo.toml" --verbose
+
+"$ROOT_DIR/collector/target/debug/agentsight" top --plain --once >"$OUT_FILE"
+cat "$OUT_FILE"
+
+grep -q "AgentSight top" "$OUT_FILE"
+grep -q "note: no eBPF: live kernel probes are Linux-only" "$OUT_FILE"


### PR DESCRIPTION
## Summary
- make live `top` skip eBPF probing on non-Linux platforms and show a Linux-only no-eBPF note
- add `script/ci/macos_top_smoke.sh` to build collector and run `agentsight top --plain --once` on macOS
- add a macOS GitHub Actions workflow that uploads the top output artifact

## Validation
- `cargo test --manifest-path collector/Cargo.toml cmd_perf_live::tests -- --nocapture`
- `cargo clippy --manifest-path collector/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path collector/Cargo.toml`
- Linux smoke: `agentsight top --plain --once` prints live top output and keeps eBPF enabled via sudo
- `bash -n script/ci/macos_top_smoke.sh`
- `git diff --check`

Note: local `cargo check --target x86_64-apple-darwin` on Linux is blocked by the missing macOS C toolchain (`cc` does not understand `-arch` / `-mmacosx-version-min`); the new macOS runner is the source of truth for build/run verification.