### PR TITLE
Fix npm 1.0.0 publish lockfile normalization

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -35,6 +35,7 @@ jobs:
 
       - name: Build frontend
         run: |
+          npm install --package-lock-only --ignore-scripts --prefix frontend
           npm ci --prefix frontend
           node frontend/scripts/prepare-sample.mjs
           npm run build --prefix frontend


### PR DESCRIPTION
## Problem

The AgentSight `v1.0.0` GitHub Release and Rust crates published successfully, but npm workflow run `31063492962` failed before packaging. npm 11 rejected `frontend/package-lock.json` because platform-specific optional dependency metadata was incomplete.

## Fix

Before the strict `npm ci` step, run npm 11 in `--package-lock-only --ignore-scripts` mode to normalize the checked-out lockfile metadata in the ephemeral runner workspace. Then run the existing clean install and frontend build.

This keeps:

- npm trusted publishing on Node 24 / npm 11;
- `npm ci` as the actual dependency installation;
- the committed source tree and immutable `v1.0.0` tag unchanged;
- package version synchronization from `collector/Cargo.toml` unchanged.

## Scope

One workflow file, one added command. No product code, crate version, release tag, credential, permission, or registry configuration change.

## Delivery

After ordinary PR CI succeeds, squash merge and manually dispatch `npm-publish.yml` from the fixed `master`. Verify `@eunomia-bpf/agentsight@1.0.0` publication and the workflow result.