### PR TITLE
sslsniff: stop reserving 512KB per ring-buffer event (silently drops events past the 3rd)

### DIFF
--- a/bpf/sslsniff.h
+++ b/bpf/sslsniff.h
@@ -6,8 +6,18 @@
 #ifndef __SSLSNIFF_H
 #define __SSLSNIFF_H
 
-#define MAX_BUF_SIZE (512 * 1024)  // 512KB eBPF buffer size (kernel limit)
-#define RING_BUFFER_SIZE (2 * 1024 * 1024)  // 2MB ring buffer
+// A TLS record is at most 16KB, so 32KB is ample for one SSL_read/SSL_write.
+// This value is load-bearing: the probes call
+//     bpf_ringbuf_reserve(&rb, sizeof(*data), 0)
+// and struct probe_SSL_data_t embeds buf[MAX_BUF_SIZE], so EVERY event reserves
+// the worst case regardless of payload. At 512KB per event a 2MB ring held only
+// 3 concurrent events; the 4th reserve returned NULL and the handler dropped the
+// event silently (no truncated flag, since the event is never created). Responses
+// whose HTTP headers alone filled those slots lost their body with no signal.
+// 32KB against a 16MB ring gives 511 concurrent events; oversized reads now take
+// the existing truncation path instead of vanishing.
+#define MAX_BUF_SIZE (32 * 1024)
+#define RING_BUFFER_SIZE (16 * 1024 * 1024)  // 16MB ring buffer
 #define TASK_COMM_LEN 16
 
 struct probe_SSL_data_t {


### PR DESCRIPTION
Fixes #132.

## Summary

`sslsniff` reserves `sizeof(struct probe_SSL_data_t)` — which embeds a fixed `buf[MAX_BUF_SIZE]` of **512 KB** — from the ring buffer on **every** event, regardless of how many bytes were actually read. With `RING_BUFFER_SIZE` at 2 MB, only **3 events** fit at once. The 4th `bpf_ringbuf_reserve()` returns `NULL` and the handler drops the event **silently**, with no `truncated` flag, because the event is never created.

The practical effect: any HTTPS response whose **headers alone** occupy the first few slots loses its **body** entirely, and the consumer has no indication that anything was lost.

## Root cause

`bpf/sslsniff.bpf.c` (all three probe paths do this):

```c
struct probe_SSL_data_t *data = bpf_ringbuf_reserve(&rb, sizeof(*data), 0);
if (!data)
    return 0;          /* <-- silent drop, no counter, no flag */
```

`bpf/sslsniff.h`:

```c
#define MAX_BUF_SIZE     (512 * 1024)        /* struct is 524352 B = 512.1 KB */
#define RING_BUFFER_SIZE (2 * 1024 * 1024)   /* 2 MB */
```

```
2097152 / 524352 = 3.99  ->  at most 3 concurrent events
```

`sizeof(*data)` is a compile-time constant, so a 1370-byte `SSL_read` still reserves 512.1 KB.

## Reproduction

Fetch a URL whose response headers are large. `patch-diff.githubusercontent.com` is a convenient case — GitHub returns a multi-kilobyte `Content-Security-Policy` header there:

```bash
sslsniff -u <uid> > cap.jsonl &
sleep 3
curl -sSL --http1.1 -H 'Accept-Encoding: identity' \
  'https://patch-diff.githubusercontent.com/raw/psf/requests/pull/2317.diff' > /dev/null
sleep 2; kill %1
```

Observed with the current code: **3 read events, 4110 bytes captured, all of it response headers**. The 1301-byte response body never appears. Every event reports `"truncated": false`.

## Fix

Two constants in `bpf/sslsniff.h`:

```c
#define MAX_BUF_SIZE     (32 * 1024)         /* a TLS record is <= 16 KB */
#define RING_BUFFER_SIZE (16 * 1024 * 1024)
```

Concurrent event capacity goes from **3 to 511**. Reads larger than 32 KB now take the existing truncation path (`truncated: true`, `bytes_lost`) instead of vanishing.

A more thorough fix would avoid reserving the worst case at all — e.g. copy into a per-CPU scratch map and emit with `bpf_ringbuf_output()` sized to the actual payload, so event cost tracks real data volume. The two-constant change is the minimal, low-risk version.

## Verification

Same URL, 2x2, two runs per cell:

| build | rate | read events | bytes captured | body complete |
|---|---|---|---|---|
| current (512 KB / 2 MB) | `--limit-rate 20K` | 3 | 4110 | no |
| current (512 KB / 2 MB) | full speed | 3 | 4110 | no |
| patched (32 KB / 16 MB) | `--limit-rate 20K` | 5 | 5913 | **yes** |
| patched (32 KB / 16 MB) | full speed | 5–6 | 5913 | **yes** |

`bpftool map show` confirms the `rb` map going from `max_entries 2097152` to `16777216`.

Note that the current build fails at **both** rates: throttling only spaces out *body* reads and cannot help when the *headers* alone exhaust the slot budget. We had previously been throttling captured downloads to 20 KB/s as a workaround; with the fix that is unnecessary.

## Why this matters

Any downstream analysis that searches captured plaintext for a string will silently produce false negatives whenever this triggers — the data is simply absent and nothing reports it. We hit exactly this: a content check over `SSL_read` plaintext reported "not found" on 4 runs where the content had in fact crossed the wire. After the fix those runs are detected correctly.

## Build note

On hosts where `/usr/local/bin/clang` is a patched LLVM branch, `sslsniff.bpf.c` may crash the compiler in the `always-inline` pass (`Assertion 'I->second && I->first == I->second->getValPtr()' failed`). Unrelated to this change — building with the distro clang works:

```bash
make CLANG=/usr/bin/clang-19 sslsniff -j8
```

This PR applies the two-constant fix described above. A more thorough follow-up would avoid reserving the worst case at all (copy into a per-CPU scratch map and emit with `bpf_ringbuf_output()` sized to the actual payload), which I'm happy to do as a separate change if you prefer that direction.
