### PR TITLE
Reuse native session discovery in web snapshots

### DIFF
--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -203,10 +203,16 @@ fn snapshot_from_sources(
         return Ok(view.export_snapshot(SnapshotOptions { audit_limit }));
     }
 
-    let agent_native_rows = agent_native_sessions
+    let mut session_cache = agent_native_sessions
         .lock()
-        .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?
-        .discover_cached(25, Duration::from_secs(2));
+        .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?;
+    let agent_native_rows = agent_native_sessions::discover_sessions(
+        &mut session_cache,
+        None,
+        None,
+        25,
+        Duration::from_secs(2),
+    );
     let mut view = view
         .lock()
         .map_err(|_| std::io::Error::other("live view lock poisoned"))?;
@@ -249,6 +255,9 @@ mod tests {
     use crate::model::{LlmCallRow, ProcessNodeRow, ViewSink};
     use crate::sinks::sqlite::SqliteStore;
     use crate::view::MaterializedView;
+    use std::ffi::OsString;
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn parses_api_query_parameters() {
@@ -375,5 +384,49 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("db prompt")
         );
+    }
+
+    #[test]
+    fn snapshot_uses_agent_native_indexed_codex_sessions() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        let old_sudo_user = std::env::var_os("SUDO_USER");
+        let temp = tempfile::tempdir().unwrap();
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::remove_var("SUDO_USER");
+        }
+
+        let result = (|| {
+            agent_native_sessions::write_codex_state_db_for_test(
+                temp.path(),
+                "gpt-web-ci",
+                33,
+                "web state prompt",
+            );
+
+            let live_view = MaterializedView::shared_bounded();
+            let sessions = Arc::new(Mutex::new(SessionCache::new()));
+            let snapshot = snapshot_from_sources(&live_view, &sessions, None, 100).unwrap();
+
+            assert_eq!(snapshot.summary.total_tokens, 33);
+            assert_eq!(snapshot.sessions.len(), 1);
+            let session = &snapshot.sessions[0];
+            assert_eq!(session.agent_type, "codex");
+            assert_eq!(session.model.as_deref(), Some("gpt-web-ci"));
+        })();
+
+        restore_env("HOME", old_home);
+        restore_env("SUDO_USER", old_sudo_user);
+        result
+    }
+
+    fn restore_env(name: &str, value: Option<OsString>) {
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
     }
 }

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -203,16 +203,18 @@ fn snapshot_from_sources(
         return Ok(view.export_snapshot(SnapshotOptions { audit_limit }));
     }
 
-    let mut session_cache = agent_native_sessions
-        .lock()
-        .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?;
-    let agent_native_rows = agent_native_sessions::discover_sessions(
-        &mut session_cache,
-        None,
-        None,
-        25,
-        Duration::from_secs(2),
-    );
+    let agent_native_rows = {
+        let mut session_cache = agent_native_sessions
+            .lock()
+            .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?;
+        agent_native_sessions::discover_sessions(
+            &mut session_cache,
+            None,
+            None,
+            25,
+            Duration::from_secs(2),
+        )
+    };
     let mut view = view
         .lock()
         .map_err(|_| std::io::Error::other("live view lock poisoned"))?;
