### PR TITLE
Restore plain once top process binding

### DIFF
--- a/collector/src/cmd_perf_live.rs
+++ b/collector/src/cmd_perf_live.rs
@@ -12,7 +12,6 @@ pub(crate) fn run_live_top_query(
     limit: usize,
     count: Option<u32>,
     options: &TopOptions,
-    scan_processes: bool,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let limit = limit.clamp(1, 100);
     let interval = Duration::from_secs(interval_secs.max(1));
@@ -24,7 +23,7 @@ pub(crate) fn run_live_top_query(
         if should_clear_screen {
             clear_screen();
         }
-        let mut top = live_view.refresh(limit, options, scan_processes)?;
+        let mut top = live_view.refresh(limit, options)?;
         sort_agent_rows(&mut top.rows, &options.sort);
         top.rows.truncate(limit);
         print_agent_top(&top);

--- a/collector/src/cmd_perf_tui.rs
+++ b/collector/src/cmd_perf_tui.rs
@@ -35,7 +35,7 @@ pub(crate) fn run_live_top_tui(
         true,
         |display_limit, options| {
             live_view
-                .refresh(display_limit, options, true)
+                .refresh(display_limit, options)
                 .map_err(Into::into)
         },
     )

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -660,7 +660,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             } else if let Some(db) = db {
                 run_top_query(db, *interval, *limit, count, &options)?;
             } else {
-                run_live_top_query(*interval, *limit, count, &options, !(*plain && *once))?;
+                run_live_top_query(*interval, *limit, count, &options)?;
             }
         }
         // All remaining commands need the binary extractor.

--- a/collector/src/view/live_top.rs
+++ b/collector/src/view/live_top.rs
@@ -59,35 +59,17 @@ impl LiveView {
         &mut self,
         limit: usize,
         options: &TopOptions,
-        scan_processes: bool,
     ) -> io::Result<AgentTopOutput<'static>> {
-        let sample = if scan_processes {
-            LiveSample::collect()?
-        } else {
-            LiveSample::default()
-        };
+        let sample = LiveSample::collect()?;
         let session_snapshot = agent_native_sessions::snapshot(
             &mut self.session_cache,
-            scan_processes.then_some(options.pid).flatten(),
+            options.pid,
             options.comm.as_deref(),
             limit,
             Duration::from_secs(2),
         );
-        let mut top = self.build_top(&sample, &session_snapshot, options);
-        if scan_processes {
-            self.previous = Some(sample);
-        } else {
-            top.mode = "agent-native sessions";
-            top.notes
-                .insert(0, "agent-native once view; no process scan".to_string());
-            if options.pid.is_some() {
-                top.notes.insert(
-                    1,
-                    "pid filters need live process binding; remove -p or run continuous top/TUI"
-                        .to_string(),
-                );
-            }
-        }
+        let top = self.build_top(&sample, &session_snapshot, options);
+        self.previous = Some(sample);
         Ok(top)
     }
 

--- a/script/ci/macos_top_smoke.sh
+++ b/script/ci/macos_top_smoke.sh
@@ -97,9 +97,9 @@ if grep -Eiq "eBPF|sudo|kernel probes|Linux-only" "$OUT_FILE"; then
     exit 1
 fi
 grep -q "codex:macos-ci" "$OUT_FILE"
-grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+history" "$OUT_FILE"
+grep -Eq "codex:macos-ci[[:space:]]+codex[[:space:]]+live" "$OUT_FILE"
 grep -q "session tokens: 15" "$OUT_FILE"
 grep -q "gpt-macos-ci" "$OUT_FILE"
 grep -q "$SESSION_LAST_MSG" "$OUT_FILE"
 grep -q "macos top token check" "$OUT_FILE"
-grep -q "agent-native once view; no process scan" "$OUT_FILE"
+grep -q "matching session path" "$OUT_FILE"


### PR DESCRIPTION
## Summary
- Restore `top --plain --once` to the normal lightweight process snapshot/session-binding path
- Remove the erroneous `scan_processes` switch and the agent-native-only once mode
- Keep `top` free of backend monitor/eBPF startup while preserving `/proc` CPU/RSS/fd evidence
- Update macOS smoke so one-shot plain top must still show a live-bound Codex session

## Scope boundary
This change may touch plain top dispatch and its smoke assertion; it must not add a new user mode, reintroduce backend monitor/eBPF capture, or change saved-DB top behavior.

## Why
PR #118 incorrectly interpreted “do not use backend/monitor” as “do not collect process snapshots”. Process snapshots and fd-path session matching are not the backend monitor; they are the core top session/process binding path.

## Validation
- `git diff --check -- collector/src/cmd_perf_live.rs collector/src/cmd_perf_tui.rs collector/src/main.rs collector/src/view/live_top.rs script/ci/macos_top_smoke.sh`
- `cargo fmt --manifest-path collector/Cargo.toml --check`
- `bash -n script/ci/macos_top_smoke.sh`
- `cargo test --manifest-path collector/Cargo.toml live_view -- --nocapture`
- `cargo build --manifest-path collector/Cargo.toml --quiet && ./collector/target/debug/agentsight top --plain --once -c codex --limit 20`

Local smoke shows `top --plain --once` is back to `live sessions` with `logs+/proc` evidence and process CPU/RSS data, with no eBPF/sudo/backend note.

## Code growth
Final diffstat before PR: 5 files, +9/-28, net -19. This deletes the avoidable switch instead of adding another compatibility flag.
