### PR TITLE
Tighten exec prompt parsing

### DIFF
--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -373,21 +373,19 @@ fn observed_codex_exec_command(audit_rows: &[AuditEventRow]) -> bool {
         .iter()
         .filter(|row| row.audit_type == "process" && row.action.as_deref() == Some("exec"))
         .filter_map(|row| row.details.get("full_command").and_then(Value::as_str))
-        .any(looks_like_codex_exec_command)
+        .any(|command| codex_exec_command_tail(command).is_some())
 }
 
 fn codex_exec_prompt_from_command(command: &str) -> Option<String> {
-    if !looks_like_codex_exec_command(command) {
-        return None;
-    }
-    agent_session::codex_exec_prompt(command)
+    agent_session::codex_exec_prompt(&codex_exec_command_tail(command)?)
 }
 
-fn looks_like_codex_exec_command(command: &str) -> bool {
+fn codex_exec_command_tail(command: &str) -> Option<String> {
     let tokens = command.split_whitespace().collect::<Vec<_>>();
-    tokens.windows(2).enumerate().any(|(index, tokens)| {
-        is_codex_executable_token(tokens[0], index == 0) && tokens[1] == "exec"
-    })
+    let index = tokens.windows(2).enumerate().find_map(|(index, tokens)| {
+        (is_codex_executable_token(tokens[0], index == 0) && tokens[1] == "exec").then_some(index)
+    })?;
+    Some(tokens[index..].join(" "))
 }
 
 fn looks_like_native_codex_exec(row: &AuditEventRow) -> bool {
@@ -753,6 +751,7 @@ mod tests {
             (11_000, "codex", "/usr/bin/codex exec --skip-git-repo-check agentsight repeated prompt"),
             (20_000, "codex", "/usr/bin/codex exec --skip-git-repo-check agentsight repeated prompt"),
             (21_000, "docker", "docker exec codex exec agentsight should not parse"),
+            (22_000, "docker", "docker exec container /usr/local/bin/codex exec agentsight should parse once"),
         ]
         .into_iter()
         .enumerate()
@@ -773,6 +772,7 @@ mod tests {
                 Some("agentsight repeated prompt".to_string()),
                 Some("agentsight repeated prompt".to_string()),
                 Some("agentsight repeated prompt".to_string()),
+                Some("agentsight should parse once".to_string()),
             ]
         );
     }


### PR DESCRIPTION
## Summary
- parse prompt text from the actual agent exec token instead of the first generic `exec` in a wrapper command
- preserve truncated exec detection for saved-session fallback
- add coverage for wrapper/container exec edge cases

## Validation
- `cargo test --manifest-path collector/Cargo.toml codex -- --nocapture`
- `cargo test --manifest-path collector/Cargo.toml`
- `AGENTSIGHT_BIN=$PWD/collector/target/debug/agentsight AGENTSIGHT_AGENT_CANARY_BUILD=0 AGENTSIGHT_AGENT_CANARY_WORK_DIR=$PWD/.artifacts/pr-tighten-codex-exec/latest-agent-canary timeout 12m bash script/e2e/latest_agent_cli_canary.sh`

## Code growth
- `collector/src/sources/agent_native.rs | 18 +++++++++---------`
- net 0 LOC
