### PR TITLE
Keep plain one-shot top agent-native only

### DIFF
--- a/collector/src/cmd_perf_live.rs
+++ b/collector/src/cmd_perf_live.rs
@@ -12,6 +12,7 @@ pub(crate) fn run_live_top_query(
     limit: usize,
     count: Option<u32>,
     options: &TopOptions,
+    scan_processes: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let limit = limit.clamp(1, 100);
     let interval = Duration::from_secs(interval_secs.max(1));
@@ -23,7 +24,7 @@ pub(crate) fn run_live_top_query(
         if should_clear_screen {
             clear_screen();
         }
-        let mut top = live_view.refresh(limit, options)?;
+        let mut top = live_view.refresh(limit, options, scan_processes)?;
         sort_agent_rows(&mut top.rows, &options.sort);
         top.rows.truncate(limit);
         print_agent_top(&top);

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -35,7 +35,7 @@ pub(crate) fn run_live_top_tui(
         true,
         |display_limit, options| {
             live_view
-                .refresh(display_limit, options)
+                .refresh(display_limit, options, true)
                 .map_err(Into::into)
         },
     )

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -660,7 +660,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             } else if let Some(db) = db {
                 run_top_query(db, *interval, *limit, count, &options)?;
             } else {
-                run_live_top_query(*interval, *limit, count, &options)?;
+                run_live_top_query(*interval, *limit, count, &options, !(*plain && *once))?;
             }
         }
         // All remaining commands need the binary extractor.

--- a/collector/src/view/live_top.rs
+++ b/collector/src/view/live_top.rs
@@ -59,17 +59,35 @@ impl LiveView {
         &mut self,
         limit: usize,
         options: &TopOptions,
+        scan_processes: bool,
     ) -> io::Result<AgentTopOutput<'static>> {
-        let sample = LiveSample::collect()?;
+        let sample = if scan_processes {
+            LiveSample::collect()?
+        } else {
+            LiveSample::default()
+        };
         let session_snapshot = agent_native_sessions::snapshot(
             &mut self.session_cache,
-            options.pid,
+            scan_processes.then_some(options.pid).flatten(),
             options.comm.as_deref(),
             limit,
             Duration::from_secs(2),
         );
-        let top = self.build_top(&sample, &session_snapshot, options);
-        self.previous = Some(sample);
+        let mut top = self.build_top(&sample, &session_snapshot, options);
+        if scan_processes {
+            self.previous = Some(sample);
+        } else {
+            top.mode = "agent-native sessions";
+            top.notes
+                .insert(0, "agent-native once view; no process scan".to_string());
+            if options.pid.is_some() {
+                top.notes.insert(
+                    1,
+                    "pid filters need live process binding; remove -p or run continuous top/TUI"
+                        .to_string(),
+                );
+            }
+        }
         Ok(top)
     }
 

--- a/script/ci/macos_top_smoke.sh
+++ b/script/ci/macos_top_smoke.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 OUT_FILE="${1:-$ROOT_DIR/.artifacts/macos-top-output.txt}"
+LIVE_OUT_FILE="${OUT_FILE%.txt}-live.txt"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "macos_top_smoke.sh requires macOS" >&2
@@ -75,6 +76,18 @@ if ! "$LSOF_BIN" -nP -Fn -p "$AGENT_PID" 2>/dev/null | grep -Fqx "n$SESSION_REAL
     exit 1
 fi
 
+HOME="$FIXTURE_HOME" TZ=UTC "$ROOT_DIR/collector/target/debug/agentsight" top --plain --count 1 -c codex --limit 20 >"$LIVE_OUT_FILE"
+cat "$LIVE_OUT_FILE"
+
+grep -q "AgentSight top" "$LIVE_OUT_FILE"
+grep -q "codex:macos-ci" "$LIVE_OUT_FILE"
+grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+live" "$LIVE_OUT_FILE"
+grep -q "session tokens: 15" "$LIVE_OUT_FILE"
+grep -q "gpt-macos-ci" "$LIVE_OUT_FILE"
+grep -q "$SESSION_LAST_MSG" "$LIVE_OUT_FILE"
+grep -q "macos top token check" "$LIVE_OUT_FILE"
+grep -q "matching session path" "$LIVE_OUT_FILE"
+
 HOME="$FIXTURE_HOME" TZ=UTC "$ROOT_DIR/collector/target/debug/agentsight" top --plain --once -c codex --limit 20 >"$OUT_FILE"
 cat "$OUT_FILE"
 
@@ -84,9 +97,9 @@ if grep -Eiq "eBPF|sudo|kernel probes|Linux-only" "$OUT_FILE"; then
     exit 1
 fi
 grep -q "codex:macos-ci" "$OUT_FILE"
-grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+live" "$OUT_FILE"
+grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+history" "$OUT_FILE"
 grep -q "session tokens: 15" "$OUT_FILE"
 grep -q "gpt-macos-ci" "$OUT_FILE"
 grep -q "$SESSION_LAST_MSG" "$OUT_FILE"
 grep -q "macos top token check" "$OUT_FILE"
-grep -q "matching session path" "$OUT_FILE"
+grep -q "agent-native once view; no process scan" "$OUT_FILE"


### PR DESCRIPTION
## Summary
- Route agentsight top --plain --once through an agent-native-only snapshot path.
- Avoid live process snapshots and fd scans for that one-shot plain output.
- Keep continuous top and TUI live views on the existing process-binding path.
- Split the macOS top smoke so live binding and one-shot agent-native behavior are both asserted.

## Validation
- cargo test
- cargo run --quiet -- top --plain --once
- bash -n script/ci/macos_top_smoke.sh
- git diff --check

## Code growth
- Final diffstat: 4 files changed, 59 insertions, 3 deletions.
- Production code: 44 insertions, 1 deletion.
- CI script: 15 insertions, 2 deletions to keep macOS live binding coverage while adding one-shot assertions.
- No fixtures added. Reduction pass removed a larger duplicated row-building implementation before commit.