### PR TITLE
ci: publish native ARM64 release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
   docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    needs: test
+    needs: release_binaries
     # Only run on push to master, not on PRs
     if: |
       github.event_name == 'push' &&
@@ -142,36 +142,23 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+    - name: Download architecture-specific binaries
+      uses: actions/download-artifact@v4
       with:
-        submodules: 'recursive'
+        pattern: docker-linux-*
+        path: docker-bin
 
-    - name: Setup Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v3
-      with:
-        node-version: '18'
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
-          libelf1 libelf-dev zlib1g-dev libclang-dev \
-          make git clang llvm pkg-config build-essential
-
-    - name: Build package
-      run: make build
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Login to Github Packages
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -179,11 +166,11 @@ jobs:
 
     - name: Build image and push to GitHub Container Registry
       id: docker_build
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: ./
-        file: dockerfile
-        platforms: linux/amd64
+        file: script/Dockerfile.release
+        platforms: linux/amd64,linux/arm64
         tags: |
           ghcr.io/${{ github.repository }}:latest
           ghcr.io/${{ github.repository }}:${{ github.sha }}
@@ -192,20 +179,20 @@ jobs:
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}
 
-  publish:
-    name: Create GitHub Release and Cargo Package
+  release_prepare:
+    name: Prepare Release and Publish Cargo Packages
     runs-on: ubuntu-latest
     needs: test
+    outputs:
+      version: ${{ steps.set_version.outputs.version }}
+      tag: ${{ steps.set_version.outputs.tag }}
+      publish_sha: ${{ steps.commit_release.outputs.publish_sha }}
     # Only run on push to master, not on PRs
     if: |
       github.event_name == 'push' &&
       github.ref == 'refs/heads/master' &&
       !contains(github.event.head_commit.message, '[skip ci]') &&
       !contains(github.event.head_commit.message, '[ci skip]')
-
-    strategy:
-      matrix:
-        target: [ x86_64-unknown-linux-gnu ]
 
     steps:
     - name: Checkout code
@@ -515,66 +502,6 @@ jobs:
         CARGO_TARGET_DIR=/tmp/agentsight-agentpprof-package \
           cargo package --manifest-path agentpprof/Cargo.toml
 
-    - name: Publish Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: |
-          collector/target/release/agentsight
-          agentpprof/target/release/agentpprof
-        prerelease: false
-        tag_name: ${{ steps.set_version.outputs.tag }}
-        target_commitish: ${{ steps.commit_release.outputs.publish_sha }}
-        generate_release_notes: true
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Smoke test published release artifact
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TAG: ${{ steps.set_version.outputs.tag }}
-      run: |
-        set -euo pipefail
-
-        smoke_dir="$(mktemp -d)"
-        gh release download "$RELEASE_TAG" \
-          --repo "$GITHUB_REPOSITORY" \
-          --pattern agentsight \
-          --dir "$smoke_dir" \
-          --clobber
-        gh release download "$RELEASE_TAG" \
-          --repo "$GITHUB_REPOSITORY" \
-          --pattern agentpprof \
-          --dir "$smoke_dir" \
-          --clobber
-
-        chmod +x "$smoke_dir/agentsight"
-        "$smoke_dir/agentsight" --version
-        "$smoke_dir/agentsight" --help | tee "$smoke_dir/help.txt"
-
-        for cmd in top monitor record report debug; do
-          if ! grep -Eq "^[[:space:]]+$cmd[[:space:]]" "$smoke_dir/help.txt"; then
-            echo "::error::release artifact is missing '$cmd' in agentsight --help"
-            exit 1
-          fi
-        done
-
-        chmod +x "$smoke_dir/agentpprof"
-        "$smoke_dir/agentpprof" --version
-        "$smoke_dir/agentpprof" --help | tee "$smoke_dir/agentpprof-help.txt"
-
-        for flag in "--output" "--view" "--tagger" "--session-file"; do
-          if ! grep -Fq -- "$flag" "$smoke_dir/agentpprof-help.txt"; then
-            echo "::error::release artifact is missing '$flag' in agentpprof --help"
-            exit 1
-          fi
-        done
-
-    - name: Dispatch npm package publish
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        RELEASE_TAG: ${{ steps.set_version.outputs.tag }}
-      run: gh workflow run npm-publish.yml --ref "$RELEASE_TAG"
-
     - name: Publish agentsight crate to crates.io
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -665,3 +592,197 @@ jobs:
             exit 1
           fi
         done
