### PR TITLE
Keep top out of backend setup

### DIFF
--- a/collector/src/cmd_perf_live.rs
+++ b/collector/src/cmd_perf_live.rs
@@ -7,7 +7,7 @@ use crate::view::top::sort_agent_rows;
 use std::io::{self, Write};
 use std::time::Duration;
 
-pub(crate) async fn run_live_top_query(
+pub(crate) fn run_live_top_query(
     interval_secs: u64,
     limit: usize,
     count: Option<u32>,

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -20,7 +20,7 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 use std::io;
 use std::time::{Duration, Instant};
 
-pub(crate) async fn run_live_top_tui(
+pub(crate) fn run_live_top_tui(
     interval_secs: u64,
     limit: usize,
     count: Option<u32>,

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -628,37 +628,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             }
             Some(ReportCommands::List) => run_db_list()?,
         },
-        Commands::Top {
-            db: Some(db),
-            pid,
-            comm,
-            sort,
-            view,
-            interval,
-            limit,
-            count,
-            once,
-            plain,
-        } => {
-            let count = if *once { Some(1) } else { *count };
-            let options = TopOptions {
-                pid: *pid,
-                comm: comm.clone(),
-                sort: sort.clone(),
-                view: view.clone(),
-            };
-            if top_uses_tui(*plain, interactive_terminal_available()) {
-                run_saved_top_tui(db, *interval, *limit, count, &options)?;
-            } else {
-                run_top_query(db, *interval, *limit, count, &options)?;
-            }
-        }
         Commands::Monitor { command } => match command {
             None => run_monitor().await?,
             Some(MonitorCommands::InstallService) => install_monitor_service()?,
         },
         Commands::Top {
-            db: None,
+            db,
             pid,
             comm,
             sort,
@@ -677,9 +652,15 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 view: view.clone(),
             };
             if top_uses_tui(*plain, interactive_terminal_available()) {
-                run_live_top_tui(*interval, *limit, count, &options).await?;
+                if let Some(db) = db {
+                    run_saved_top_tui(db, *interval, *limit, count, &options)?;
+                } else {
+                    run_live_top_tui(*interval, *limit, count, &options)?;
+                }
+            } else if let Some(db) = db {
+                run_top_query(db, *interval, *limit, count, &options)?;
             } else {
-                run_live_top_query(*interval, *limit, count, &options).await?;
+                run_live_top_query(*interval, *limit, count, &options)?;
             }
         }
         // All remaining commands need the binary extractor.


### PR DESCRIPTION
## Summary
- merge saved/live top dispatch into one early top branch before backend setup
- remove unnecessary async wrappers from live top plain/TUI runners
- keep top on process snapshots plus agent-native sessions; no eBPF/backend initialization is introduced

## Validation
- cargo test --bin agentsight --quiet
- cargo clippy --bin agentsight --tests -- -D warnings
- cargo build --bin agentsight --quiet && /usr/bin/time -f 'elapsed=%e maxrss=%M' target/debug/agentsight top --plain --once

## Code growth
- 3 files changed, 11 insertions(+), 30 deletions(-)
- net -19 LOC; production-code simplification only, no test fixture or boilerplate growth