### PR TITLE
[codex] Fix macOS top session token binding

### DIFF
--- a/agent-session/src/process_match.rs
+++ b/agent-session/src/process_match.rs
@@ -4,7 +4,7 @@
 //! Process-to-session matching logic.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::parser::{normalize_session_log_path, session_log_path_from_str};
 use crate::{
@@ -165,7 +165,7 @@ impl SessionProcessMatcher {
 
     fn link_trace(
         &mut self,
-        session_path: &PathBuf,
+        session_path: &Path,
         process: &LiveProcessCandidate,
         path_evidence: &HashMap<u32, BTreeMap<PathBuf, &'static str>>,
     ) -> Option<&'static str> {
@@ -196,7 +196,7 @@ impl SessionProcessMatcher {
 
     fn can_use_cwd_trace(
         &self,
-        session_path: &PathBuf,
+        session_path: &Path,
         process: &LiveProcessCandidate,
         path_evidence: &HashMap<u32, BTreeMap<PathBuf, &'static str>>,
     ) -> bool {
@@ -289,13 +289,23 @@ fn recent_cwd_distance_ms(
 ) -> Option<u64> {
     let session_cwd = session.cwd.as_deref().filter(|value| !value.is_empty())?;
     let process_cwd = process.cwd.as_deref().filter(|value| !value.is_empty())?;
-    if session_cwd != process_cwd {
+    if normalize_cwd(session_cwd) != normalize_cwd(process_cwd) {
         return None;
     }
     let process_start_ms = process_start_ms(process, now_ms)?;
     let session_end_ms = session_end_ms(session);
     (session_end_ms.saturating_add(SESSION_PROCESS_START_SKEW_MS) >= process_start_ms)
         .then_some(session_end_ms.abs_diff(process_start_ms))
+}
+
+fn normalize_cwd(cwd: &str) -> String {
+    let path = Path::new(cwd);
+    if !path.is_absolute() {
+        return cwd.to_string();
+    }
+    std::fs::canonicalize(path)
+        .map(|path| path.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| cwd.to_string())
 }
 
 fn process_start_ms(process: &LiveProcessCandidate, now_ms: u64) -> Option<u64> {
@@ -318,5 +328,37 @@ fn confidence_for_evidence(evidence: &str) -> f32 {
         TRACE_STICKY_BINDING => 0.70,
         TRACE_RECENT_CWD => 0.55,
         _ => 0.50,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recent_cwd_match_uses_canonical_paths() {
+        let raw = std::env::temp_dir().join(format!(
+            "agent-session-cwd-test-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&raw).unwrap();
+        let cwd = raw.canonicalize().unwrap();
+        let session = SessionProcessInput {
+            id: "session".to_string(),
+            agent: "codex".to_string(),
+            path: cwd.join(".codex/sessions/2026/07/12/session.jsonl"),
+            start_timestamp_ms: Some(1_000),
+            end_timestamp_ms: Some(10_000),
+            cwd: Some(cwd.to_string_lossy().to_string()),
+        };
+        let process = LiveProcessCandidate {
+            agent: "codex".to_string(),
+            age_s: Some(5.0),
+            cwd: Some(raw.to_string_lossy().to_string()),
+            ..Default::default()
+        };
+
+        assert!(recent_cwd_distance_ms(&session, &process, 12_000).is_some());
+        std::fs::remove_dir_all(&raw).unwrap();
     }
 }

--- a/collector/src/sources/proc.rs
+++ b/collector/src/sources/proc.rs
@@ -2,12 +2,14 @@
 // Copyright (c) 2026 eunomia-bpf org.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::fs;
 use std::io;
 use std::path::PathBuf;
 use std::sync::OnceLock;
 use std::time::Instant;
 use sysinfo::{Pid, Process, ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
+
+#[cfg(target_os = "linux")]
+use std::fs;
 
 pub(crate) use agent_session::{ProcessKey, ProcessTree};
 
@@ -138,11 +140,11 @@ pub(crate) fn collect_fd_paths(
 
     for tree in process_trees {
         for key in &tree.members {
-            if process_starttime_ticks(key.pid) != Some(key.starttime_ticks) {
+            if !process_key_is_current(*key) {
                 continue;
             }
             let paths = scan_proc_fd_paths(key.pid);
-            if process_starttime_ticks(key.pid) != Some(key.starttime_ticks) {
+            if !process_key_is_current(*key) {
                 continue;
             }
             if !paths.is_empty() {
@@ -152,6 +154,20 @@ pub(crate) fn collect_fd_paths(
     }
 
     out
+}
+
+fn process_key_is_current(key: ProcessKey) -> bool {
+    process_key_is_current_impl(key)
+}
+
+#[cfg(target_os = "linux")]
+fn process_key_is_current_impl(key: ProcessKey) -> bool {
+    process_starttime_ticks(key.pid) == Some(key.starttime_ticks)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn process_key_is_current_impl(_key: ProcessKey) -> bool {
+    true
 }
 
 pub(crate) fn children_by_ppid(procs: &BTreeMap<u32, ProcInfo>) -> HashMap<u32, Vec<u32>> {
@@ -294,8 +310,14 @@ pub(crate) fn process_starttime_ticks(pid: u32) -> Option<u64> {
 
 pub(crate) fn scan_proc_fd_paths(pid: u32) -> BTreeSet<PathBuf> {
     let mut out = BTreeSet::new();
+    scan_proc_fd_paths_into(pid, &mut out);
+    out
+}
+
+#[cfg(target_os = "linux")]
+fn scan_proc_fd_paths_into(pid: u32, out: &mut BTreeSet<PathBuf>) {
     let Ok(entries) = fs::read_dir(format!("/proc/{pid}/fd")) else {
-        return out;
+        return;
     };
     for entry in entries.flatten() {
         let Ok(target) = fs::read_link(entry.path()) else {
@@ -303,7 +325,45 @@ pub(crate) fn scan_proc_fd_paths(pid: u32) -> BTreeSet<PathBuf> {
         };
         out.insert(target);
     }
-    out
+}
+
+#[cfg(target_os = "macos")]
+fn scan_proc_fd_paths_into(pid: u32, out: &mut BTreeSet<PathBuf>) {
+    let Ok(output) = std::process::Command::new(lsof_path())
+        .args(["-nP", "-Fn", "-p", &pid.to_string()])
+        .output()
+    else {
+        return;
+    };
+    if !output.status.success() {
+        return;
+    }
+    parse_lsof_file_names(&String::from_utf8_lossy(&output.stdout), out);
+}
+
+#[cfg(target_os = "macos")]
+fn lsof_path() -> &'static str {
+    if std::path::Path::new("/usr/sbin/lsof").is_file() {
+        "/usr/sbin/lsof"
+    } else {
+        "lsof"
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+fn scan_proc_fd_paths_into(_pid: u32, _out: &mut BTreeSet<PathBuf>) {}
+
+#[cfg(any(test, target_os = "macos"))]
+fn parse_lsof_file_names(output: &str, out: &mut BTreeSet<PathBuf>) {
+    for line in output.lines() {
+        let Some(path) = line.strip_prefix('n') else {
+            continue;
+        };
+        let path = path.trim().trim_end_matches(" (deleted)");
+        if path.starts_with('/') {
+            out.insert(PathBuf::from(path));
+        }
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -430,5 +490,18 @@ mod tests {
 
         let paths = scan_proc_fd_paths(std::process::id());
         assert!(paths.contains(&path));
+    }
+
+    #[test]
+    fn lsof_parser_keeps_absolute_file_names() {
+        let mut out = BTreeSet::new();
+
+        parse_lsof_file_names(
+            "p123\nn/private/tmp/session.jsonl\nnlocalhost:1234\nn\n",
+            &mut out,
+        );
+
+        assert!(out.contains(&PathBuf::from("/private/tmp/session.jsonl")));
+        assert_eq!(out.len(), 1);
     }
 }

--- a/collector/src/view/live_top.rs
+++ b/collector/src/view/live_top.rs
@@ -722,10 +722,12 @@ mod tests {
             agent_type: "claude".to_string(),
             start_timestamp_ms: now_ms().saturating_sub(10_000),
             end_timestamp_ms: Some(now_ms().saturating_sub(5_000)),
+            total_tokens: 42,
             attributes: json!({
                 "path": path.to_string_lossy(),
                 "display_id": "claude:cwd",
                 "cwd": "/work",
+                "last_message_at": "2026-07-12T10:00:00Z",
             }),
             ..Default::default()
         };
@@ -760,6 +762,11 @@ mod tests {
         assert_eq!(top.rows[0].session, "claude:cwd");
         assert_eq!(top.rows[0].pid, Some(42));
         assert_eq!(top.rows[0].trace, "agent-native+proc+cwd_recent");
+        assert_eq!(top.rows[0].tokens, Some(42));
+        assert_eq!(
+            top.rows[0].last_message_at.as_deref(),
+            Some("2026-07-12T10:00:00Z")
+        );
     }
 
     #[test]

--- a/collector/tests/export_snapshot_test.rs
+++ b/collector/tests/export_snapshot_test.rs
@@ -105,23 +105,27 @@ fn top_discovers_agent_native_sessions() {
     std::fs::write(
         session_path,
         concat!(
-            "{\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.5\"}}\n",
-            "{\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":11,\"output_tokens\":4,\"total_tokens\":15}}}}\n",
+            "{\"timestamp\":\"2026-07-12T10:00:00Z\",\"type\":\"turn_context\",\"payload\":{\"model\":\"gpt-5.5\"}}\n",
+            "{\"timestamp\":\"2026-07-12T10:00:00Z\",\"type\":\"event_msg\",\"payload\":{\"type\":\"token_count\",\"info\":{\"total_token_usage\":{\"input_tokens\":11,\"output_tokens\":4,\"total_tokens\":15}}}}\n",
             "{\"type\":\"response_item\",\"payload\":{\"type\":\"function_call\",\"name\":\"shell\"}}\n",
-            "{\"type\":\"message\",\"content\":\"fix the test\"}\n",
+            "{\"timestamp\":\"2026-07-12T10:00:00Z\",\"type\":\"message\",\"content\":\"fix the test\"}\n",
         ),
     )
     .expect("codex session");
 
+    let tz = std::ffi::OsStr::new("UTC");
     let top = agentsight_stdout_with_env(
         &["top", "--once", "--limit", "20"],
-        &[("HOME", temp.path().as_os_str())],
+        &[("HOME", temp.path().as_os_str()), ("TZ", tz)],
     );
     assert!(top.contains("live sessions"), "{top}");
     assert!(top.contains("codex:rollout-test"), "{top}");
     assert!(top.contains("TOKENS"), "{top}");
     assert!(top.contains("ACTIVITY"), "{top}");
+    assert!(top.contains("LAST MSG"), "{top}");
+    assert!(top.contains("session tokens: 15"), "{top}");
     assert!(top.contains("15"), "{top}");
+    assert!(top.contains("10:00:00"), "{top}");
     assert!(top.contains("1 tool"), "{top}");
     assert!(top.contains("fix the test"), "{top}");
 }

--- a/script/ci/macos_top_smoke.sh
+++ b/script/ci/macos_top_smoke.sh
@@ -13,8 +13,77 @@ mkdir -p "$(dirname "$OUT_FILE")"
 
 cargo build --manifest-path "$ROOT_DIR/collector/Cargo.toml" --verbose
 
-"$ROOT_DIR/collector/target/debug/agentsight" top --plain --once >"$OUT_FILE"
+TMP_ROOT="$(mktemp -d)"
+AGENT_PID=""
+cleanup() {
+    if [[ -n "$AGENT_PID" ]]; then
+        kill "$AGENT_PID" 2>/dev/null || true
+        wait "$AGENT_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+FIXTURE_HOME="$TMP_ROOT/home"
+WORK_DIR="$TMP_ROOT/work"
+BIN_DIR="$TMP_ROOT/bin"
+SESSION_PATH="$FIXTURE_HOME/.codex/sessions/2026/07/12/macos-ci.jsonl"
+mkdir -p "$(dirname "$SESSION_PATH")" "$WORK_DIR" "$BIN_DIR"
+SESSION_REAL_PATH="$(cd "$(dirname "$SESSION_PATH")" && pwd -P)/$(basename "$SESSION_PATH")"
+SESSION_TS="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+SESSION_LAST_MSG="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$SESSION_TS" '+%H:%M:%S')"
+LSOF_BIN="/usr/sbin/lsof"
+if [[ ! -x "$LSOF_BIN" ]]; then
+    LSOF_BIN="$(command -v lsof || true)"
+fi
+if [[ -z "$LSOF_BIN" ]]; then
+    echo "lsof not found; macOS session fd binding cannot be tested" >&2
+    exit 1
+fi
+
+cat >"$SESSION_PATH" <<EOF
+{"timestamp":"$SESSION_TS","type":"turn_context","payload":{"model":"gpt-macos-ci","cwd":"$WORK_DIR"}}
+{"timestamp":"$SESSION_TS","type":"event_msg","payload":{"type":"user_message","message":"macos top token check"}}
+{"timestamp":"$SESSION_TS","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":11,"output_tokens":4,"total_tokens":15}}}}
+EOF
+
+cat >"$BIN_DIR/codex" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exec 3<"$AGENTSIGHT_SESSION_PATH"
+sleep "${AGENTSIGHT_SLEEP_SECS:-30}"
+EOF
+chmod +x "$BIN_DIR/codex"
+
+(
+    cd "$WORK_DIR"
+    AGENTSIGHT_SESSION_PATH="$SESSION_PATH" AGENTSIGHT_SLEEP_SECS=30 "$BIN_DIR/codex"
+) &
+AGENT_PID=$!
+
+for _ in {1..20}; do
+    if ps -p "$AGENT_PID" >/dev/null 2>&1 &&
+        "$LSOF_BIN" -nP -Fn -p "$AGENT_PID" 2>/dev/null | grep -Fqx "n$SESSION_REAL_PATH"; then
+        break
+    fi
+    sleep 0.25
+done
+
+if ! "$LSOF_BIN" -nP -Fn -p "$AGENT_PID" 2>/dev/null | grep -Fqx "n$SESSION_REAL_PATH"; then
+    echo "mock codex process did not open expected session fd: $SESSION_REAL_PATH" >&2
+    "$LSOF_BIN" -nP -Fn -p "$AGENT_PID" >&2 || true
+    exit 1
+fi
+
+HOME="$FIXTURE_HOME" TZ=UTC "$ROOT_DIR/collector/target/debug/agentsight" top --plain --once -c codex --limit 20 >"$OUT_FILE"
 cat "$OUT_FILE"
 
 grep -q "AgentSight top" "$OUT_FILE"
 grep -q "note: no eBPF: live kernel probes are Linux-only" "$OUT_FILE"
+grep -q "codex:macos-ci" "$OUT_FILE"
+grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+live" "$OUT_FILE"
+grep -q "session tokens: 15" "$OUT_FILE"
+grep -q "gpt-macos-ci" "$OUT_FILE"
+grep -q "$SESSION_LAST_MSG" "$OUT_FILE"
+grep -q "macos top token check" "$OUT_FILE"
+grep -q "matching session path" "$OUT_FILE"


### PR DESCRIPTION
## Summary
- add a macOS fd-path backend for live session matching via `lsof -Fn -p <pid>`
- preserve token and last-message fields when an agent-native session binds to a live process
- extend macOS top smoke to create a real Codex session fixture, keep it open from a mock codex process, and assert live binding, tokens, model, prompt, and last message

## Local validation
- `bash -n script/ci/macos_top_smoke.sh`
- `cargo clippy --manifest-path collector/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path collector/Cargo.toml`
- local fixture smoke for `agentsight top --plain --once -c codex --limit 20` with session-path binding output
