### PR TITLE
Disable record default filters

### DIFF
--- a/collector/src/cmd_trace.rs
+++ b/collector/src/cmd_trace.rs
@@ -28,9 +28,6 @@ use crate::view::{MaterializedView, SharedMaterializedView, process_select};
 pub(crate) const DEFAULT_SERVER_LISTEN: &str = "127.0.0.1";
 pub(crate) const DEFAULT_RECORD_STDIO_MAX_BYTES: u32 = 65_536;
 
-const DEFAULT_SSL_FILTER: &str = "data=0\\r\\n\\r\\n";
-const DEFAULT_HTTP_FILTER: &str = "request.path_prefix=/v1/rgstr | response.status_code=202 | request.method=HEAD | response.body=";
-
 pub(crate) struct StartedWebServer {
     pub(crate) url: String,
     pub(crate) _handle: tokio::task::JoinHandle<()>,
@@ -89,13 +86,13 @@ impl TraceConfig {
     pub(crate) fn for_record() -> Self {
         Self {
             ssl: true,
-            ssl_filter: vec![DEFAULT_SSL_FILTER.to_string()],
+            ssl_filter: Vec::new(),
             ssl_http: true,
             process: true,
             stdio_max_bytes: DEFAULT_RECORD_STDIO_MAX_BYTES,
             system: true,
             system_interval: 2,
-            http_filter: vec![DEFAULT_HTTP_FILTER.to_string()],
+            http_filter: Vec::new(),
             quiet: true,
             ..Default::default()
         }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,9 +70,9 @@ sudo ./collector/target/release/agentsight debug ssl --http-parser
 
 Use `top` for the normal live view. Use `record` when you want a durable
 agent-run artifact; it starts SSL, process, system, and web-view collection with
-AgentSight's default filters, and saves a local SQLite session for `report`,
-`top --db`, `report prompts`, and other report queries.
+no default event filters, and saves a local SQLite session for `report`, `top
+--db`, `report prompts`, and other report queries.
 
 Use `debug trace` only when you need low-level control over capture sources or
-filters. It is the advanced replacement for a raw trace command, not the normal
-record/report workflow.
+explicit filters. It is the advanced replacement for a raw trace command, not
+the normal record/report workflow.

--- a/docs/usage.zh-CN.md
+++ b/docs/usage.zh-CN.md
@@ -90,7 +90,7 @@ sudo ./collector/target/release/agentsight debug ssl --http-parser
 
 - `record -- <command>` 用于启动并记录一个命令；`record -c/-p` 用于附加到已运行进程
 - **自动开启**：SSL 监控 + 进程监控 + 系统监控 + Web 服务器（端口 7395）
-- **内置过滤规则**：自动过滤掉注册请求（`/v1/rgstr`）、HEAD 请求、空响应体、202 状态码、二进制数据等噪音
+- **默认不丢弃事件**：如需过滤请求、响应或 SSL 片段，使用 `debug trace` 的显式过滤选项
 - 默认**静默模式**（不输出到底层事件流），数据写入实时 view 和本地 SQLite session
 
 典型用法：
@@ -125,7 +125,7 @@ sudo ./agentsight debug trace --ssl true --process false --server --http-filter 
 | Web 服务器 | 默认开启，可用 `--no-server` 关闭 | 需 `--server` |
 | 系统监控 | 默认开启 | 需 `--system` |
 | 控制台输出 | 默认关闭 | 默认开启 |
-| 过滤规则 | 内置预设 | 用户自定义 |
+| 过滤规则 | 默认不过滤 | 用户自定义 |
 | 持久化 | 默认 SQLite | 传 `--db` 时写 SQLite |
 
 简单来说：**实时查看用 `top`，保存复盘用 `record`，深度调试用 `debug trace`**。


### PR DESCRIPTION
## Summary
- Stop applying SSL/HTTP filters by default in `record`/record-derived trace config
- Remove the default filter constants so capture keeps request/response facts unless a user explicitly passes filters
- Update usage docs to say `record` defaults to no event filters and `debug trace` is the explicit-filter path

## Why
The default HTTP filter included `response.body=`, which was intended to drop empty responses but could drop useful response events in the capture pipeline. Defaults should preserve facts; filtering remains available when explicitly requested.

## Validation
- `cargo fmt --manifest-path collector/Cargo.toml --check`
- `cargo test --manifest-path collector/Cargo.toml --quiet`
- `AGENTSIGHT_AGENT_CANARY_BUILD=0 AGENTSIGHT_AGENT_CANARY_WORK_DIR=... script/e2e/latest_agent_cli_canary.sh`

Observed in the real-agent canary with defaults disabled: filter metrics reported no loaded filter metrics, prompt capture still passed for latest Codex/Claude/OpenCode, and completed LLM calls were retained for mock-record, Claude, and OpenCode DBs.

## Code growth
Final diffstat is 3 files, +8/-11. Production code is net-reducing: it deletes two default filter constants and replaces two default vectors with empty vectors. Docs are updated in place. No test boilerplate, fixtures, or generated data were added.
