### PR TITLE
Use absolute raw URL for the semantic flamegraph image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ agentsight top
 </div>
 
 <div align="center">
-  <img src="docs/flamegraph-example/semantic-flamegraph-top200.svg" alt="Semantic flamegraph of the top 200 agent stacks" width="1000">
+  <img src="https://github.com/eunomia-bpf/agentsight/raw/master/docs/flamegraph-example/semantic-flamegraph-top200.svg" alt="Semantic flamegraph of the top 200 agent stacks" width="1000">
   <p><em>Width is system-effect weight; the uneven stack height shows prompt, tool-call, process, and effect paths ending at different depths. See the <a href="docs/agentpprof.md#example-flamegraphs">agentpprof guide</a> for the other profiles and how widths and stack depths are drawn.</em></p>
 </div>
 


### PR DESCRIPTION
The `<img src="docs/flamegraph-example/semantic-flamegraph-top200.svg">` reference is relative to the repo root, so it renders on GitHub but breaks when this README is synced to https://eunomia.dev/agentsight/ (resolves to a nonexistent `/agentsight/docs/` path and fails the site's link audit, which currently blocks the site's deploy CI). The sibling `top-mode-demo.png` image already uses the absolute `raw/master` URL form; this matches it.

Note: the `<a href="docs/agentpprof.md#example-flamegraphs">` link in the same block has the same repo-root-relative issue on the synced site (renders fine on GitHub, 404s on eunomia.dev). Not changed here since the site audit does not flag anchors; can follow up if you want it site-safe too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuA7NpqV4a9GBucCT59mUS