### PR TITLE
docs: keep flamegraph wording image-grounded

### DIFF
--- a/docs/agentpprof-zh.md
+++ b/docs/agentpprof-zh.md
@@ -46,7 +46,7 @@ Flamegraph 的价值不只是聚合，还在于**用堆栈表达因果关联**�
 
 ![语义 flamegraph](flamegraph-example/semantic-flamegraph-top200.svg)
 
-图中合并了 top 200 stack 的共享前缀。宽度表示 system-effect weight；不同 frame 处结束的栈形成参差的轮廓。
+图中选取权重最高的 200 条路径。几条路径如果开头几层相同，就共用同一个矩形；矩形越宽，system-effect weight 越大。路径结束的深度不同，所以轮廓参差不齐。
 
 ### Tokens 视图
 

--- a/docs/agentpprof-zh.md
+++ b/docs/agentpprof-zh.md
@@ -42,13 +42,11 @@ Flamegraph 的价值不只是聚合，还在于**用堆栈表达因果关联**�
 
 ## Flamegraph 示例
 
-以下图片展示了每个视图呈现的内容。
-
 ### 语义栈总览
 
 ![语义 flamegraph](flamegraph-example/semantic-flamegraph-top200.svg)
 
-图中合并了 top 200 stack 的共享前缀。宽度表示 system-effect weight；不同 frame 处结束的栈形成参差的上沿。
+图中合并了 top 200 stack 的共享前缀。宽度表示 system-effect weight；不同 frame 处结束的栈形成参差的轮廓。
 
 ### Tokens 视图
 
@@ -96,7 +94,7 @@ Wall-clock 时间分布与 token 消耗相似：review（`prompt:review`）领�
 
 ### Rendering
 
-这些 SVG 合并共享栈前缀，并按图头显示的度量确定 frame 宽度。栈深度决定纵向行，因此在不同 frame 处结束的路径会形成参差的上沿。
+这些 SVG 合并共享栈前缀，并按图头显示的度量确定 frame 宽度。栈深度决定纵向行，因此在不同 frame 处结束的路径会形成参差的轮廓。
 
 ## 工作原理
 

--- a/docs/agentpprof.md
+++ b/docs/agentpprof.md
@@ -92,9 +92,9 @@ time went, and use `files` and `network` for security audits.
 
 ![Semantic flamegraph](flamegraph-example/semantic-flamegraph-top200.svg)
 
-The figure shows collapsed prefixes from the top 200 stacks. Width is
-system-effect weight; stacks ending at different frames produce an uneven
-outline.
+The figure shows the 200 highest-weight paths. Paths with the same opening
+frames share a rectangle; wider rectangles have greater system-effect weight.
+Paths end at different depths, producing an uneven outline.
 
 ### Tokens View
 

--- a/docs/agentpprof.md
+++ b/docs/agentpprof.md
@@ -88,15 +88,13 @@ time went, and use `files` and `network` for security audits.
 
 ## Example Flamegraphs
 
-The figures below demonstrate what each view shows.
-
 ### Semantic Stack Overview
 
 ![Semantic flamegraph](flamegraph-example/semantic-flamegraph-top200.svg)
 
 The figure shows collapsed prefixes from the top 200 stacks. Width is
-system-effect weight; stacks ending at different frames produce the ragged
-upper edge.
+system-effect weight; stacks ending at different frames produce an uneven
+outline.
 
 ### Tokens View
 
@@ -148,7 +146,7 @@ Network activity is sparse relative to file operations, confirming that most dev
 
 The SVGs merge shared stack prefixes and size each frame by the metric shown in
 the figure header. Stack depth sets the vertical row, so paths ending at
-different frames form an uneven top edge.
+different frames form an uneven outline.
 
 ## Tagging
 


### PR DESCRIPTION
## User request (verbatim)

> 你把这几个图都提一个 PR 到主线, 在 doc 的文档里面引用它们; 最好看的是 research worktree 里的 R221 版本放在 README 里面 *Live sessions ranked by model, session tokens, health, process family, tool calls, file activity, and network activity 这个下面, 只把图和文字解释(以及链接到 doc 里面的md链接, 放在文字解释里面) 放到 readme*

> [eunomia-bpf/agentsight](https://github.com/eunomia-bpf/agentsight) 我不是让你把 有。最好看的是 research worktree 里的 R221 版本放进主要的 READNE 的吗

> [agentpprof.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/agentpprof.md) 你不是应该改 这个和他的中文版本而不是增加新的文档?

> 创建一个新的 worktree

> docs 你有没有创建新的文件夹

> 文字内容放进现有的 docs/agentpprof.md 和 docs/agentpprof-zh.md 为啥文本改这么多?

> 修啊

> reviewer 要和用户原有表达对齐 review, 不是你的表达, 我们的 skills 说清楚这个了吗

> 先 rebase 到现在的 main

> 直接开一个新的 branch 和 PR

> 文档里面不能有任何图上看不出来的内部工程/research信息和标识符

> 我的原话应该记录在 github PR 里面

> 就是 PR message

> 合并了 top 200 stack 的共享前缀 啥意思

## Why this follow-up exists

PR #125 was merged while its final review fixes were still being prepared. This PR contains the resulting wording corrections on top of the merged result.

## Changes

- use direction-neutral “uneven outline / 参差的轮廓” for the semantic figure and shared rendering explanation
- remove two replacement intro sentences that added no image-grounded information
- explain the visible top-200 prefix collapsing in plain language instead of profiler jargon

## Scope and validation

- two existing Markdown files only: `+6/-10`
- `git diff --check origin/master...HEAD`
- no code, asset, folder, or unrelated prose changes