@@ -255,7 +257,6 @@ mod tests {
     use crate::model::{LlmCallRow, ProcessNodeRow, ViewSink};
     use crate::sinks::sqlite::SqliteStore;
     use crate::view::MaterializedView;
-    use std::ffi::OsString;
 
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
@@ -397,13 +398,8 @@ mod tests {
             std::env::remove_var("SUDO_USER");
         }
 
-        let result = (|| {
-            agent_native_sessions::write_codex_state_db_for_test(
-                temp.path(),
-                "gpt-web-ci",
-                33,
-                "web state prompt",
-            );
+        let result = std::panic::catch_unwind(|| {
+            agent_native_sessions::write_codex_state_db_for_test(temp.path());
 
             let live_view = MaterializedView::shared_bounded();
             let sessions = Arc::new(Mutex::new(SessionCache::new()));
@@ -414,19 +410,18 @@ mod tests {
             let session = &snapshot.sessions[0];
             assert_eq!(session.agent_type, "codex");
             assert_eq!(session.model.as_deref(), Some("gpt-web-ci"));
-        })();
+        });
 
-        restore_env("HOME", old_home);
-        restore_env("SUDO_USER", old_sudo_user);
-        result
-    }
-
-    fn restore_env(name: &str, value: Option<OsString>) {
         unsafe {
-            match value {
-                Some(value) => std::env::set_var(name, value),
-                None => std::env::remove_var(name),
+            match old_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match old_sudo_user {
+                Some(value) => std::env::set_var("SUDO_USER", value),
+                None => std::env::remove_var("SUDO_USER"),
             }
         }
+        assert!(result.is_ok());
     }
 }

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -40,6 +40,17 @@ pub(crate) fn snapshot(
     limit: usize,
     max_age: Duration,
 ) -> Snapshot {
+    let filtered = discover_sessions(cache, pid_filter, text_filter, limit, max_age);
+    materialized_view(&filtered).export_snapshot(SnapshotOptions { audit_limit: 0 })
+}
+
+pub(crate) fn discover_sessions(
+    cache: &mut SessionCache,
+    pid_filter: Option<u32>,
+    text_filter: Option<&str>,
+    limit: usize,
+    max_age: Duration,
+) -> Vec<LocalSession> {
     let indexed_codex = codex_state_sessions(limit);
     let mut sessions = if indexed_codex.is_empty() {
         cache.discover_cached(limit, max_age)
@@ -56,11 +67,10 @@ pub(crate) fn snapshot(
     };
     let mut seen = HashSet::new();
     sessions.retain(|session| seen.insert(session.display_id.clone()));
-    let filtered: Vec<LocalSession> = sessions
+    sessions
         .into_iter()
         .filter(|s| matches_filter(s, pid_filter, text_filter))
-        .collect();
-    materialized_view(&filtered).export_snapshot(SnapshotOptions { audit_limit: 0 })
+        .collect()
 }
 
 fn codex_state_sessions(limit: usize) -> Vec<LocalSession> {
@@ -803,6 +813,38 @@ pub(crate) fn parse_content_for_test(
 }
 
 #[cfg(test)]
+pub(crate) fn write_codex_state_db_for_test(home: &Path, model: &str, tokens: i64, preview: &str) {
+    let codex_dir = home.join(".codex");
+    fs::create_dir_all(&codex_dir).unwrap();
+    let conn = rusqlite::Connection::open(codex_dir.join("state_5.sqlite")).unwrap();
+    let rollout_path = sql_quote(&home.join(".codex/sessions/session.jsonl").to_string_lossy());
+    let model = sql_quote(model);
+    let preview = sql_quote(preview);
+    conn.execute_batch(&format!(
+        "CREATE TABLE threads (
+            id TEXT PRIMARY KEY,
+            rollout_path TEXT,
+            model TEXT,
+            tokens_used INTEGER NOT NULL DEFAULT 0,
+            preview TEXT,
+            cwd TEXT,
+            created_at_ms INTEGER,
+            updated_at_ms INTEGER
+        );
+        INSERT INTO threads
+        (id, rollout_path, model, tokens_used, preview, cwd, created_at_ms, updated_at_ms)
+        VALUES
+        ('019f49ca-54e7-7a91-82e7-a52b53cfd456', '{rollout_path}', '{model}', {tokens}, '{preview}', '/work/repo', 1800000, 1900000);"
+    ))
+    .unwrap();
+}
+
+#[cfg(test)]
+fn sql_quote(value: &str) -> String {
+    value.replace('\'', "''")
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 
@@ -833,40 +875,7 @@ mod tests {
     #[test]
     fn codex_state_db_produces_indexed_session_metadata() {
         let temp = tempfile::tempdir().unwrap();
-        let codex_dir = temp.path().join(".codex");
-        fs::create_dir_all(&codex_dir).unwrap();
-        let conn = rusqlite::Connection::open(codex_dir.join("state_5.sqlite")).unwrap();
-        conn.execute_batch(
-            "CREATE TABLE threads (
-                id TEXT PRIMARY KEY,
-                rollout_path TEXT,
-                model TEXT,
-                tokens_used INTEGER NOT NULL DEFAULT 0,
-                preview TEXT,
-                cwd TEXT,
-                created_at_ms INTEGER,
-                updated_at_ms INTEGER
-            );",
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO threads
-             (id, rollout_path, model, tokens_used, preview, cwd, created_at_ms, updated_at_ms)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-            rusqlite::params![
-                "019f49ca-54e7-7a91-82e7-a52b53cfd456",
-                temp.path()
-                    .join(".codex/sessions/session.jsonl")
-                    .to_string_lossy(),
-                "gpt-5.5",
-                12345i64,
-                "hello from state",
-                "/work/repo",
-                1_800_000i64,
-                1_900_000i64,
-            ],
-        )
-        .unwrap();
+        write_codex_state_db_for_test(temp.path(), "gpt-5.5", 12345, "hello from state");
 
         let sessions = codex_state_sessions_in_home(temp.path(), 5);
 

--- a/collector/src/sources/agent_native.rs
+++ b/collector/src/sources/agent_native.rs
@@ -813,14 +813,11 @@ pub(crate) fn parse_content_for_test(
 }
 
 #[cfg(test)]
-pub(crate) fn write_codex_state_db_for_test(home: &Path, model: &str, tokens: i64, preview: &str) {
+pub(crate) fn write_codex_state_db_for_test(home: &Path) {
     let codex_dir = home.join(".codex");
     fs::create_dir_all(&codex_dir).unwrap();
     let conn = rusqlite::Connection::open(codex_dir.join("state_5.sqlite")).unwrap();
-    let rollout_path = sql_quote(&home.join(".codex/sessions/session.jsonl").to_string_lossy());
-    let model = sql_quote(model);
-    let preview = sql_quote(preview);
-    conn.execute_batch(&format!(
+    conn.execute_batch(
         "CREATE TABLE threads (
             id TEXT PRIMARY KEY,
             rollout_path TEXT,
@@ -834,14 +831,9 @@ pub(crate) fn write_codex_state_db_for_test(home: &Path, model: &str, tokens: i6
         INSERT INTO threads
         (id, rollout_path, model, tokens_used, preview, cwd, created_at_ms, updated_at_ms)
         VALUES
-        ('019f49ca-54e7-7a91-82e7-a52b53cfd456', '{rollout_path}', '{model}', {tokens}, '{preview}', '/work/repo', 1800000, 1900000);"
-    ))
+        ('019f49ca-54e7-7a91-82e7-a52b53cfd456', '/tmp/session.jsonl', 'gpt-web-ci', 33, 'web state prompt', '/work/repo', 1800000, 1900000);",
+    )
     .unwrap();
-}
-
-#[cfg(test)]
-fn sql_quote(value: &str) -> String {
-    value.replace('\'', "''")
 }
 
 #[cfg(test)]
@@ -875,17 +867,17 @@ mod tests {
     #[test]
     fn codex_state_db_produces_indexed_session_metadata() {
         let temp = tempfile::tempdir().unwrap();
-        write_codex_state_db_for_test(temp.path(), "gpt-5.5", 12345, "hello from state");
+        write_codex_state_db_for_test(temp.path());
 
         let sessions = codex_state_sessions_in_home(temp.path(), 5);
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].display_id, "codex:019f49.fd456");
-        assert_eq!(sessions[0].model.as_deref(), Some("gpt-5.5"));
-        assert_eq!(sessions[0].usage.total_tokens, 12345);
+        assert_eq!(sessions[0].model.as_deref(), Some("gpt-web-ci"));
+        assert_eq!(sessions[0].usage.total_tokens, 33);
         assert_eq!(
             sessions[0].prompt_preview.as_deref(),
-            Some("hello from state")
+            Some("web state prompt")
         );
         assert_eq!(sessions[0].cwd.as_deref(), Some("/work/repo"));
         assert_eq!(


### PR DESCRIPTION
## Summary
- make agent-native session discovery reusable so Web/API snapshots use the same Codex state-index path as top
- keep Web/API saved-DB behavior unchanged
- add regression coverage for `/api/v1/snapshot` local mode reading indexed Codex session metadata/tokens

## Validation
- `cargo check --bin agentsight`
- `cargo test --bin agentsight snapshot_uses_agent_native_indexed_codex_sessions`
- `cargo test --bin agentsight codex_state_db_produces_indexed_session_metadata`
- `cargo test --bin agentsight`
- `git diff --check`

## Code growth
- Final local diff before PR: 2 files changed, 102 insertions(+), 40 deletions(-), net +62
- Production behavior change is small: Web uses shared discovery instead of raw `discover_cached`; agent-native extraction is factored out of `snapshot`
- Growth is mostly one regression test and a shared test DB fixture; no new runtime dependencies or fixtures
