### PR TITLE
Fix top native session source

### DIFF
--- a/agent-session/src/types.rs
+++ b/agent-session/src/types.rs
@@ -169,6 +169,7 @@ pub struct SessionCache {
     cached_sessions: Vec<AgentSession>,
     last_refresh: Option<Instant>,
     last_limit: usize,
+    last_excluded_agents: Vec<String>,
 }
 
 struct CacheEntry {
@@ -182,19 +183,39 @@ impl SessionCache {
     }
 
     pub fn discover_cached(&mut self, limit: usize, max_age: Duration) -> Vec<AgentSession> {
+        self.discover_cached_excluding(limit, max_age, &[])
+    }
+
+    pub fn discover_cached_excluding(
+        &mut self,
+        limit: usize,
+        max_age: Duration,
+        excluded_agents: &[&str],
+    ) -> Vec<AgentSession> {
         let target = limit.clamp(1, 25);
+        let mut excluded_agents = excluded_agents
+            .iter()
+            .map(|agent| (*agent).to_string())
+            .collect::<Vec<_>>();
+        excluded_agents.sort();
         if self.last_limit < target
+            || self.last_excluded_agents != excluded_agents
             || self
                 .last_refresh
                 .is_none_or(|last| last.elapsed() >= max_age)
         {
-            self.refresh(target);
+            self.refresh(target, &excluded_agents);
         }
         self.cached_sessions.iter().take(target).cloned().collect()
     }
 
-    fn refresh(&mut self, limit: usize) {
+    fn refresh(&mut self, limit: usize, excluded_agents: &[String]) {
         let mut candidates = discover_session_files();
+        candidates.retain(|candidate| {
+            !excluded_agents
+                .iter()
+                .any(|agent| agent == candidate.agent)
+        });
         candidates.sort_by_key(|candidate| std::cmp::Reverse(candidate.updated));
         let target = limit.clamp(1, 25);
         let mut live_paths = HashSet::new();
@@ -233,5 +254,6 @@ impl SessionCache {
         self.cached_sessions = sessions;
         self.last_refresh = Some(Instant::now());
         self.last_limit = target;
+        self.last_excluded_agents = excluded_agents.to_vec();
     }
 }

--- a/collector/src/cmd_monitor.rs
+++ b/collector/src/cmd_monitor.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use crate::output::{AgentTopOutput, AgentTopRow, TopOptions, clear_screen, print_agent_top};
 use crate::sources::proc::{self as procfs, ProcSnapshot};
 use crate::state::{agentsight_state_dir_for_home, ensure_agentsight_state_dir_for_home};
 use crate::view::live_top::{LiveMonitorSample, LiveView};
-use crate::view::top::sort_agent_rows;
 use chrono::{Datelike, Local, NaiveDate};
-use rusqlite::{Connection, OpenFlags, params};
+use rusqlite::{Connection, params};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::{self, Write};
@@ -179,46 +177,6 @@ pub(crate) fn install_monitor_service() -> Result<(), Box<dyn std::error::Error 
     Ok(())
 }
 
-pub(crate) fn active_monitor_db_path() -> Option<PathBuf> {
-    active_monitor().map(|pid_file| pid_file.db_path)
-}
-
-pub(crate) async fn run_monitor_top_query(
-    interval_secs: u64,
-    limit: usize,
-    count: Option<u32>,
-    options: &TopOptions,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let active = active_monitor().ok_or("monitor is not running")?;
-    let limit = limit.clamp(1, 100);
-    let interval = Duration::from_secs(interval_secs.max(1));
-    let shutdown = crate::shutdown_notify();
-    let mut iterations = 0u32;
-    let should_clear_screen = count != Some(1);
-
-    loop {
-        if should_clear_screen {
-            clear_screen();
-        }
-        let mut top = build_monitor_top(&active.db_path, limit, options)?;
-        sort_agent_rows(&mut top.rows, &options.sort);
-        top.rows.truncate(limit);
-        print_agent_top(&top);
-        io::stdout().flush()?;
-
-        iterations += 1;
-        if count.is_some_and(|max| iterations >= max) || crate::shutdown_requested() {
-            break;
-        }
-        tokio::select! {
-            _ = tokio::time::sleep(interval) => {}
-            _ = shutdown.notified() => break,
-        }
-    }
-
-    Ok(())
-}
-
 fn print_monitor_tick(path: &Path, stats: &MonitorWriteStats) {
     println!(
         "saved {} sessions | {} windows -> {}",
@@ -226,124 +184,6 @@ fn print_monitor_tick(path: &Path, stats: &MonitorWriteStats) {
         stats.windows,
         path.display()
     );
-}
-
-fn build_monitor_top(
-    db_path: &Path,
-    limit: usize,
-    options: &TopOptions,
-) -> Result<AgentTopOutput<'static>, Box<dyn std::error::Error + Send + Sync>> {
-    let rows = load_monitor_top_rows(db_path, options)?;
-    let db_note = format!(
-        "using background monitor data from {}; no live eBPF/probes started",
-        db_path.display()
-    );
-    let mut process_counts = BTreeMap::new();
-    for row in &rows {
-        *process_counts.entry(row.agent.clone()).or_insert(0i64) += row.processes.max(1) as i64;
-    }
-    let mut sections = Vec::new();
-    if !process_counts.is_empty() {
-        let mut sorted = process_counts.into_iter().collect::<Vec<_>>();
-        sorted.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
-        sorted.truncate(limit);
-        sections.push(("Processes", "monitor", sorted));
-    }
-
-    Ok(AgentTopOutput {
-        mode: "monitor",
-        db: None,
-        duration_s: 0.0,
-        view_events: rows.len() as i64,
-        llm_calls: 0,
-        total_tokens: 0,
-        rows,
-        sections,
-        failures: Vec::new(),
-        notes: vec![db_note],
-    })
-}
-
-fn load_monitor_top_rows(
-    db_path: &Path,
-    options: &TopOptions,
-) -> rusqlite::Result<Vec<AgentTopRow>> {
-    let conn = Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY)?;
-    let network_targets_expr = if monitor_windows_has_network_targets_column(&conn)? {
-        "w.network_targets"
-    } else {
-        "0"
-    };
-    let now_ms = now_epoch_ms();
-    let sql = format!(
-        "SELECT
-            t.session_id, t.display_id, t.agent_type, t.root_pid, t.first_seen_ms,
-            t.command, t.cwd, w.window_start_ms, w.window_end_ms, w.process_count,
-            w.cpu_ms, w.rss_bytes, w.file_targets, {network_targets_expr}
-         FROM monitor_windows w
-         JOIN tracked_sessions t USING(session_id, root_pid, root_starttime_ticks)
-         WHERE w.id IN (
-            SELECT MAX(id)
-            FROM monitor_windows
-            GROUP BY session_id, root_pid, root_starttime_ticks
-         )
-         ORDER BY w.window_end_ms DESC"
-    );
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], |row| {
-        let session_id: String = row.get(0)?;
-        let display_id: String = row.get(1)?;
-        let agent_type: String = row.get(2)?;
-        let root_pid: u32 = row.get::<_, i64>(3)? as u32;
-        let first_seen_ms: u64 = row.get::<_, i64>(4)? as u64;
-        let command: String = row.get(5)?;
-        let cwd: Option<String> = row.get(6)?;
-        let window_start_ms: u64 = row.get::<_, i64>(7)? as u64;
-        let window_end_ms: u64 = row.get::<_, i64>(8)? as u64;
-        let process_count: usize = row.get::<_, i64>(9)? as usize;
-        let cpu_ms: u64 = row.get::<_, i64>(10)? as u64;
-        let rss_bytes: u64 = row.get::<_, i64>(11)? as u64;
-        let file_targets: usize = row.get::<_, i64>(12)? as usize;
-        let network_targets: usize = row.get::<_, i64>(13)? as usize;
-        let window_ms = window_end_ms.saturating_sub(window_start_ms).max(1);
-        let cpu_percent = cpu_ms as f64 / window_ms as f64 * 100.0;
-        Ok(AgentTopRow {
-            session: if display_id.is_empty() {
-                short_monitor_session_id(&session_id)
-            } else {
-                display_id
-            },
-            agent: agent_type,
-            pid: Some(root_pid),
-            model: None,
-            age_s: Some(now_ms.saturating_sub(first_seen_ms) as f64 / 1000.0),
-            cpu_percent,
-            rss_mb: bytes_to_mb(rss_bytes),
-            processes: process_count,
-            tokens: None,
-            tools: 0,
-            execs: 0,
-            failures: 0,
-            files: file_targets,
-            network: network_targets,
-            unattributed: 0,
-            trace: "proc+db".to_string(),
-            command,
-            workspace: cwd,
-            last_message_at: None,
-            tool_breakdown: Vec::new(),
-            file_breakdown: Vec::new(),
-        })
-    })?;
-
-    let mut out = Vec::new();
-    for row in rows {
-        let row = row?;
-        if options.matches(row.pid, Some(&row.agent), Some(&row.command)) {
-            out.push(row);
-        }
-    }
-    Ok(out)
 }
 
 fn build_monitor_sample(live: &LiveMonitorSample, io_state: &mut MonitorIoState) -> MonitorSample {
@@ -787,23 +627,6 @@ fn now_epoch_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|duration| duration.as_millis() as u64)
         .unwrap_or_default()
