### PR TITLE
Keep plain top off live capture backend

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ make install
 
 ```bash
 # Live agent sessions
-sudo ./agentsight top
+./agentsight top
 
 # Launch and record a command
 sudo ./agentsight record -- claude
@@ -137,7 +137,7 @@ This logic is in `build_trace_agent()` in `collector/src/cmd_trace.rs`.
 
 ## CLI Subcommands
 
-- **`top`** — Primary live view. Run as `sudo ./agentsight top`; it loads eBPF probes and also reads agent-native sessions when present.
+- **`top`** — Primary live view. Plain/non-TTY output uses process snapshots and agent-native sessions; interactive TUI top also loads eBPF probes when sudo is already available.
 - **`record`** — Optimized recording. Use `sudo ./agentsight record -- <command>` to launch and trace a command, or `sudo ./agentsight record -c <comm>` / `-p <pid>` to attach. It enables SSL, process, stdio when applicable, system monitoring, materialized view sinks, and the web UI by default.
 - **`stat`** — Query the latest saved session, or run `sudo ./agentsight stat -- <command>` and print counters when the command exits.
 - **`report [summary|token|audit|prompts|export|list]`** — Query saved local SQLite sessions; these usually do not need sudo. `report` with no subcommand defaults to `summary`.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ AgentSight captures critical interactions that application-level tools miss:
 ### Prerequisites
 
 - **Linux kernel**: 4.1+ with eBPF support (5.0+ recommended)
-- **sudo access**: optional for `top`; eBPF probes are enabled automatically when sudo is already available
+- **sudo access**: optional for `top`; interactive top enables eBPF automatically when sudo is already available
 
 For source builds, see [docs/build.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/build.md).
 
@@ -91,7 +91,7 @@ file in the current directory. Start with the live and record commands, then
 use `agentsight report` for structured queries:
 
 ```bash
-agentsight top                               # live ranked view; uses eBPF when sudo is already available
+agentsight top                               # live ranked view; interactive TUI uses eBPF when sudo is already available
 agentsight monitor install-service           # install/start the background monitor service
 agentsight top --db run.db --once            # ranked view of a saved session
 sudo agentsight record -- claude             # record a command
@@ -194,7 +194,7 @@ collector setup and backend integration.
 ## ❓ Frequently Asked Questions
 
 **Q: What permissions does AgentSight need?**
-A: `top` works without sudo by using process snapshots and native agent session files. If you run it with sudo, or your user already has passwordless/cached sudo, it also enables live eBPF process capture. With `record -- <command>`, the monitored agent still runs as your normal user; only the probes are elevated.
+A: `top` works without sudo by using process snapshots and native agent session files. Interactive `top` enables live eBPF process capture when you run it with sudo or your user already has passwordless/cached sudo; plain/non-TTY `top` stays snapshot-only. With `record -- <command>`, the monitored agent still runs as your normal user; only the probes are elevated.
 
 **Q: What's the performance impact?**
 A: Our evaluation reports less than 3% CPU overhead for typical traced agent workloads.

