### PR TITLE
fix: rehash PID tracker probe cluster on remove

### DIFF
--- a/bpf/process_filter.h
+++ b/bpf/process_filter.h
@@ -98,12 +98,42 @@ static inline bool pid_tracker_add(struct pid_tracker *tracker, pid_t pid, pid_t
 	return false;  /* Table full */
 }
 
-/* Remove a PID from the tracker */
+/* Remove a PID from the tracker.
+ * Clearing a slot in place breaks linear-probing find (it stops at the
+ * first inactive slot).  Rehash the rest of the cluster after delete.
+ * The walk is bounded so a full-table wrap cannot loop forever.
+ */
 static inline void pid_tracker_remove(struct pid_tracker *tracker, pid_t pid)
 {
-	struct tracked_pid_entry *entry = pid_tracker_find(tracker, pid);
-	if (entry) {
+	unsigned int hash = pid_hash(pid);
+	unsigned int i;
+
+	for (i = 0; i < TRACKED_PIDS_HASH_SIZE; i++) {
+		unsigned int idx = (hash + i) & TRACKED_PIDS_HASH_MASK;
+		struct tracked_pid_entry *entry = &tracker->entries[idx];
+
+		if (!entry->is_active)
+			return;
+
+		if (entry->pid != pid)
+			continue;
+
 		entry->is_active = false;
+
+		for (unsigned int n = 1; n < TRACKED_PIDS_HASH_SIZE; n++) {
+			unsigned int j = (idx + n) & TRACKED_PIDS_HASH_MASK;
+			if (!tracker->entries[j].is_active)
+				break;
+			struct tracked_pid_entry moved = tracker->entries[j];
+			tracker->entries[j].is_active = false;
+			/* is_tracked is always true for active entries today
+			 * (set only in pid_tracker_add); keep the guard so a
+			 * non-tracked occupancy is not promoted by re-insert.
+			 */
+			if (moved.is_tracked)
+				pid_tracker_add(tracker, moved.pid, moved.ppid);
+		}
+		return;
 	}
 }
 

--- a/bpf/test_process_filter.c
+++ b/bpf/test_process_filter.c
@@ -139,6 +139,25 @@ void test_pid_tracker_remove() {
     // Test removing non-existent PID (should not crash)
     pid_tracker_remove(&tracker, 9999);
     test_assert(true, "removing non-existent PID should not crash");
+
+    // Regression: open-addressing delete must rehash the probe cluster.
+    // PIDs that differ by a multiple of TRACKED_PIDS_HASH_SIZE collide.
+    // Removing the head must leave later collisions findable.
+    pid_t base = 1000;
+    pid_t collision1 = base + TRACKED_PIDS_HASH_SIZE;      /* 1000+4096 */
+    pid_t collision2 = base + (2 * TRACKED_PIDS_HASH_SIZE); /* 1000+8192 */
+    pid_tracker_add(&tracker, base, 1);
+    pid_tracker_add(&tracker, collision1, base);
+    pid_tracker_add(&tracker, collision2, base);
+
+    pid_tracker_remove(&tracker, base);
+
+    test_assert(pid_tracker_find(&tracker, base) == NULL,
+                "removed collision head should be absent");
+    test_assert(pid_tracker_find(&tracker, collision1) != NULL,
+                "collision entry after removed head should remain findable");
+    test_assert(pid_tracker_find(&tracker, collision2) != NULL,
+                "second collision entry after removed head should remain findable");
 }
 
 void test_pid_tracker_is_tracked() {


### PR DESCRIPTION
## Summary

`pid_tracker_remove()` in `bpf/process_filter.h` used the classic broken open-addressing delete: it cleared the slot in place. `pid_tracker_find()` stops at the first inactive slot, so every entry that probed past the removed slot became unreachable. This is a silent data-loss bug in the shipped **1.0.0** release.

### Failure mode

- The PID tracker is a fixed-size open-addressing table with linear probing (`pid_hash(pid) = pid & 4095`).
- When a tracked process exits, `pid_tracker_remove` ran. If other tracked PIDs had collided into the same probe cluster (any two PIDs differing by a multiple of 4096), those later entries became unfindable.
- Common case: a parent exits before its children; siblings/descendants in the same cluster silently stop being tracked. Subsequent execs, file ops, and network summaries vanish from `agentsight record` with no error.

### Reproduction

Insert `base=1000`, `c1=1000+4096`, `c2=1000+8192` (all hash to bucket 1000), then remove `base`:

- Before removal: all three findable
- After buggy removal: `find(c1)` and `find(c2)` both return NULL

### Fix

Port the cluster-rehash approach from the research branch (only `pid_tracker_remove`; no lineage-tracking feature). After clearing the target slot, walk the rest of the probe cluster with a bounded loop and re-insert each subsequent active entry via `pid_tracker_add`.

The `if (moved.is_tracked)` guard is kept: on master, `is_tracked` is only assigned in `pid_tracker_add` (always `true`), so the guard is a no-op today, but it avoids promoting a non-tracked occupancy if that ever becomes possible.

Out of scope (intentionally not fixed here):

- Untracked PIDs not flushing aggregation state on exit (`bpf/process.c` around the exit path)
- `should_track_pid_lineage` and related research-branch process changes

## Validation

```bash
cd bpf && make test
```

All unit and runtime tests passed (exit 0), including the new collision regression in `test_process_filter`.

Regression demonstration (stash header fix only):

- Old remove: `collision entry after removed head should remain findable` **FAIL**
- Fixed remove: all `pid_tracker_remove` assertions **PASS**

Standalone scratch build against master vs fixed header also showed FAIL then PASS for the same three-PID collision case.

## Test plan

- [x] `cd bpf && make test` (unit + process/stdiocap runtime)
- [x] Regression fails against old `pid_tracker_remove`, passes with the fix
- [ ] Review CI on this PR