-}
-
-fn bytes_to_mb(bytes: u64) -> u64 {
-    if bytes == 0 {
-        0
-    } else {
-        bytes.div_ceil(1_048_576)
-    }
-}
-
-fn short_monitor_session_id(session_id: &str) -> String {
-    session_id
-        .rsplit(':')
-        .next()
-        .filter(|value| !value.is_empty())
-        .unwrap_or(session_id)
-        .to_string()
 }
 
 fn systemd_user_dir() -> io::Result<PathBuf> {
@@ -1317,25 +1140,11 @@ mod tests {
             .conn
             .query_row("SELECT COUNT(*) FROM network_samples", [], |row| row.get(0))
             .unwrap();
-        let top = build_monitor_top(
-            store.path(),
-            10,
-            &TopOptions {
-                pid: None,
-                comm: None,
-                sort: "cpu".to_string(),
-                view: "all".to_string(),
-            },
-        )
-        .unwrap();
 
         assert_eq!(stats.sessions, 1);
         assert_eq!(stats.windows, 1);
         assert_eq!((windows, file_targets), (1, 3));
         assert_eq!((process_samples, file_samples, network_samples), (1, 1, 1));
-        assert_eq!(top.rows.len(), 1);
-        assert_eq!(top.rows[0].files, 2);
-        assert_eq!(top.rows[0].network, 1);
     }
 
     #[test]

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -50,9 +50,7 @@ use cli_db::{
 };
 use cmd_debug::{run_raw_process, run_raw_ssl, run_raw_stdio, run_system};
 use cmd_exec::{default_session_db_path, print_session_summary, run_exec};
-use cmd_monitor::{
-    active_monitor_db_path, install_monitor_service, run_monitor, run_monitor_top_query,
-};
+use cmd_monitor::{install_monitor_service, run_monitor};
 use cmd_perf::run_top_query;
 use cmd_perf_live::run_live_top_query;
 use cmd_perf_tui::{run_live_top_tui, run_saved_top_tui};
@@ -132,10 +130,6 @@ fn interactive_terminal_available() -> bool {
 
 fn top_uses_tui(plain: bool, interactive: bool) -> bool {
     !plain && interactive
-}
-
-fn top_uses_monitor_snapshot(plain: bool, monitor_active: bool) -> bool {
-    plain && monitor_active
 }
 
 fn command_uses_top_tui(cli: &Cli) -> bool {
@@ -659,27 +653,6 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 run_top_query(db, *interval, *limit, count, &options)?;
             }
         }
-        Commands::Top {
-            db: None,
-            pid,
-            comm,
-            sort,
-            view,
-            interval,
-            limit,
-            count,
-            once,
-            plain,
-        } if top_uses_monitor_snapshot(*plain, active_monitor_db_path().is_some()) => {
-            let count = if *once { Some(1) } else { *count };
-            let options = TopOptions {
-                pid: *pid,
-                comm: comm.clone(),
-                sort: sort.clone(),
-                view: view.clone(),
-            };
-            run_monitor_top_query(*interval, *limit, count, &options).await?;
-        }
         Commands::Monitor { command } => match command {
             None => run_monitor().await?,
             Some(MonitorCommands::InstallService) => install_monitor_service()?,
@@ -984,7 +957,7 @@ async fn run_with_extractor(
 
 #[cfg(test)]
 mod tests {
-    use super::{top_uses_monitor_snapshot, top_uses_tui};
+    use super::top_uses_tui;
 
     #[test]
     fn default_interactive_top_uses_tui() {
@@ -995,12 +968,5 @@ mod tests {
     fn only_plain_or_non_tty_disable_tui() {
         assert!(!top_uses_tui(true, true));
         assert!(!top_uses_tui(false, false));
-    }
-
-    #[test]
-    fn monitor_snapshot_requires_explicit_plain_mode() {
-        assert!(top_uses_monitor_snapshot(true, true));
-        assert!(!top_uses_monitor_snapshot(false, true));
-        assert!(!top_uses_monitor_snapshot(true, false));
     }
 }

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -4,9 +4,9 @@
 use agent_session::{AgentSession, TokenUsage};
 use serde_json::Value;
 use std::cmp::Reverse;
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::time::{Duration, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 #[cfg(test)]
 use std::fs;
@@ -38,12 +38,182 @@ pub(crate) fn snapshot(
     limit: usize,
     max_age: Duration,
 ) -> Snapshot {
-    let filtered: Vec<LocalSession> = cache
-        .discover_cached(limit, max_age)
+    let indexed_codex = codex_state_sessions(limit);
+    let mut sessions = if indexed_codex.is_empty() {
+        cache.discover_cached(limit, max_age)
+    } else {
+        let mut sessions = indexed_codex;
+        sessions.extend(cache.discover_cached_excluding(
+            limit,
+            max_age,
+            &[agent_session::AGENT_CODEX],
+        ));
+        sessions.sort_by_key(|session| Reverse(session.updated));
+        sessions.truncate(limit.clamp(1, 25));
+        sessions
+    };
+    let mut seen = HashSet::new();
+    sessions.retain(|session| seen.insert(session.display_id.clone()));
+    let filtered: Vec<LocalSession> = sessions
         .into_iter()
         .filter(|s| matches_filter(s, pid_filter, text_filter))
         .collect();
     materialized_view(&filtered).export_snapshot(SnapshotOptions { audit_limit: 0 })
+}
+
+fn codex_state_sessions(limit: usize) -> Vec<LocalSession> {
+    user_home_dir()
+        .as_deref()
+        .map(|home| codex_state_sessions_in_home(home, limit))
+        .unwrap_or_default()
+}
+
+fn codex_state_sessions_in_home(home: &Path, limit: usize) -> Vec<LocalSession> {
+    let db_path = home.join(".codex/state_5.sqlite");
+    let Ok(conn) =
+        rusqlite::Connection::open_with_flags(db_path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY)
+    else {
+        return Vec::new();
+    };
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT id, rollout_path, model, tokens_used, preview, cwd, created_at_ms, updated_at_ms
+         FROM threads
+         ORDER BY updated_at_ms DESC
+         LIMIT ?1",
+    ) else {
+        return Vec::new();
+    };
+    let Ok(rows) = stmt.query_map([limit.clamp(1, 25) as i64], |row| {
+        let id: String = row.get(0)?;
+        let rollout_path: String = row.get(1)?;
+        let model: Option<String> = row.get(2)?;
+        let tokens_used: i64 = row.get(3)?;
+        let preview: Option<String> = row.get(4)?;
+        let cwd: Option<String> = row.get(5)?;
+        let created_at_ms: Option<i64> = row.get(6)?;
+        let updated_at_ms: Option<i64> = row.get(7)?;
+        Ok(codex_state_session(
+            id,
+            rollout_path,
+            model,
+            tokens_used,
+            preview,
+            cwd,
+            created_at_ms,
+            updated_at_ms,
+        ))
+    }) else {
+        return Vec::new();
+    };
+
+    rows.filter_map(Result::ok).collect()
+}
+
+fn codex_state_session(
+    id: String,
+    rollout_path: String,
+    model: Option<String>,
+    tokens_used: i64,
+    preview: Option<String>,
+    cwd: Option<String>,
+    created_at_ms: Option<i64>,
+    updated_at_ms: Option<i64>,
+) -> LocalSession {
+    let updated_ms = updated_at_ms.and_then(non_negative_i64_to_u64);
+    let created_ms = created_at_ms
+        .and_then(non_negative_i64_to_u64)
+        .or(updated_ms);
+    let updated = updated_ms.map(system_time_from_ms).unwrap_or(UNIX_EPOCH);
+    let usage = TokenUsage {
+        total_tokens: tokens_used.max(0),
+        ..Default::default()
+    };
+    let model = model.filter(|value| !value.is_empty());
+    let mut model_usage = BTreeMap::new();
+    if let Some(model) = model.as_deref() {
+        model_usage.insert(model.to_string(), usage.clone());
+    }
+    let prompt_preview = preview
+        .and_then(|text| clean_prompt_text(&text))
+        .map(|text| truncate_text(&text, 180));
+    let last_message_at = updated_ms.map(iso_utc_from_ms);
+
+    LocalSession {
+        agent_type: agent_session::AGENT_CODEX.to_string(),
+        session_id: id.clone(),
+        conversation_id: Some(id.clone()),
+        display_id: format!("{}:{}", agent_session::AGENT_CODEX, short_session_id(&id)),
+        path: PathBuf::from(rollout_path),
+        updated,
+        start_timestamp_ms: created_ms,
+        end_timestamp_ms: updated_ms,
+        model,
+        usage,
+        model_usage,
+        tools: BTreeMap::new(),
+        files: BTreeMap::new(),
+        prompt_preview,
+        duration_ms: created_ms
+            .zip(updated_ms)
+            .map(|(start, end)| end.saturating_sub(start))
+            .unwrap_or_default(),
+        cwd,
+        last_message_at,
+        events: Default::default(),
+    }
+}
+
+fn user_home_dir() -> Option<PathBuf> {
+    std::env::var("SUDO_USER")
+        .ok()
+        .and_then(|user| {
+            std::fs::read_to_string("/etc/passwd")
+                .ok()
+                .and_then(|passwd| {
+                    passwd
+                        .lines()
+                        .find(|line| line.starts_with(&format!("{user}:")))
+                        .and_then(|line| line.split(':').nth(5))
+                        .map(PathBuf::from)
+                })
+        })
+        .or_else(dirs::home_dir)
+}
+
+fn non_negative_i64_to_u64(value: i64) -> Option<u64> {
+    u64::try_from(value).ok()
+}
+
+fn system_time_from_ms(value: u64) -> SystemTime {
+    UNIX_EPOCH + Duration::from_millis(value)
+}
+
+fn iso_utc_from_ms(value: u64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp_millis(value as i64)
+        .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
+        .unwrap_or_default()
+}
+
+fn short_session_id(id: &str) -> String {
+    let compact = id.rsplit(['/', '\\']).next().unwrap_or(id).trim();
+    if compact.chars().count() <= 12 {
+        return compact.to_string();
+    }
+    let head = compact.chars().take(6).collect::<String>();
+    let tail = compact
+        .chars()
+        .rev()
+        .take(5)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<String>();
+    format!("{head}.{tail}")
+}
+
+fn clean_prompt_text(text: &str) -> Option<String> {
+    let text = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!text.trim().is_empty()).then(|| text.trim().to_string())
 }
 
 fn view_id(session: &LocalSession) -> String {
@@ -672,6 +842,70 @@ mod tests {
             rows[0].request.get("prompt").and_then(Value::as_str),
             Some("agentsight local codex prompt")
         );
+    }
+
+    #[test]
+    fn codex_state_db_produces_indexed_session_metadata() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_dir = temp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let conn = rusqlite::Connection::open(codex_dir.join("state_5.sqlite")).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                rollout_path TEXT,
+                model TEXT,
+                tokens_used INTEGER NOT NULL DEFAULT 0,
+                preview TEXT,
+                cwd TEXT,
+                created_at_ms INTEGER,
+                updated_at_ms INTEGER
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO threads
+             (id, rollout_path, model, tokens_used, preview, cwd, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            rusqlite::params![
+                "019f49ca-54e7-7a91-82e7-a52b53cfd456",
+                temp.path()
+                    .join(".codex/sessions/session.jsonl")
+                    .to_string_lossy(),
+                "gpt-5.5",
+                12345i64,
+                "hello from state",
+                "/work/repo",
+                1_800_000i64,
+                1_900_000i64,
+            ],
+        )
+        .unwrap();
+
+        let sessions = codex_state_sessions_in_home(temp.path(), 5);
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].display_id, "codex:019f49.fd456");
+        assert_eq!(sessions[0].model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(sessions[0].usage.total_tokens, 12345);
+        assert_eq!(
+            sessions[0].prompt_preview.as_deref(),
+            Some("hello from state")
+        );
+        assert_eq!(sessions[0].cwd.as_deref(), Some("/work/repo"));
+        assert_eq!(
+            sessions[0].last_message_at.as_deref(),
+            Some("1970-01-01T00:31:40.000Z")
+        );
+    }
+
+    #[test]
+    fn codex_state_db_errors_return_empty_for_jsonl_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::create_dir_all(temp.path().join(".codex")).unwrap();
+        fs::write(temp.path().join(".codex/state_5.sqlite"), "not sqlite").unwrap();
+
+        assert!(codex_state_sessions_in_home(temp.path(), 5).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- remove the `top --plain` monitor-DB shortcut so `top --plain --once` always uses the live/native top path
- read recent Codex thread metadata from `~/.codex/state_5.sqlite` in the collector, using the existing collector `rusqlite` dependency
- keep the background `agentsight monitor` writer, but stop using its process-only DB as the default `top` backend

## Why

`agentsight top --plain --once` could silently switch to the background monitor DB whenever a monitor pid file existed. That backend only stores process/window data, so Codex model, token, and last-message fields were rendered as empty even though Codex had authoritative metadata in `~/.codex/state_5.sqlite`.

Without the monitor shortcut, the old native path had to scan large Codex rollout files. On this machine it took about 19s and ~274MB RSS. Using the Codex state index keeps the native path fast and accurate.

The Codex SQLite read now lives in `collector/src/sources/agent_native.rs`, not in `agent-session`, so the portable parser crate does not gain a SQLite dependency. If the state DB cannot be opened or queried, the loader returns no indexed sessions and the normal JSONL fallback remains available.

## Local validation

- `cargo test --manifest-path agent-session/Cargo.toml -- --nocapture` - passed, 4 tests
- `cargo test --manifest-path collector/Cargo.toml` - passed, 191 passed, 1 ignored; export snapshot 5 passed; system runner 3 passed
- `cargo build --manifest-path collector/Cargo.toml` - passed
- real local Codex state comparison:
  - `collector/target/debug/agentsight top --plain --once --limit 10` while `~/.agentsight/monitor/monitor.pid` existed rendered `live sessions`, not `monitor`
  - output included Codex `LAST MSG`, `MODEL`, `TOKENS`, workspace, and preview
  - runtime improved from previous no-monitor JSONL scan `elapsed=19.14 maxrss=273844` to `elapsed=0.78 maxrss=26604`

## Code-growth review

Final source diffstat: 4 files changed, 265 insertions, 234 deletions, net +31 source lines.

There is no lockfile or dependency growth in the final patch. The remaining source growth is the collector-side Codex state loader plus two focused tests. The monitor-top backend deletion removes the process-only top projection that caused this bug.

The test data is small and local to `agent_native` tests; no persistent fixture files are added.

## Notes

One unbound Codex process row can still appear as `/proc` when there is no safe session-path evidence tying that process tree to a specific Codex thread. This PR does not guess-bind app-server/background processes by cwd alone.