+
+  arm64_build:
+    name: Build ARM64 Release Candidate
+    runs-on: ubuntu-24.04-arm
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: 'recursive'
+
+    - name: Setup Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libelf1 libelf-dev zlib1g-dev libclang-dev \
+          make git clang llvm pkg-config build-essential
+
+    - name: Build release binaries
+      run: |
+        make build
+        cargo build --release --manifest-path agentpprof/Cargo.toml
+
+    - name: Smoke test ARM64 binaries
+      run: |
+        set -euo pipefail
+        file collector/target/release/agentsight | grep -F "ARM aarch64"
+        file agentpprof/target/release/agentpprof | grep -F "ARM aarch64"
+        collector/target/release/agentsight --version
+        agentpprof/target/release/agentpprof --version
+
+  release_binaries:
+    name: Build Release Binaries (${{ matrix.arch }})
+    needs: release_prepare
+    runs-on: ${{ matrix.runner }}
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, '[ci skip]')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - arch: x86_64
+          docker_arch: amd64
+          runner: ubuntu-24.04
+          legacy_assets: true
+        - arch: aarch64
+          docker_arch: arm64
+          runner: ubuntu-24.04-arm
+          legacy_assets: false
+
+    steps:
+    - name: Checkout release snapshot
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.release_prepare.outputs.publish_sha }}
+        submodules: 'recursive'
+
+    - name: Setup Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libelf1 libelf-dev zlib1g-dev libclang-dev \
+          make git clang llvm pkg-config build-essential
+
+    - name: Build release binaries
+      run: |
+        make build
+        cargo build --release --manifest-path agentpprof/Cargo.toml
+
+    - name: Smoke test release binaries
+      run: |
+        set -euo pipefail
+        collector/target/release/agentsight --version
+        collector/target/release/agentsight --help | grep -Eq '^[[:space:]]+record[[:space:]]'
+        agentpprof/target/release/agentpprof --version
+        agentpprof/target/release/agentpprof --help | grep -F -- '--session-file'
+
+    - name: Prepare architecture-qualified assets
+      run: |
+        set -euo pipefail
+        mkdir -p release-assets docker-assets
+        install -m 0755 collector/target/release/agentsight \
+          "release-assets/agentsight-${{ matrix.arch }}"
+        install -m 0755 agentpprof/target/release/agentpprof \
+          "release-assets/agentpprof-${{ matrix.arch }}"
+        install -m 0755 collector/target/release/agentsight docker-assets/agentsight
+
+        if [ "${{ matrix.legacy_assets }}" = "true" ]; then
+          cp release-assets/agentsight-x86_64 release-assets/agentsight
+          cp release-assets/agentpprof-x86_64 release-assets/agentpprof
+        fi
+
+    - name: Upload release assets
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-linux-${{ matrix.arch }}
+        path: release-assets/
+        if-no-files-found: error
+        retention-days: 1
+
+    - name: Upload Docker binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: docker-linux-${{ matrix.docker_arch }}
+        path: docker-assets/agentsight
+        if-no-files-found: error
+        retention-days: 1
+
+  release:
+    name: Assemble GitHub Release
+    needs: [release_prepare, release_binaries]
+    runs-on: ubuntu-24.04
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, '[ci skip]')
+
+    steps:
+    - name: Download release assets
+      uses: actions/download-artifact@v4
+      with:
+        pattern: release-linux-*
+        path: release-assets
+        merge-multiple: true
+
+    - name: Verify release asset architectures
+      run: |
+        set -euo pipefail
+        file release-assets/agentsight-x86_64 | grep -F "x86-64"
+        file release-assets/agentsight-aarch64 | grep -F "ARM aarch64"
+        cmp release-assets/agentsight release-assets/agentsight-x86_64
+        cmp release-assets/agentpprof release-assets/agentpprof-x86_64
+
+    - name: Publish GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        files: release-assets/*
+        prerelease: false
+        tag_name: ${{ needs.release_prepare.outputs.tag }}
+        target_commitish: ${{ needs.release_prepare.outputs.publish_sha }}
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Smoke test published x86_64 artifacts
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TAG: ${{ needs.release_prepare.outputs.tag }}
+      run: |
+        set -euo pipefail
+        smoke_dir="$(mktemp -d)"
+        gh release download "$RELEASE_TAG" \
+          --repo "$GITHUB_REPOSITORY" \
+          --pattern agentsight \
+          --pattern agentpprof \
+          --dir "$smoke_dir"
+
+        chmod +x "$smoke_dir/agentsight" "$smoke_dir/agentpprof"
+        "$smoke_dir/agentsight" --version
+        "$smoke_dir/agentsight" --help | tee "$smoke_dir/help.txt"
+        grep -Eq '^[[:space:]]+record[[:space:]]' "$smoke_dir/help.txt"
+        "$smoke_dir/agentpprof" --version
+        "$smoke_dir/agentpprof" --help | grep -F -- '--session-file'
+
+    - name: Dispatch npm package publish
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        RELEASE_TAG: ${{ needs.release_prepare.outputs.tag }}
+      run: gh workflow run npm-publish.yml --ref "$RELEASE_TAG"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
   docker:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
-    needs: release_binaries
+    needs: [release_binaries, publish_crates]
     # Only run on push to master, not on PRs
     if: |
       github.event_name == 'push' &&
@@ -180,13 +180,17 @@ jobs:
       run: echo ${{ steps.docker_build.outputs.digest }}
 
   release_prepare:
-    name: Prepare Release and Publish Cargo Packages
+    name: Prepare Release Snapshot
     runs-on: ubuntu-latest
     needs: test
     outputs:
       version: ${{ steps.set_version.outputs.version }}
       tag: ${{ steps.set_version.outputs.tag }}
       publish_sha: ${{ steps.commit_release.outputs.publish_sha }}
+      agent_session_version: ${{ steps.set_version.outputs.agent_session_version }}
+      agentsight_capture_version: ${{ steps.set_version.outputs.agentsight_capture_version }}
+      agentvis_version: ${{ steps.set_version.outputs.agentvis_version }}
+      agentpprof_version: ${{ steps.set_version.outputs.agentpprof_version }}
     # Only run on push to master, not on PRs
     if: |
       github.event_name == 'push' &&
@@ -389,6 +393,40 @@ jobs:
           fi
         done
 
+  publish_crates:
+    name: Publish Cargo Packages
+    needs: [release_prepare, release_binaries]
+    runs-on: ubuntu-24.04
+    if: |
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master' &&
+      !contains(github.event.head_commit.message, '[skip ci]') &&
+      !contains(github.event.head_commit.message, '[ci skip]')
+
+    steps:
+    - name: Checkout validated release snapshot
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ needs.release_prepare.outputs.publish_sha }}
+        submodules: 'recursive'
+
+    - name: Setup Rust
+      uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        toolchain: stable
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          libelf1 libelf-dev zlib1g-dev libclang-dev \
+          make git clang llvm pkg-config build-essential
+
     - name: Verify agent-session Cargo package
       run: |
         CARGO_TARGET_DIR=/tmp/agentsight-agent-session-package \
@@ -420,7 +458,7 @@ jobs:
           exit 1
         fi
 
-        VERSION="${{ steps.set_version.outputs.agent_session_version }}"
+        VERSION="${{ needs.release_prepare.outputs.agent_session_version }}"
         if crates_io_version_exists "agent-session" "$VERSION"; then
           echo "agent-session ${VERSION} already exists on crates.io; skipping publish."
         else
@@ -452,7 +490,7 @@ jobs:
           exit 1
         fi
 
-        VERSION="${{ steps.set_version.outputs.agentvis_version }}"
+        VERSION="${{ needs.release_prepare.outputs.agentvis_version }}"
         cargo publish --manifest-path agentvis/Cargo.toml
         for attempt in 1 2 3 4 5 6; do
           if curl --retry 3 --retry-delay 2 -A "$CRATES_IO_USER_AGENT" -fsS \
@@ -480,7 +518,7 @@ jobs:
           exit 1
         fi
 
-        VERSION="${{ steps.set_version.outputs.agentsight_capture_version }}"
+        VERSION="${{ needs.release_prepare.outputs.agentsight_capture_version }}"
         cargo publish --manifest-path agentsight-capture/Cargo.toml
         for attempt in 1 2 3 4 5 6; do
           if curl --retry 3 --retry-delay 2 -A "$CRATES_IO_USER_AGENT" -fsS \
@@ -517,7 +555,7 @@ jobs:
 
     - name: Smoke test cargo install from crates.io
       env:
-        VERSION: ${{ steps.set_version.outputs.version }}
+        VERSION: ${{ needs.release_prepare.outputs.version }}
       run: |
         set -euo pipefail
 
@@ -562,7 +600,7 @@ jobs:
 
     - name: Smoke test agentpprof cargo install from crates.io
       env:
-        VERSION: ${{ steps.set_version.outputs.agentpprof_version }}
+        VERSION: ${{ needs.release_prepare.outputs.agentpprof_version }}
       run: |
         set -euo pipefail
 
@@ -726,7 +764,7 @@ jobs:
 
   release:
     name: Assemble GitHub Release
-    needs: [release_prepare, release_binaries]
+    needs: [release_prepare, release_binaries, publish_crates]
     runs-on: ubuntu-24.04
     if: |
       github.event_name == 'push' &&

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,12 +133,6 @@ jobs:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     needs: [release_binaries, publish_crates]
-    # Only run on push to master, not on PRs
-    if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/master' &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]')
 
     steps:
     - name: Checkout code
@@ -397,11 +391,6 @@ jobs:
     name: Publish Cargo Packages
     needs: [release_prepare, release_binaries]
     runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/master' &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]')
 
     steps:
     - name: Checkout validated release snapshot
@@ -631,74 +620,29 @@ jobs:
           fi
         done
 
-  arm64_build:
-    name: Build ARM64 Release Candidate
-    runs-on: ubuntu-24.04-arm
-    if: github.event_name == 'pull_request'
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
-
-    - name: Setup Rust
-      uses: actions-rust-lang/setup-rust-toolchain@v1
-      with:
-        toolchain: stable
-
-    - name: Setup Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: '18'
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends \
-          libelf1 libelf-dev zlib1g-dev libclang-dev \
-          make git clang llvm pkg-config build-essential
-
-    - name: Build release binaries
-      run: |
-        make build
-        cargo build --release --manifest-path agentpprof/Cargo.toml
-
-    - name: Smoke test ARM64 binaries
-      run: |
-        set -euo pipefail
-        file collector/target/release/agentsight | grep -F "ARM aarch64"
-        file agentpprof/target/release/agentpprof | grep -F "ARM aarch64"
-        collector/target/release/agentsight --version
-        agentpprof/target/release/agentpprof --version
-
   release_binaries:
     name: Build Release Binaries (${{ matrix.arch }})
     needs: release_prepare
     runs-on: ${{ matrix.runner }}
     if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/master' &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]')
+      !cancelled() &&
+      (
+        github.event_name == 'pull_request' ||
+        (
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/master' &&
+          needs.release_prepare.result == 'success'
+        )
+      )
     strategy:
       fail-fast: false
-      matrix:
-        include:
-        - arch: x86_64
-          docker_arch: amd64
-          runner: ubuntu-24.04
-          legacy_assets: true
-        - arch: aarch64
-          docker_arch: arm64
-          runner: ubuntu-24.04-arm
-          legacy_assets: false
+      matrix: ${{ fromJSON(github.event_name == 'pull_request' && '{"include":[{"arch":"aarch64","docker_arch":"arm64","runner":"ubuntu-24.04-arm","legacy_assets":false}]}' || '{"include":[{"arch":"x86_64","docker_arch":"amd64","runner":"ubuntu-24.04","legacy_assets":true},{"arch":"aarch64","docker_arch":"arm64","runner":"ubuntu-24.04-arm","legacy_assets":false}]}') }}
 
     steps:
     - name: Checkout release snapshot
       uses: actions/checkout@v4
       with:
-        ref: ${{ needs.release_prepare.outputs.publish_sha }}
+        ref: ${{ needs.release_prepare.outputs.publish_sha || github.sha }}
         submodules: 'recursive'
 
     - name: Setup Rust
@@ -747,6 +691,7 @@ jobs:
         fi
 
     - name: Upload release assets
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v4
       with:
         name: release-linux-${{ matrix.arch }}
@@ -755,6 +700,7 @@ jobs:
         retention-days: 1
 
     - name: Upload Docker binary
+      if: github.event_name == 'push'
       uses: actions/upload-artifact@v4
       with:
         name: docker-linux-${{ matrix.docker_arch }}
@@ -766,11 +712,6 @@ jobs:
     name: Assemble GitHub Release
     needs: [release_prepare, release_binaries, publish_crates]
     runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'push' &&
-      github.ref == 'refs/heads/master' &&
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]')
 
     steps:
     - name: Download release assets

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ For local use, install with `cargo install agentsight` or download the latest
 release binary, then start with `agentsight top`. Use the examples below when
 you want to record a specific command or inspect saved sessions.
 
+GitHub releases provide `agentsight-x86_64` and `agentsight-aarch64` for Linux.
+The unsuffixed `agentsight` asset remains an x86_64 compatibility alias.
+
 #### Docker
 
 Docker is useful for container, CI, or isolated Linux environments, but it still needs privileged host access for eBPF. See [docs/docker.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/docker.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -91,6 +91,9 @@ Rust 应用可以依赖
 随后 `agentsight report` 和 `agentsight report list` 也默认查看当前目录里的记录。
 如果要查看 Claude/Codex/Gemini 的原生日志总览，显式运行 `agentsight report --local`。
 
+GitHub Release 为 Linux 提供 `agentsight-x86_64` 和 `agentsight-aarch64`；
+无后缀的 `agentsight` 继续作为 x86_64 兼容文件保留。
+
 #### Docker
 
 AgentSight 通过 Docker 运行，使用 `--privileged` 以支持 eBPF，`--pid=host` 以访问宿主机进程，`-v /sys:/sys:ro` 用于进程监控，`-v /usr:/usr:ro -v /lib:/lib:ro` 用于访问 SSL 库（在共享库如 `libssl.so` 上附加 uprobe 所需）。示例：

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -2,6 +2,9 @@
 
 Use Docker when you want a packaged AgentSight runtime for container, CI, or isolated Linux environments. Docker does not remove the eBPF permission requirements: the container must observe the host kernel and host processes, so it needs privileged mode and host mounts.
 
+The published `ghcr.io/eunomia-bpf/agentsight` image supports both `linux/amd64`
+and `linux/arm64`.
+
 For local day-to-day use, the release binary plus `agentsight top` or
 `sudo agentsight record -- ...` in [README.md](https://github.com/eunomia-bpf/agentsight#quick-start) is usually simpler.
 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -5,6 +5,10 @@ Use Docker when you want a packaged AgentSight runtime for container, CI, or iso
 The published `ghcr.io/eunomia-bpf/agentsight` image supports both `linux/amd64`
 and `linux/arm64`.
 
+Release CI uses `script/Dockerfile.release` with architecture-specific binaries
+staged by the workflow. It is not a standalone source-build Dockerfile; local
+source builds continue to use the repository-root `dockerfile` after `make build`.
+
 For local day-to-day use, the release binary plus `agentsight top` or
 `sudo agentsight record -- ...` in [README.md](https://github.com/eunomia-bpf/agentsight#quick-start) is usually simpler.
 

--- a/script/Dockerfile.release
+++ b/script/Dockerfile.release
@@ -1,0 +1,19 @@
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:24.04
+
+ARG TARGETARCH
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libelf1 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY docker-bin/docker-linux-${TARGETARCH}/agentsight /app/agentsight
+
+RUN chmod +x /app/agentsight
+
+EXPOSE 7395
+
+ENTRYPOINT ["/app/agentsight"]


### PR DESCRIPTION
## Summary

- split release preparation from architecture-specific binary builds and final release assembly
- build and smoke-test `agentsight` and `agentpprof` natively on x86_64 and ARM64 GitHub-hosted runners
- publish architecture-qualified Linux assets while retaining the unsuffixed x86_64 compatibility assets
- publish one multi-architecture `linux/amd64` + `linux/arm64` GHCR image from the same verified binaries
- gate irreversible Cargo publication on successful native builds for both release architectures

## Root cause

The release workflow had a single x86_64 matrix entry and also performed versioning, crate publication, tagging, and asset upload in the same job. Adding an ARM64 matrix row would duplicate those release-side effects. The Docker job likewise copied one host-built x86_64 binary into an amd64-only image.

## Validation

- `make test`
- `actionlint` workflow syntax/expression validation (excluding pre-existing v3 action-age warnings and pre-existing shellcheck findings)
- local `linux/amd64` build of `script/Dockerfile.release` with the architecture-specific artifact layout
- the PR-only `Build Release Binaries (aarch64)` matrix job performs the same native ARM64 build and binary smoke path used by releases

Closes #22