### PR TITLE
Tighten AgentSight testing evidence rules

### DIFF
--- a/skills/agentsight-testing/SKILL.md
+++ b/skills/agentsight-testing/SKILL.md
@@ -12,6 +12,12 @@ unit-test boundary. Prefer real binaries, real commands, and saved evidence.
 Mocks are allowed only for narrow regression tests; they do not replace real
 agent validation when the relevant CLI is installed and authenticated.
 
+CI can supplement this proof, but it does not replace direct observation. The
+agent doing the change must inspect the TUI/UI/CLI output or saved artifacts
+itself and report what was observed. Do not defer missing observation to "the
+next PR" or say CI should cover it unless the user explicitly narrows the task
+to CI work.
+
 ## Validation Ladder
 
 Run the narrowest relevant check first, then widen until the changed behavior
@@ -32,17 +38,25 @@ has been exercised end to end.
    - `collector/target/debug/agentsight stat -- <short command>` when the change affects stat/record paths
 4. TUI smoke:
    - Run `agentsight top` in a real terminal or PTY.
-   - Capture the screen text or screenshot artifact.
+   - Capture the screen text or screenshot artifact. Prefer terminal buffer
+     capture such as `tmux capture-pane`, `script` output that includes the
+     rendered screen, or a real screenshot; raw alt-screen escape logs without
+     readable fields are not sufficient.
    - Verify key fields by screen buffer/text, not OCR: session id, agent, state, tokens, last message, model, evidence.
 5. Web UI smoke:
    - Start a command that serves the web UI (`record`, `stat`, or the relevant server mode).
    - Open the URL in a browser or Playwright.
    - Verify the page loads real session/event data and save a screenshot artifact.
+   - The screenshot/artifact must show the relevant feature state, not only that
+     a page rendered or that some JSON endpoint returned data.
 6. Real supported-agent smoke:
    - Check installed/authenticated CLIs with `command -v`.
    - Native session agents: `claude`, `codex`, `gemini`.
    - Live/record targets from README support: Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw/Node/OpenAI-compatible clients, and any command path touched by the change.
    - For each available CLI, run a short non-destructive prompt under AgentSight and verify the expected rows/events. Do not count a mock agent as satisfying this step.
+   - Seeing generic captured data is not enough. Verify the product-level fields
+     affected by the change, such as prompt text, response/last message, token
+     counts, model, session binding, tool calls, evidence, and report/top rows.
 
 ## Real Agent Rules
 
@@ -63,10 +77,11 @@ has been exercised end to end.
 Before saying a PR is done, provide:
 
 - Commands run and pass/fail status.
-- TUI screen text or screenshot path.
-- Web UI screenshot path or Playwright artifact path.
+- TUI screen text or screenshot path, plus the specific fields observed.
+- Web UI screenshot path or Playwright artifact path, plus the specific UI state observed.
 - Real agent matrix: agent, installed/authenticated status, AgentSight command,
-  observed output, result.
+  observed output, DB/artifact path when available, inspection command, fields
+  verified, and result.
 - CI links after push.
 - Copilot review/comment/thread status for the final pushed head.
 


### PR DESCRIPTION
## Summary
- clarify that CI supplements but does not replace direct TUI/UI/CLI observation
- require readable TUI artifacts and feature-specific Web UI screenshots
- require real-agent matrices to include inspected fields, DB/artifact paths, and inspection commands

## Validation
- python3 /home/yunwei37/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/agentsight-testing
- git diff --check