--- a/collector/src/cmd_perf_live.rs
+++ b/collector/src/cmd_perf_live.rs
@@ -200,7 +200,6 @@ fn record_live_ebpf_event(state: &Arc<Mutex<LiveCaptureState>>, event: &Event) {
 }
 
 pub(crate) async fn run_live_top_query(
-    binary_extractor: &BinaryExtractor,
     interval_secs: u64,
     limit: usize,
     count: Option<u32>,
@@ -211,17 +210,12 @@ pub(crate) async fn run_live_top_query(
     let mut iterations = 0u32;
     let should_clear_screen = count != Some(1);
     let mut live_view = LiveView::default();
-    let capture = start_live_ebpf_capture(binary_extractor, options).await;
 
     loop {
         if should_clear_screen {
             clear_screen();
         }
-        let capture_snapshot = capture.as_ref().map(LiveEbpfCapture::snapshot);
-        let mut top = live_view.refresh(capture_snapshot.as_ref(), limit, options)?;
-        if let Some(note) = capture.as_ref().and_then(|capture| capture.start_note()) {
-            top.notes.push(note.to_string());
-        }
+        let mut top = live_view.refresh(None, limit, options)?;
         sort_agent_rows(&mut top.rows, &options.sort);
         top.rows.truncate(limit);
         print_agent_top(&top);
@@ -232,10 +226,6 @@ pub(crate) async fn run_live_top_query(
             break;
         }
         std::thread::sleep(interval);
-    }
-
-    if let Some(capture) = capture {
-        capture.stop();
     }
 
     Ok(())

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -657,6 +657,28 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             None => run_monitor().await?,
             Some(MonitorCommands::InstallService) => install_monitor_service()?,
         },
+        Commands::Top {
+            db: None,
+            pid,
+            comm,
+            sort,
+            view,
+            interval,
+            limit,
+            count,
+            once,
+            plain,
+        } if !top_uses_tui(*plain, interactive_terminal_available()) =>
+        {
+            let count = if *once { Some(1) } else { *count };
+            let options = TopOptions {
+                pid: *pid,
+                comm: comm.clone(),
+                sort: sort.clone(),
+                view: view.clone(),
+            };
+            run_live_top_query(*interval, *limit, count, &options).await?;
+        }
         // All remaining commands need the binary extractor.
         _ => {
             let binary_extractor = BinaryExtractor::new().await?;
@@ -787,7 +809,7 @@ async fn run_with_extractor(
             if top_uses_tui(*plain, interactive_terminal_available()) {
                 run_live_top_tui(binary_extractor, *interval, *limit, count, &options).await?;
             } else {
-                run_live_top_query(binary_extractor, *interval, *limit, count, &options).await?;
+                run_live_top_query(*interval, *limit, count, &options).await?;
             }
         }
         Commands::Debug(cmd) => match cmd {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -668,8 +668,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             count,
             once,
             plain,
-        } if !top_uses_tui(*plain, interactive_terminal_available()) =>
-        {
+        } => {
             let count = if *once { Some(1) } else { *count };
             let options = TopOptions {
                 pid: *pid,
@@ -677,7 +676,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 sort: sort.clone(),
                 view: view.clone(),
             };
-            run_live_top_query(*interval, *limit, count, &options).await?;
+            if top_uses_tui(*plain, interactive_terminal_available()) {
+                let binary_extractor = BinaryExtractor::new().await?;
+                run_live_top_tui(&binary_extractor, *interval, *limit, count, &options).await?;
+            } else {
+                run_live_top_query(*interval, *limit, count, &options).await?;
+            }
         }
         // All remaining commands need the binary extractor.
         _ => {
@@ -786,28 +790,6 @@ async fn run_with_extractor(
             if let Some(ref db) = db_path_for_summary {
                 print_session_summary(db);
             }
-        }
-        Commands::Top {
-            db: None,
-            pid,
-            comm,
-            sort,
-            view,
-            interval,
-            limit,
-            count,
-            once,
-            plain,
-        } => {
-            let count = if *once { Some(1) } else { *count };
-            let options = TopOptions {
-                pid: *pid,
-                comm: comm.clone(),
-                sort: sort.clone(),
-                view: view.clone(),
-            };
-            debug_assert!(top_uses_tui(*plain, interactive_terminal_available()));
-            run_live_top_tui(binary_extractor, *interval, *limit, count, &options).await?;
         }
         Commands::Debug(cmd) => match cmd {
             DebugCommands::Ssl {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -187,7 +187,7 @@ async fn setup_signal_handler(suppress_terminal_output: bool) {
                agentsight top\n\
                agentsight report\n\
                agentsight report prompts --json\n\n\
-             top works without sudo and enables eBPF automatically when sudo is already available;\n\
+             top works without sudo; interactive top enables eBPF when sudo is already available;\n\
              record keeps the monitored agent unprivileged while elevating only the probes."
 )]
 struct Cli {
@@ -806,11 +806,8 @@ async fn run_with_extractor(
                 sort: sort.clone(),
                 view: view.clone(),
             };
-            if top_uses_tui(*plain, interactive_terminal_available()) {
-                run_live_top_tui(binary_extractor, *interval, *limit, count, &options).await?;
-            } else {
-                run_live_top_query(*interval, *limit, count, &options).await?;
-            }
+            debug_assert!(top_uses_tui(*plain, interactive_terminal_available()));
+            run_live_top_tui(binary_extractor, *interval, *limit, count, &options).await?;
         }
         Commands::Debug(cmd) => match cmd {
             DebugCommands::Ssl {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -46,7 +46,8 @@ make build-frontend  # Frontend only
 
 Navigate to the repository root after `make build`. Commands that load eBPF
 probes should be run with `sudo`, except `top`, which can run without sudo and
-uses live eBPF capture only when sudo is already available.
+uses live eBPF capture only for the interactive TUI when sudo is already
+available; plain/non-TTY output stays snapshot-only.
 
 ```sh
 # Live view of local agent sessions

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -45,8 +45,8 @@ make build-frontend  # 仅编译前端
 ## 从源码运行
 
 `make build` 完成后，在仓库根目录运行下面的命令。除 `top` 外，需要加载 eBPF probes
-的命令推荐显式使用 `sudo`；`top` 无需 sudo 也能工作，并且只在 sudo 已可用时启用
-live eBPF capture。
+的命令推荐显式使用 `sudo`；`top` 无需 sudo 也能工作，交互式 TUI 只在 sudo 已可用时
+启用 live eBPF capture，plain/non-TTY 输出保持 snapshot-only。
 
 ```sh
 # 实时查看本机智能体 session

--- a/script/ci/macos_top_smoke.sh
+++ b/script/ci/macos_top_smoke.sh
@@ -79,7 +79,7 @@ HOME="$FIXTURE_HOME" TZ=UTC "$ROOT_DIR/collector/target/debug/agentsight" top --
 cat "$OUT_FILE"
 
 grep -q "AgentSight top" "$OUT_FILE"
-if grep -Eq "eBPF|sudo|kernel probes|Linux-only" "$OUT_FILE"; then
+if grep -Eiq "eBPF|sudo|kernel probes|Linux-only" "$OUT_FILE"; then
     echo "plain top unexpectedly mentioned live backend/probe state" >&2
     exit 1
 fi

--- a/script/ci/macos_top_smoke.sh
+++ b/script/ci/macos_top_smoke.sh
@@ -79,7 +79,10 @@ HOME="$FIXTURE_HOME" TZ=UTC "$ROOT_DIR/collector/target/debug/agentsight" top --
 cat "$OUT_FILE"
 
 grep -q "AgentSight top" "$OUT_FILE"
-grep -q "note: no eBPF: live kernel probes are Linux-only" "$OUT_FILE"
+if grep -Eq "eBPF|sudo|kernel probes|Linux-only" "$OUT_FILE"; then
+    echo "plain top unexpectedly mentioned live backend/probe state" >&2
+    exit 1
+fi
 grep -q "codex:macos-ci" "$OUT_FILE"
 grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+live" "$OUT_FILE"
 grep -q "session tokens: 15" "$OUT_FILE"


### PR DESCRIPTION
## Summary
- route live non-TUI top before BinaryExtractor setup
- remove live eBPF capture from plain live top output
- keep interactive TUI top on the existing live eBPF capture path

## Validation
- cargo build --bin agentsight
- cargo test --bin agentsight
- git diff --check
- ./target/debug/agentsight top --plain --once (no eBPF/sudo/kernel notes; elapsed=0.27s locally)

## Code growth
- 2 files changed, 24 insertions(+), 12 deletions(-), net +12 production LOC
- no fixtures or test boilerplate added
- reduction pass removed the initial special-case helper/tests and made all plain live top snapshot-only