### PR TITLE
[publish npm] Add guarded npm publish retry trigger

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,8 @@ on:
   release:
     types: [published]
   push:
+    branches:
+      - "master"
     tags:
       - "v*"
 
@@ -15,6 +17,7 @@ permissions:
 jobs:
   publish:
     name: Publish @eunomia-bpf/agentsight
+    if: github.event_name != 'push' || startsWith(github.ref, 'refs/tags/') || contains(github.event.head_commit.message, '[publish npm]')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Problem

AgentSight `v1.0.0` is already immutable and the GitHub connector available to the release operator cannot invoke `workflow_dispatch`. Creating or moving a release tag just to retry npm publication would be misleading.

## Change

Allow the existing npm workflow to observe pushes to `master`, but run its publish job only when the push commit message contains `[publish npm]`.

Existing triggers remain unchanged in behavior:

- manual `workflow_dispatch` always runs;
- published release events always run;
- `v*` tag pushes always run;
- ordinary master pushes produce a skipped npm job;
- an explicit `[publish npm]` master commit provides an auditable, idempotent retry path.

The workflow already checks npm before publishing, so an existing package version is skipped rather than republished.

## Scope

One workflow file. No package version, source code, tag, release, permissions, credentials, or registry settings change.

## Delivery

After exact-head CI succeeds, squash merge with a commit title containing `[publish npm]`. The merge push should trigger this fixed workflow from `master`; verify workflow success and `@eunomia-bpf/agentsight@1.0.0` in the npm registry.