### PR TITLE
Fix zero-token record summary counts

### DIFF
--- a/collector/src/cli_db.rs
+++ b/collector/src/cli_db.rs
@@ -220,6 +220,8 @@ impl SessionSummary {
         Ok(Self {
             source: s.source.clone(),
             duration_s: s.duration_s(),
+            api_calls: s.llm_calls,
+            total_tokens: s.total_tokens,
             first_llm_after_ms,
             first_tool_after_ms,
             prompt_chars,
@@ -415,6 +417,8 @@ mod tests {
 
         let summary = sqlite_summary(&db);
         assert_eq!(summary.duration_s, 0.9);
+        assert_eq!(summary.api_calls, 1);
+        assert_eq!(summary.total_tokens, 15);
         assert_eq!(summary.first_llm_after_ms, Some(200));
         assert_eq!(summary.first_tool_after_ms, Some(500));
         assert_eq!(summary.prompt_chars.count, 1);
@@ -433,6 +437,26 @@ mod tests {
                 .endpoints
                 .contains(&"api.anthropic.com/v1/messages(2)".to_string())
         );
+    }
+
+    #[test]
+    fn sqlite_summary_counts_llm_calls_without_token_usage() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = temp.path().join("summary-zero-token.db");
+        SqliteStore::open(&db)
+            .unwrap()
+            .connection()
+            .execute(
+                "INSERT INTO llm_calls (id, start_timestamp_ms, status)
+                 VALUES ('llm-zero-token', 1000, 'success')",
+                [],
+            )
+            .unwrap();
+
+        let summary = sqlite_summary(&db);
+        assert_eq!(summary.api_calls, 1);
+        assert_eq!(summary.total_tokens, 0);
+        assert!(summary.models.is_empty());
     }
 
     #[test]

--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -285,6 +285,8 @@ pub(crate) struct AgentTopOutput<'a> {
 pub(crate) struct SessionSummary {
     pub(crate) source: String,
     pub(crate) duration_s: f64,
+    pub(crate) api_calls: i64,
+    pub(crate) total_tokens: i64,
     pub(crate) first_llm_after_ms: Option<u64>,
     pub(crate) first_tool_after_ms: Option<u64>,
     pub(crate) prompt_chars: SummaryStats,
@@ -450,8 +452,6 @@ pub(crate) fn print_record_shutdown() {
 }
 
 pub(crate) fn print_record_session_summary(db_path: &str, summary: &SessionSummary) {
-    let api_calls: i64 = summary.models.iter().map(|m| m.4).sum();
-    let tokens: i64 = summary.models.iter().map(|m| m.3).sum();
     let execs: usize = summary.processes.values().sum();
     println!();
     println!(
@@ -461,8 +461,8 @@ pub(crate) fn print_record_session_summary(db_path: &str, summary: &SessionSumma
     );
     println!(
         "{} API calls · {} tokens · {} execs · {} files · {} network endpoints",
-        api_calls,
-        format_count(tokens),
+        summary.api_calls,
+        format_count(summary.total_tokens),
         execs,
         summary.files.len(),
         summary.endpoints.len()
@@ -657,8 +657,6 @@ pub(crate) fn print_agent_top(top: &AgentTopOutput<'_>) {
 }
 
 pub(crate) fn print_session_summary(summary: &SessionSummary) {
-    let total_tokens: i64 = summary.models.iter().map(|m| m.3).sum();
-    let total_calls: i64 = summary.models.iter().map(|m| m.4).sum();
     let has_tokens = summary
         .models
         .iter()
@@ -668,11 +666,11 @@ pub(crate) fn print_session_summary(summary: &SessionSummary) {
     if summary.duration_s > 0.0 {
         print!(" · {:.0}s", summary.duration_s);
     }
-    if total_calls > 0 {
-        print!(" · {total_calls} API calls");
+    if summary.api_calls > 0 {
+        print!(" · {} API calls", summary.api_calls);
     }
     if has_tokens {
-        print!(" · {total_tokens} tokens");
+        print!(" · {} tokens", summary.total_tokens);
     }
     println!("\n");
 


### PR DESCRIPTION
## Summary
- Count API calls in record/report summaries from the snapshot summary instead of token-summary rows
- Keep token/model details filtered to rows with token data
- Add a regression test for LLM calls that have no token_usage rows

## Repro
The latest-agent canary produced a mock curl DB where `top --db` showed `LLM: 1`, but `record`/`report summary` derived API calls from token rows and displayed `0 API calls` when no token usage was extracted.

## Validation
- `cargo fmt --manifest-path collector/Cargo.toml --check`
- `cargo test --manifest-path collector/Cargo.toml sqlite_summary -- --nocapture`
- `cargo build --manifest-path collector/Cargo.toml`
- `script/e2e/latest_agent_cli_canary.sh` with `AGENTSIGHT_AGENT_CANARY_BUILD=0` before the fix exposed the zero-token summary mismatch while still proving real Codex/Claude/OpenCode prompt capture
- Rechecked the same mock DB after the fix: `agentsight report summary --db .../mock-record.db` now prints `sqlite session · 1s · 1 API calls`

## Code growth
Final diffstat is 2 files, +31/-9. Production change adds two summary fields and removes duplicated derived counts at print sites; the rest is one compact regression test. No fixture or generated data growth.