### PR TITLE
Support Cursor sessions through the agent-native path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ eBPF Programs (kernel) → JSON stdout → Rust Runners → Analyzer Chain → O
 - **`collector/src/`** — Rust streaming pipeline (flat module layout):
   - `runners/` — Execute eBPF binaries and parse their JSON output into event streams (BinaryRunner, ProcessRunner, SystemRunner, AgentRunner, FakeRunner for tests)
   - `analyzers/` — Pluggable stream processors: SSEProcessor, HTTPParser, SSLFilter, HTTPFilter, AuthHeaderRemover, TimestampNormalizer, MaterializingAnalyzer (feeds the materialized view)
-  - `sources/` — Non-eBPF inputs: agent-native session files (`~/.claude`, `~/.codex`), `/proc` snapshots, saved SQLite databases
+  - `sources/` — Non-eBPF inputs: agent-native session files (`~/.claude`, `~/.codex`, `~/.cursor`), `/proc` snapshots, saved SQLite databases
   - `view/` — MaterializedView: projects events into rows (llm_calls, audit_events, process_nodes, ...) and serves snapshots
   - `sinks/` — ViewSink implementations: SQLite row store, OTel exporter (maps LLM call rows to OpenTelemetry `gen_ai.*` spans via OTLP/HTTP JSON; enabled by `debug trace --otel`, see `docs/otel.md`)
   - `output/` — CLI/TUI rendering of snapshots

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ For a saved SQLite session, run `agentsight report serve --db run.db` and open t
 | Grok Build | `sudo ./agentsight record -- grok` |
 | Python (aider, open-interpreter, …) | `sudo ./agentsight record -c python` |
 | Docker containers (OpenClaw, …) | `sudo ./agentsight record -c node --binary-path docker://openclaw` |
+| Cursor (IDE) | `agentsight top` reads its local sessions, no sudo needed |
 | Any command | `sudo ./agentsight record -- <command>` |
 
 See [docs/agents.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/agents.md) for agent-specific setup, SSL quirks, browser capture, MCP stdio, and advanced flags.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ A: `record` stores sessions as `agentsight-*.db` files in the current directory 
 **Q: Why doesn't AgentSight capture traffic from Claude Code, Node.js, or Gemini CLI?**
 A: These applications statically link their SSL library (BoringSSL for Claude/Bun, OpenSSL for **all** Node.js — both NVM and system installs) into their own binary instead of using system `libssl.so`, so there's nothing for sslsniff to hook by default. AgentSight handles this for you: `record -- <command>` always discovers the binary, and `record -c node` now auto-discovers the Node binary too. For Claude attach mode, pass `--binary-path`. See the "Zero-Config: record" and "Monitoring Node.js AI Tools" sections.
 
+**Q: Can AgentSight trace IDE agents like Cursor?**
+A: Not through eBPF. They are Electron apps that mostly run on macOS or Windows, their TLS sits inside a stripped framework binary and a helper process, and Cursor's API traffic is protobuf rather than JSON, so even a successful capture produces no LLM events. Support for these agents goes through the agent-native session path instead. See [IDE-Based Agents](https://github.com/eunomia-bpf/agentsight/blob/master/docs/agents.md#ide-based-agents-cursor-antigravity-windsurf) for the details.
+
 **Q: What should I check if tracing fails?**
 A: Verify you are on Linux with eBPF support, have `sudo` or `CAP_BPF`/`CAP_SYS_ADMIN`, and are using `record -- <command>` or the correct `--binary-path` for statically linked agents.
 

--- a/agent-session/src/lib.rs
+++ b/agent-session/src/lib.rs
@@ -34,12 +34,12 @@ pub use types::{
 // Re-export parser functions
 pub use parser::{
     agent_source_for_path, codex_exec_prompt, codex_total_token_usage, collapse_project_path,
-    command_process_chain, contains_private_marker, count_session_dirs, discover_session_files,
-    discover_session_files_in_dir, discover_session_files_in_home, fixture_session_path,
-    is_codex_cli_entrypoint, normalize_session_log_path, parse_session_content, parse_session_file,
-    parse_session_path, path_component_strings, path_group, semantic_task_label,
-    session_candidate_from_path, session_log_path_from_str, short_hash, tool_category,
-    truncate_clean,
+    command_process_chain, contains_private_marker, count_session_dirs, count_session_dirs_in_home,
+    discover_session_files, discover_session_files_in_dir, discover_session_files_in_home,
+    fixture_session_path, is_codex_cli_entrypoint, normalize_session_log_path,
+    parse_session_content, parse_session_file, parse_session_path, path_component_strings,
+    path_group, semantic_task_label, session_candidate_from_path, session_log_path_from_str,
+    short_hash, tool_category, truncate_clean,
 };
 
 // Re-export process matching types and functions

--- a/agent-session/src/lib.rs
+++ b/agent-session/src/lib.rs
@@ -17,6 +17,7 @@ mod types;
 pub const AGENT_CLAUDE: &str = "claude";
 pub const AGENT_CODEX: &str = "codex";
 pub const AGENT_GEMINI: &str = "gemini";
+pub const AGENT_CURSOR: &str = "cursor";
 
 pub const TRACE_EBPF_FILE: &str = "ebpf_file";
 pub const TRACE_PROC_FD: &str = "proc_fd";

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1943,7 +1943,9 @@ fn shell_file_actions(
     if depth > 2 {
         return Vec::new();
     }
-    let mut cwd = ["workdir", "cwd"]
+    // Cursor's Shell tool names this working_directory rather than workdir or
+    // cwd, and it is the only cwd signal on a command that has no leading cd.
+    let mut cwd = ["workdir", "cwd", "working_directory"]
         .iter()
         .find_map(|key| input.get(*key).and_then(Value::as_str))
         .map(PathBuf::from);
@@ -3504,6 +3506,82 @@ mod tests {
         // Flag-shaped keys such as "-i" are not paths.
         assert_eq!(access_of("/repo"), "read");
         assert_eq!(session.files.get("/repo/d.rs"), Some(&1));
+    }
+
+    #[test]
+    fn cursor_shell_mv_yields_rename_with_previous_path() {
+        // Rename never arrives as a dedicated Cursor tool. It only ever comes
+        // through Shell, and Cursor emits it as a compound command with a cd.
+        let content = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"tidy up"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"cd /repo && mv hello.py greet.py","description":"rename it"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"rm /repo/stale.txt","description":"drop it"}}]}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &content,
+        )
+        .expect("session");
+
+        let all: Vec<&ToolPath> = session
+            .events
+            .tools
+            .iter()
+            .flat_map(|tool| tool.paths.iter())
+            .collect();
+        let renamed = all
+            .iter()
+            .find(|path| path.access == "rename")
+            .expect("rename");
+        assert_eq!(renamed.path, "/repo/greet.py");
+        assert_eq!(renamed.previous_path.as_deref(), Some("/repo/hello.py"));
+        assert!(
+            all.iter()
+                .any(|path| path.access == "delete" && path.path == "/repo/stale.txt")
+        );
+        assert_eq!(session.events.tools[0].category, "shell");
+        assert_eq!(
+            session.events.tools[0].command,
+            "cd /repo && mv hello.py greet.py"
+        );
+        // command_name is the first token of a compound command, so Cursor's
+        // habit of prefixing with cd surfaces as "cd" rather than "mv". That is
+        // pre-existing behaviour shared with the other agents, not Cursor
+        // specific, so it stays as is here.
+        assert_eq!(session.events.tools[0].command_name, "cd");
+    }
+
+
+    #[test]
+    fn cursor_shell_working_directory_resolves_relative_paths() {
+        // Cursor names this key working_directory, where Claude and Codex use
+        // workdir or cwd. Without it the relative paths below resolve against
+        // nothing and the session records no files at all.
+        let content = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"move it"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"mv hello.py archive/greet.py","working_directory":"/repo","description":"move"}}]}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &content,
+        )
+        .expect("session");
+
+        let renamed = session.events.tools[0]
+            .paths
+            .iter()
+            .find(|path| path.access == "rename")
+            .expect("rename");
+        assert_eq!(renamed.path, "/repo/archive/greet.py");
+        assert_eq!(renamed.previous_path.as_deref(), Some("/repo/hello.py"));
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1330,6 +1330,9 @@ fn parse_cursor_jsonl(
     let mut events = SessionEvents::default();
     let mut current_prompt_index = 0usize;
 
+    // Resolve cwd before the walk so tool events group their paths against it.
+    acc.cwd = cursor_session_cwd(content, children);
+
     let mut delegations = Vec::new();
     cursor_absorb_transcript(
         content,
@@ -1440,6 +1443,79 @@ fn cursor_absorb_transcript(
             _ => {}
         }
     }
+}
+
+/// Work out a Cursor session's working directory from its transcripts.
+///
+/// Cursor records no cwd field, unlike Claude and Codex. Two signals are
+/// available and both are exact: `Shell.working_directory`, present on some
+/// commands, and the absolute paths that file tools carry.
+///
+/// The project directory name is deliberately not used. It is a lossy encoding
+/// (`Users-alec-cursor-test`) that cannot be inverted, since a hyphen in a real
+/// directory name is indistinguishable from a separator, so un-collapsing it
+/// yields `/Users/alec/cursor/test` for a directory actually named
+/// `cursor-test`. A wrong cwd is worse than none, and the SQLite enrichment can
+/// supply the real path from `workspaceIdentifier`.
+fn cursor_session_cwd(content: &str, children: &[(PathBuf, String)]) -> Option<String> {
+    let mut absolute: Vec<PathBuf> = Vec::new();
+    for transcript in std::iter::once(content).chain(children.iter().map(|(_, body)| body.as_str()))
+    {
+        for line in transcript.lines() {
+            let Ok(record) = serde_json::from_str::<Value>(line.trim()) else {
+                continue;
+            };
+            for part in cursor_tool_uses(&record) {
+                let Some(input) = part.get("input") else {
+                    continue;
+                };
+                if let Some(dir) = input.get("working_directory").and_then(Value::as_str)
+                    && Path::new(dir).is_absolute()
+                {
+                    return Some(dir.to_string());
+                }
+                for key in ["path", "paths"] {
+                    match input.get(key) {
+                        Some(Value::String(value)) => absolute.push(PathBuf::from(value)),
+                        Some(Value::Array(values)) => absolute
+                            .extend(values.iter().filter_map(Value::as_str).map(PathBuf::from)),
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+    common_parent_dir(&absolute)
+}
+
+/// The deepest directory containing every one of the given absolute paths.
+fn common_parent_dir(paths: &[PathBuf]) -> Option<String> {
+    let mut dirs = paths
+        .iter()
+        .filter(|path| path.is_absolute())
+        .filter_map(|path| path.parent())
+        .map(|dir| {
+            dir.components()
+                .map(|part| part.as_os_str().to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+        });
+    let mut shared = dirs.next()?;
+    for candidate in dirs {
+        let keep = shared
+            .iter()
+            .zip(candidate.iter())
+            .take_while(|(left, right)| left == right)
+            .count();
+        shared.truncate(keep);
+    }
+    // A single leading "/" component means the paths share nothing useful.
+    (shared.len() > 1).then(|| {
+        let mut out = PathBuf::new();
+        for part in shared {
+            out.push(part);
+        }
+        out.to_string_lossy().into_owned()
+    })
 }
 
 /// Find which parent prompt delegated a given sub-agent transcript.
@@ -3457,6 +3533,8 @@ mod tests {
         .join("\n")
     }
 
+
+
     #[test]
     fn cursor_transcript_counts_prompts_and_responses() {
         let session = parse_session_content(
@@ -3672,6 +3750,119 @@ mod tests {
         // prompt match its work would land on prompt 1, the last one seen.
         assert_eq!(tool_at("Write"), 0);
         assert_eq!(tool_at("Delete"), 1);
+    }
+
+    #[test]
+    fn cursor_cwd_prefers_working_directory_then_common_path_prefix() {
+        let with_dir = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"go"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"ls","working_directory":"/repo/app"}}]}}"#,
+        ]
+        .join("\n");
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &with_dir,
+        )
+        .expect("session");
+        assert_eq!(session.cwd.as_deref(), Some("/repo/app"));
+
+        // With no working_directory anywhere, fall back to the directory that
+        // contains every absolute path the tools touched.
+        let paths_only = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"go"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/repo/app/src/main.rs","contents":"x"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/repo/app/README.md"}}]}}"#,
+        ]
+        .join("\n");
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &paths_only,
+        )
+        .expect("session");
+        assert_eq!(session.cwd.as_deref(), Some("/repo/app"));
+
+        // Nothing to go on leaves cwd unset rather than guessed. The project
+        // directory name is a lossy encoding and inverting it invents paths.
+        let bare = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"hello"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}"#,
+        ]
+        .join("\n");
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/projects/Users-alec-cursor-test/agent-transcripts/a/a.jsonl"),
+            UNIX_EPOCH,
+            &bare,
+        )
+        .expect("session");
+        assert_eq!(session.cwd, None);
+    }
+
+    #[test]
+    fn cursor_truncated_and_empty_transcripts_degrade_without_error() {
+        // Cursor appends while a session runs, so the last line can be torn.
+        // Everything before it must still parse.
+        let torn = concat!(
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"start"}]}}"#,
+            "\n",
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/repo/a.rs"}}]}}"#,
+            "\n",
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_"#,
+        );
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            torn,
+        )
+        .expect("session");
+        assert_eq!(session.events.prompts.len(), 1);
+        assert_eq!(session.tools.get("Read"), Some(&1));
+
+        // A transcript holding nothing but a turn marker has no prompt, no
+        // tools and no tokens, so it yields None. That is the same treatment
+        // every other agent gets for an empty session, and it keeps abandoned
+        // sessions out of `top` rather than showing blank rows.
+        for empty in [
+            "",
+            "\n\n",
+            r#"{"type":"turn_ended","status":"error","error":"aborted"}"#,
+            "not json at all",
+        ] {
+            assert!(
+                parse_session_content(
+                    AGENT_CURSOR,
+                    &PathBuf::from("/tmp/session.jsonl"),
+                    UNIX_EPOCH,
+                    empty,
+                )
+                .is_none(),
+                "expected no session for {empty:?}"
+            );
+        }
+
+        // A child whose Task prompt no longer matches still contributes its
+        // work, attributed to the last prompt rather than dropped.
+        let orphan = vec![(
+            PathBuf::from("/tmp/subagents/orphan.jsonl"),
+            [
+                r#"{"role":"user","message":{"content":[{"type":"text","text":"unrelated wording"}]}}"#,
+                r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/repo/z.rs","contents":"x"}}]}}"#,
+            ]
+            .join("\n"),
+        )];
+        let session = parse_cursor_jsonl(
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &cursor_parent_fixture(),
+            &orphan,
+        )
+        .expect("session");
+        assert_eq!(session.tools.get("Write"), Some(&1));
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -212,6 +212,13 @@ fn parse_session_impl(
 ) -> Option<AgentSession> {
     if agent == AGENT_GEMINI {
         parse_gemini_json(path, updated, content)
+    } else if agent == AGENT_CURSOR {
+        // Cursor splits one session across a parent transcript and a subagents/
+        // directory. Reading the siblings here keeps `parse_cursor_jsonl` a pure
+        // function of its inputs, so the folding stays unit-testable, while every
+        // caller that reaches this dispatch still gets the whole session.
+        let children = read_cursor_subagents(path);
+        parse_cursor_jsonl(path, updated, content, &children)
     } else {
         parse_jsonl(agent, path, updated, content)
     }
@@ -1279,6 +1286,156 @@ fn parse_gemini_json(path: &Path, updated: SystemTime, content: &str) -> Option<
         }
     }
     acc.finish_with_events(events)
+}
+
+/// Read the `subagents/*.jsonl` transcripts that sit beside a Cursor parent
+/// transcript. A missing directory is normal (plenty of sessions never delegate)
+/// and yields an empty list rather than an error.
+fn read_cursor_subagents(path: &Path) -> Vec<(PathBuf, String)> {
+    let Some(dir) = path.parent().map(|parent| parent.join("subagents")) else {
+        return Vec::new();
+    };
+    let Ok(entries) = fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    let mut out: Vec<(PathBuf, String)> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|child| child.extension().and_then(|ext| ext.to_str()) == Some("jsonl"))
+        .filter_map(|child| {
+            let content = fs::read_to_string(&child).ok()?;
+            Some((child, content))
+        })
+        .collect();
+    // Directory order is arbitrary; keep parses deterministic across runs.
+    out.sort_by(|left, right| left.0.cmp(&right.0));
+    out
+}
+
+/// Parse a Cursor agent transcript, folding in any delegated sub-agent
+/// transcripts so the session reflects everything it actually did.
+///
+/// Cursor decides per turn whether to delegate, so a single session mixes turns
+/// where the parent works directly with turns where it only issues `Task` calls
+/// and the children do the work. Reading the parent alone reports those sessions
+/// as having done nothing.
+fn parse_cursor_jsonl(
+    path: &Path,
+    updated: SystemTime,
+    content: &str,
+    children: &[(PathBuf, String)],
+) -> Option<AgentSession> {
+    let mut acc = SessionAccumulator::new(AGENT_CURSOR, path, updated);
+    acc.conversation_id = Some(acc.session_id.clone());
+    let mut events = SessionEvents::default();
+    let mut current_prompt_index = 0usize;
+
+    cursor_absorb_transcript(
+        content,
+        CursorScope::Parent,
+        &mut acc,
+        &mut events,
+        &mut current_prompt_index,
+    );
+    for (_, child_content) in children {
+        cursor_absorb_transcript(
+            child_content,
+            CursorScope::Subagent,
+            &mut acc,
+            &mut events,
+            &mut current_prompt_index,
+        );
+    }
+
+    acc.finish_with_events(events)
+}
+
+/// Which transcript in a Cursor session is being read.
+///
+/// A sub-agent's `role: user` records hold the `Task` prompt Cursor generated,
+/// not anything a person typed, so they must not become `UserPrompt`s. Their
+/// work still belongs to the session, and attributes to whichever human prompt
+/// was current when the delegation happened.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CursorScope {
+    Parent,
+    Subagent,
+}
+
+/// Walk one Cursor transcript, adding its records to the running session.
+fn cursor_absorb_transcript(
+    content: &str,
+    scope: CursorScope,
+    acc: &mut SessionAccumulator,
+    events: &mut SessionEvents,
+    current_prompt_index: &mut usize,
+) {
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        // Cursor appends while a session runs, so a torn final line is expected
+        // rather than exceptional. Skip it and keep the records we already have.
+        let Ok(record) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+
+        match record.get("role").and_then(Value::as_str) {
+            Some("user") if scope == CursorScope::Parent => {
+                let text = cursor_text_of(&record);
+                if !text.is_empty() {
+                    *current_prompt_index = events.upsert_prompt(None, &text, Vec::new());
+                    if acc.prompt_preview.is_none() {
+                        acc.prompt_preview = Some(truncate_clean(&text, 180));
+                    }
+                }
+            }
+            Some("assistant") => {
+                let text = cursor_text_of(&record);
+                if !text.is_empty() {
+                    events.llm_responses.push(LlmResponse {
+                        ts_ms: None,
+                        prompt_index: *current_prompt_index,
+                        // Model, tokens, and timestamps live in state.vscdb, not
+                        // the transcript. The SQLite enrichment fills them in.
+                        model: String::new(),
+                        source_id: String::new(),
+                        text_hash: short_hash(&text, 12),
+                        preview: truncate_clean(&text, 140),
+                        input_tokens: 0,
+                        output_tokens: 0,
+                        cache_tokens: 0,
+                        total_tokens: 0,
+                        tag: String::new(),
+                        response_phase: String::new(),
+                        skill: String::new(),
+                        task_path: Vec::new(),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Join the `text` parts of a Cursor message record.
+fn cursor_text_of(record: &Value) -> String {
+    let Some(parts) = record
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return String::new();
+    };
+    parts
+        .iter()
+        .filter(|part| part.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|part| part.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
 }
 
 struct SessionAccumulator {
@@ -3139,6 +3296,71 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::time::UNIX_EPOCH;
+
+    /// A Cursor parent transcript that both delegates and works directly.
+    /// Sessions mix the two per turn, so a fixture with only one pattern passes
+    /// while the other silently breaks.
+    fn cursor_parent_fixture() -> String {
+        [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"create hello.py"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"delegating"},{"type":"tool_use","name":"Task","input":{"description":"Create hello.py","prompt":"make it","subagent_type":"generalPurpose"}}]}}"#,
+            r#"{"type":"turn_ended","status":"success"}"#,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"now delete it"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Delete","input":{"path":"/repo/hello.py"}},{"type":"text","text":"deleted"}]}}"#,
+            r#"{"type":"turn_ended","status":"success"}"#,
+        ]
+        .join("\n")
+    }
+
+    /// The child spawned by the `Task` call above. All of the first turn's real
+    /// work lives here, none of it in the parent.
+    fn cursor_subagent_fixture() -> String {
+        [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"make it"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/repo/hello.py","contents":"print(1)\n"}},{"type":"text","text":"written"}]}}"#,
+            r#"{"type":"turn_ended","status":"success"}"#,
+        ]
+        .join("\n")
+    }
+
+    #[test]
+    fn cursor_transcript_counts_prompts_and_responses() {
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &cursor_parent_fixture(),
+        )
+        .expect("session");
+
+        assert_eq!(session.agent_type, AGENT_CURSOR);
+        assert_eq!(session.events.prompts.len(), 2);
+        assert_eq!(session.events.llm_responses.len(), 2);
+        assert_eq!(session.events.prompts[0].preview, "create hello.py");
+        assert_eq!(session.events.prompts[1].index, 1);
+        assert_eq!(session.events.llm_responses[1].prompt_index, 1);
+        assert_eq!(session.prompt_preview.as_deref(), Some("create hello.py"));
+    }
+
+    #[test]
+    fn cursor_subagent_prompts_are_not_user_prompts() {
+        let children = vec![(
+            PathBuf::from("/tmp/subagents/child.jsonl"),
+            cursor_subagent_fixture(),
+        )];
+        let session = parse_cursor_jsonl(
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &cursor_parent_fixture(),
+            &children,
+        )
+        .expect("session");
+
+        // The child's own "user" record holds the Task prompt Cursor generated,
+        // so folding it in must not invent a third human prompt.
+        assert_eq!(session.events.prompts.len(), 2);
+        assert_eq!(session.events.llm_responses.len(), 3);
+    }
 
     #[test]
     fn cursor_paths_classify_but_only_parents_discover() {

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1396,7 +1396,7 @@ fn cursor_absorb_transcript(
 
         match record.get("role").and_then(Value::as_str) {
             Some("user") if scope == CursorScope::Parent => {
-                let text = cursor_text_of(&record);
+                let text = cursor_user_query(&cursor_text_of(&record));
                 if !text.is_empty() {
                     *current_prompt_index = events.upsert_prompt(None, &text, Vec::new());
                     if acc.prompt_preview.is_none() {
@@ -1538,6 +1538,36 @@ fn cursor_delegating_prompt_index(
         .iter()
         .find(|(_, prompt)| opening.contains(prompt.as_str()))
         .map(|(index, _)| *index)
+}
+
+/// Strip Cursor's user message wrapper.
+///
+/// Every user record Cursor writes, in parent and sub-agent transcripts alike,
+/// wraps what the person actually typed:
+///
+/// ```text
+/// <timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>
+/// <user_query>
+/// Create hello.py that prints Hello
+/// </user_query>
+/// ```
+///
+/// Without unwrapping, every prompt preview in `top` and in reports shows the
+/// timestamp header rather than the prompt. Text with no wrapper is returned
+/// unchanged, so this is safe if the format shifts.
+fn cursor_user_query(text: &str) -> String {
+    const OPEN: &str = "<user_query>";
+    const CLOSE: &str = "</user_query>";
+    let Some(start) = text.find(OPEN) else {
+        return text.trim().to_string();
+    };
+    let rest = &text[start + OPEN.len()..];
+    let inner = match rest.find(CLOSE) {
+        Some(end) => &rest[..end],
+        // A torn final line can cut the closing tag off.
+        None => rest,
+    };
+    inner.trim().to_string()
 }
 
 /// The text of the first user record in a transcript.
@@ -3510,7 +3540,8 @@ mod tests {
     /// while the other silently breaks.
     fn cursor_parent_fixture() -> String {
         [
-            r#"{"role":"user","message":{"content":[{"type":"text","text":"create hello.py"}]}}"#,
+            // Cursor wraps every user message, parent and child alike.
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>\n<user_query>\ncreate hello.py\n</user_query>"}]}}"#,
             r#"{"role":"assistant","message":{"content":[{"type":"text","text":"delegating"},{"type":"tool_use","name":"Task","input":{"description":"Create hello.py","prompt":"make it","subagent_type":"generalPurpose"}}]}}"#,
             r#"{"type":"turn_ended","status":"success"}"#,
             r#"{"role":"user","message":{"content":[{"type":"text","text":"now delete it"}]}}"#,
@@ -3548,7 +3579,10 @@ mod tests {
         assert_eq!(session.agent_type, AGENT_CURSOR);
         assert_eq!(session.events.prompts.len(), 2);
         assert_eq!(session.events.llm_responses.len(), 2);
+        // The <timestamp>/<user_query> wrapper is stripped, so previews show
+        // what the person typed rather than Cursor's header.
         assert_eq!(session.events.prompts[0].preview, "create hello.py");
+        assert_eq!(session.events.prompts[1].preview, "now delete it");
         assert_eq!(session.events.prompts[1].index, 1);
         assert_eq!(session.events.llm_responses[1].prompt_index, 1);
         assert_eq!(session.prompt_preview.as_deref(), Some("create hello.py"));

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -3108,7 +3108,13 @@ fn extract_path_groups(
 /// nothing, which under-reports file activity for any project not written in
 /// the handful of languages the extension list happens to name.
 fn plausible_path_operand(part: &str) -> bool {
-    !definitely_not_a_path(part)
+    let part = part.trim_matches(['"', '\'']);
+    // A bare number in operand position is a file descriptor, not a file. The
+    // tokenizer splits `cat x 2>&1` into `x` and `2` and `>&1`, so without this
+    // every redirected command records a read of a file called "2".
+    !part.is_empty()
+        && !part.chars().all(|c| c.is_ascii_digit())
+        && !definitely_not_a_path(part)
 }
 
 /// A token found by scanning a whole command, where it could be anything.
@@ -4587,6 +4593,7 @@ mod tests {
         assert_eq!(heredoc.paths[0].path, "src/real.rs");
     }
 
+
     #[test]
     fn shell_path_operands_are_not_limited_to_known_extensions() {
         let paths_of = |command: &str| {
@@ -4627,6 +4634,28 @@ mod tests {
             "rm $TARGET",
             "rm -rf",
         ] {
+            assert!(
+                paths_of(command).is_empty(),
+                "{command} should record nothing, got {:?}",
+                paths_of(command)
+            );
+        }
+
+        // A redirected command splits into a bare file descriptor. Without the
+        // numeric guard, every `2>&1` recorded a read of a file called "2".
+        let redirected = paths_of("cat notes.txt 2>&1");
+        assert!(
+            redirected
+                .iter()
+                .any(|(path, _)| path == "/repo/notes.txt"),
+            "the real file should still be recorded, got {redirected:?}"
+        );
+        assert!(
+            !redirected.iter().any(|(path, _)| path.ends_with("/2")),
+            "a file descriptor is not a file, got {redirected:?}"
+        );
+
+        for command in ["rm 2", "cat 1"] {
             assert!(
                 paths_of(command).is_empty(),
                 "{command} should record nothing, got {:?}",

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -133,9 +133,14 @@ fn cursor_is_empty_window(path: &Path) -> bool {
 
 /// Count sessions and bytes per agent directory.
 pub fn count_session_dirs() -> Vec<SessionDirStat> {
-    let Some(home) = user_home_dir() else {
-        return Vec::new();
-    };
+    user_home_dir()
+        .as_deref()
+        .map(count_session_dirs_in_home)
+        .unwrap_or_default()
+}
+
+/// Count sessions and bytes per agent directory under a specific home directory.
+pub fn count_session_dirs_in_home(home: &Path) -> Vec<SessionDirStat> {
     [
         (AGENT_CLAUDE, home.join(".claude/projects")),
         (AGENT_CODEX, home.join(".codex/sessions")),

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -3162,9 +3162,9 @@ mod tests {
             &home.join(".cursor/projects/repo/agent-transcripts/abc/other.jsonl")
         ));
 
-        assert!(cursor_is_empty_window(
-            &home.join(".cursor/projects/empty-window/agent-transcripts/abc/abc.jsonl")
-        ));
+        assert!(cursor_is_empty_window(&home.join(
+            ".cursor/projects/empty-window/agent-transcripts/abc/abc.jsonl"
+        )));
         assert!(!cursor_is_empty_window(&parent));
 
         let fixture = fixture_session_path(AGENT_CURSOR, &home).expect("fixture");

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1392,6 +1392,9 @@ fn cursor_absorb_transcript(
                 }
             }
             Some("assistant") => {
+                for part in cursor_tool_uses(&record) {
+                    cursor_push_tool_event(part, acc, events, *current_prompt_index);
+                }
                 let text = cursor_text_of(&record);
                 if !text.is_empty() {
                     events.llm_responses.push(LlmResponse {
@@ -1417,6 +1420,72 @@ fn cursor_absorb_transcript(
             _ => {}
         }
     }
+}
+
+/// The `tool_use` parts of a Cursor message record.
+fn cursor_tool_uses(record: &Value) -> Vec<&Value> {
+    record
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)
+        .map(|parts| {
+            parts
+                .iter()
+                .filter(|part| part.get("type").and_then(Value::as_str) == Some("tool_use"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Turn one `tool_use` part into a `ToolEvent`.
+///
+/// Cursor's tool vocabulary isn't fixed. Two machines on the same version showed
+/// fifteen names with little overlap, tracking which features each person used,
+/// so an unrecognised name has to produce an event in the catch-all category
+/// rather than being dropped.
+fn cursor_push_tool_event(
+    part: &Value,
+    acc: &mut SessionAccumulator,
+    events: &mut SessionEvents,
+    prompt_index: usize,
+) {
+    let Some(name) = part.get("name").and_then(Value::as_str).filter(|n| !n.is_empty()) else {
+        return;
+    };
+    let input = part.get("input").cloned().unwrap_or(Value::Null);
+    // Only Shell carries a command; everything else leaves these empty.
+    let command = input
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+
+    acc.add_tool(name);
+    events.tools.push(ToolEvent {
+        ts_ms: None,
+        prompt_index,
+        tool_name: name.to_string(),
+        category: tool_category(name, &command),
+        command_name: basename_from_command(&command),
+        effect: if command.is_empty() {
+            String::new()
+        } else {
+            command_effect(&command)
+        },
+        command,
+        process_chain: Vec::new(),
+        // Cursor writes no tool_result records. The only signal is turn-level
+        // turn_ended.status, so per-tool status stays unset rather than guessed.
+        status: String::new(),
+        path_groups: Vec::new(),
+        paths: Vec::new(),
+        domains: Vec::new(),
+        // Cursor's tool_use parts carry only type, name and input. No id.
+        call_id: None,
+        invoked_skill: String::new(),
+        skill: String::new(),
+        task_path: Vec::new(),
+    });
 }
 
 /// Join the `text` parts of a Cursor message record.
@@ -2540,11 +2609,21 @@ fn explicit_exit_codes(output: &str) -> Vec<i32> {
 
 pub fn tool_category(name: &str, command: &str) -> String {
     let n = name.to_ascii_lowercase();
-    if n.ends_with("exec_command") || n.ends_with("shell_command") || n == "bash" {
+    if n.ends_with("exec_command") || n.ends_with("shell_command") || n == "bash" || n == "shell" {
         "shell"
-    } else if ["apply_patch", "edit", "write", "multiedit", "notebookedit"].contains(&n.as_str()) {
+    } else if [
+        "apply_patch",
+        "edit",
+        "write",
+        "multiedit",
+        "notebookedit",
+        "strreplace",
+        "delete",
+    ]
+    .contains(&n.as_str())
+    {
         "edit"
-    } else if ["read", "grep", "glob", "ls"].contains(&n.as_str()) {
+    } else if ["read", "grep", "glob", "ls", "readlints"].contains(&n.as_str()) {
         "read"
     } else if n.contains("web")
         || n.contains("browser")
@@ -3340,6 +3419,47 @@ mod tests {
         assert_eq!(session.events.prompts[1].index, 1);
         assert_eq!(session.events.llm_responses[1].prompt_index, 1);
         assert_eq!(session.prompt_preview.as_deref(), Some("create hello.py"));
+    }
+
+    #[test]
+    fn cursor_tool_uses_become_events_and_unknown_names_are_kept() {
+        let content = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"do work"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"cargo test","description":"run tests"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"StrReplace","input":{"path":"/repo/a.rs","old_string":"x","new_string":"y"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"ReadLints","input":{"paths":["/repo/a.rs"]}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"SomeToolWeHaveNeverSeen","input":{"whatever":1}}]}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &content,
+        )
+        .expect("session");
+
+        let named = |name: &str| {
+            session
+                .events
+                .tools
+                .iter()
+                .find(|tool| tool.tool_name == name)
+                .unwrap_or_else(|| panic!("{name} missing"))
+        };
+        assert_eq!(session.events.tools.len(), 4);
+        assert_eq!(named("Shell").category, "shell");
+        assert_eq!(named("Shell").command, "cargo test");
+        assert_eq!(named("Shell").command_name, "cargo");
+        assert_eq!(named("StrReplace").category, "edit");
+        assert_eq!(named("ReadLints").category, "read");
+        // An unfamiliar name still produces an event, in the catch-all category.
+        assert_eq!(named("SomeToolWeHaveNeverSeen").category, "tool");
+        // Cursor has no per-tool result records and no tool call ids.
+        assert!(named("Shell").call_id.is_none());
+        assert!(named("Shell").status.is_empty());
+        assert_eq!(session.tools.get("Shell"), Some(&1));
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -68,9 +68,6 @@ fn candidate_updated(agent: &str, path: &Path, meta: &fs::Metadata) -> SystemTim
     }
 }
 
-/// A Cursor candidate is the parent transcript, but its session includes any
-/// `subagents/*.jsonl` siblings, so `updated` is the max mtime across all of
-/// them. This is what lets a child-only write invalidate the cached session.
 fn cursor_candidate_updated(path: &Path, parent_updated: SystemTime) -> SystemTime {
     let mut updated = parent_updated;
     let Some(subagents) = path.parent().map(|dir| dir.join("subagents")) else {
@@ -89,10 +86,6 @@ fn cursor_candidate_updated(path: &Path, parent_updated: SystemTime) -> SystemTi
     updated
 }
 
-/// One Cursor session can appear under both its real workspace directory and
-/// `empty-window` (a stale fork left behind when a window later opened a
-/// folder). Keep one candidate per composer id: a real workspace beats
-/// `empty-window`, then the newer file wins.
 fn dedupe_cursor_candidates(out: &mut Vec<SessionCandidate>) {
     let mut best: BTreeMap<String, (bool, SystemTime, usize)> = BTreeMap::new();
     let mut drop = vec![false; out.len()];
@@ -213,10 +206,7 @@ fn parse_session_impl(
     if agent == AGENT_GEMINI {
         parse_gemini_json(path, updated, content)
     } else if agent == AGENT_CURSOR {
-        // Cursor splits one session across a parent transcript and a subagents/
-        // directory. Reading the siblings here keeps `parse_cursor_jsonl` a pure
-        // function of its inputs, so the folding stays unit-testable, while every
-        // caller that reaches this dispatch still gets the whole session.
+        // Read siblings here so the parser stays a pure function of its inputs.
         let children = read_cursor_subagents(path);
         parse_cursor_jsonl(path, updated, content, &children)
     } else {
@@ -263,20 +253,11 @@ pub fn agent_source_for_path(path: &Path) -> Option<&'static str> {
     }
 }
 
-/// Cursor transcripts live under `agent-transcripts/`; other `.jsonl` files in
-/// a project directory (vendored dependencies under `canvases/`, for example)
-/// are not sessions. Matches parent and subagent transcripts alike, so process
-/// matching can classify any fd path Cursor holds open.
 fn is_cursor_transcript(path: &Path) -> bool {
     path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
         && path.to_string_lossy().contains("/agent-transcripts/")
 }
 
-/// Discovery emits one candidate per Cursor session: the parent transcript,
-/// whose file stem equals its directory name (`<composerId>/<composerId>.jsonl`).
-/// A `subagents/<childId>.jsonl` file never matches, so delegated runs cannot
-/// surface as standalone sessions or crowd the session cache's parse window;
-/// the parser folds them into the parent instead.
 fn is_cursor_parent_transcript(path: &Path) -> bool {
     is_cursor_transcript(path)
         && path.file_stem().is_some_and(|stem| {
@@ -1288,9 +1269,6 @@ fn parse_gemini_json(path: &Path, updated: SystemTime, content: &str) -> Option<
     acc.finish_with_events(events)
 }
 
-/// Read the `subagents/*.jsonl` transcripts that sit beside a Cursor parent
-/// transcript. A missing directory is normal (plenty of sessions never delegate)
-/// and yields an empty list rather than an error.
 fn read_cursor_subagents(path: &Path) -> Vec<(PathBuf, String)> {
     let Some(dir) = path.parent().map(|parent| parent.join("subagents")) else {
         return Vec::new();
@@ -1312,13 +1290,6 @@ fn read_cursor_subagents(path: &Path) -> Vec<(PathBuf, String)> {
     out
 }
 
-/// Parse a Cursor agent transcript, folding in any delegated sub-agent
-/// transcripts so the session reflects everything it actually did.
-///
-/// Cursor decides per turn whether to delegate, so a single session mixes turns
-/// where the parent works directly with turns where it only issues `Task` calls
-/// and the children do the work. Reading the parent alone reports those sessions
-/// as having done nothing.
 fn parse_cursor_jsonl(
     path: &Path,
     updated: SystemTime,
@@ -1343,10 +1314,7 @@ fn parse_cursor_jsonl(
         &mut delegations,
     );
     for (_, child_content) in children {
-        // Attribute the child's work to the prompt that delegated it, not to
-        // whichever prompt happened to be last. A session that delegates early
-        // and works directly later would otherwise pin all delegated file
-        // activity on the final prompt.
+        // Attribute the child's work to the prompt that delegated it, not the last one.
         let mut index = cursor_delegating_prompt_index(child_content, &delegations)
             .unwrap_or(current_prompt_index);
         cursor_absorb_transcript(
@@ -1362,19 +1330,13 @@ fn parse_cursor_jsonl(
     acc.finish_with_events(events)
 }
 
-/// Which transcript in a Cursor session is being read.
-///
-/// A sub-agent's `role: user` records hold the `Task` prompt Cursor generated,
-/// not anything a person typed, so they must not become `UserPrompt`s. Their
-/// work still belongs to the session, and attributes to whichever human prompt
-/// was current when the delegation happened.
+// A sub-agent's user records hold the generated Task prompt, not a human one.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum CursorScope {
     Parent,
     Subagent,
 }
 
-/// Walk one Cursor transcript, adding its records to the running session.
 fn cursor_absorb_transcript(
     content: &str,
     scope: CursorScope,
@@ -1398,10 +1360,7 @@ fn cursor_absorb_transcript(
             continue;
         };
 
-        // Cursor records no per-tool result, so the only outcome signal is the
-        // turn marker. A failed turn marks every tool call it contained, which
-        // is the same shape as the other agents' tool_result handling, just at
-        // turn granularity rather than per call.
+        // Cursor writes no tool_result, so a failed turn is the only outcome signal.
         if record.get("type").and_then(Value::as_str) == Some("turn_ended") {
             let failed = record
                 .get("status")
@@ -1424,9 +1383,7 @@ fn cursor_absorb_transcript(
         match record.get("role").and_then(Value::as_str) {
             Some("user") => {
                 let raw = cursor_text_of(&record);
-                // The wrapper's timestamp is the only clock in the transcript,
-                // and sub-agent messages carry one too, so read it in both
-                // scopes even though only the parent contributes prompts.
+                // The only clock a transcript has, and children carry one too.
                 if let Some(ts) = cursor_wrapper_ts_ms(&raw) {
                     current_ts_ms = Some(ts);
                 }
@@ -1482,18 +1439,6 @@ fn cursor_absorb_transcript(
     }
 }
 
-/// Work out a Cursor session's working directory from its transcripts.
-///
-/// Cursor records no cwd field, unlike Claude and Codex. Two signals are
-/// available and both are exact: `Shell.working_directory`, present on some
-/// commands, and the absolute paths that file tools carry.
-///
-/// The project directory name is deliberately not used. It is a lossy encoding
-/// (`Users-alec-cursor-test`) that cannot be inverted, since a hyphen in a real
-/// directory name is indistinguishable from a separator, so un-collapsing it
-/// yields `/Users/alec/cursor/test` for a directory actually named
-/// `cursor-test`. A wrong cwd is worse than none, and the SQLite enrichment can
-/// supply the real path from `workspaceIdentifier`.
 fn cursor_session_cwd(content: &str, children: &[(PathBuf, String)]) -> Option<String> {
     let mut absolute: Vec<PathBuf> = Vec::new();
     for transcript in std::iter::once(content).chain(children.iter().map(|(_, body)| body.as_str()))
@@ -1525,7 +1470,6 @@ fn cursor_session_cwd(content: &str, children: &[(PathBuf, String)]) -> Option<S
     common_parent_dir(&absolute)
 }
 
-/// The deepest directory containing every one of the given absolute paths.
 fn common_parent_dir(paths: &[PathBuf]) -> Option<String> {
     let mut dirs = paths
         .iter()
@@ -1555,14 +1499,6 @@ fn common_parent_dir(paths: &[PathBuf]) -> Option<String> {
     })
 }
 
-/// Find which parent prompt delegated a given sub-agent transcript.
-///
-/// A `Task` call records no child id, but Cursor seeds the child's first user
-/// message with the `Task` prompt wrapped in `<timestamp>` and `<user_query>`
-/// metadata, so the prompt text appears verbatim inside it. Matching on
-/// containment recovered all eight parent-child pairs on a real session with no
-/// ambiguity. Falling back to the caller's current index keeps a session that
-/// changes this shape merely imprecise rather than broken.
 fn cursor_delegating_prompt_index(
     child_content: &str,
     delegations: &[(usize, String)],
@@ -1577,21 +1513,6 @@ fn cursor_delegating_prompt_index(
         .map(|(index, _)| *index)
 }
 
-/// Read the clock out of Cursor's user message wrapper.
-///
-/// Cursor writes no timestamp fields anywhere in a transcript. The one clock it
-/// does record is inside the wrapper on each user message:
-///
-/// ```text
-/// <timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>
-/// ```
-///
-/// Resolution is one minute, so several turns commonly share a value. Checked
-/// against `state.vscdb`, where the matching bubble records `createdAt` of
-/// `2026-08-08T03:11:58.512Z` against this parsing to `03:12:00Z`, so the value
-/// is right and simply rounded. The database is the better source when a
-/// consumer can reach it, but `agent-session` cannot, and without this every
-/// Cursor tool event is dropped by anything that requires a timestamp.
 fn cursor_wrapper_ts_ms(text: &str) -> Option<i64> {
     const OPEN: &str = "<timestamp>";
     const CLOSE: &str = "</timestamp>";
@@ -1615,21 +1536,6 @@ fn cursor_wrapper_ts_ms(text: &str) -> Option<i64> {
     Some(naive.and_utc().timestamp_millis() - offset_hours * 3_600_000)
 }
 
-/// Strip Cursor's user message wrapper.
-///
-/// Every user record Cursor writes, in parent and sub-agent transcripts alike,
-/// wraps what the person actually typed:
-///
-/// ```text
-/// <timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>
-/// <user_query>
-/// Create hello.py that prints Hello
-/// </user_query>
-/// ```
-///
-/// Without unwrapping, every prompt preview in `top` and in reports shows the
-/// timestamp header rather than the prompt. Text with no wrapper is returned
-/// unchanged, so this is safe if the format shifts.
 fn cursor_user_query(text: &str) -> String {
     const OPEN: &str = "<user_query>";
     const CLOSE: &str = "</user_query>";
@@ -1645,7 +1551,6 @@ fn cursor_user_query(text: &str) -> String {
     inner.trim().to_string()
 }
 
-/// The text of the first user record in a transcript.
 fn cursor_first_user_text(content: &str) -> Option<String> {
     content.lines().find_map(|line| {
         let record = serde_json::from_str::<Value>(line.trim()).ok()?;
@@ -1655,7 +1560,6 @@ fn cursor_first_user_text(content: &str) -> Option<String> {
     })
 }
 
-/// The `tool_use` parts of a Cursor message record.
 fn cursor_tool_uses(record: &Value) -> Vec<&Value> {
     record
         .get("message")
@@ -1670,12 +1574,6 @@ fn cursor_tool_uses(record: &Value) -> Vec<&Value> {
         .unwrap_or_default()
 }
 
-/// Turn one `tool_use` part into a `ToolEvent`.
-///
-/// Cursor's tool vocabulary isn't fixed. Two machines on the same version showed
-/// fifteen names with little overlap, tracking which features each person used,
-/// so an unrecognised name has to produce an event in the catch-all category
-/// rather than being dropped.
 fn cursor_push_tool_event(
     part: &Value,
     acc: &mut SessionAccumulator,
@@ -1695,9 +1593,7 @@ fn cursor_push_tool_event(
     acc.add_tool(name);
     let event = tool_event_from_input(
         acc.cwd.as_deref(),
-        // Inherited from the turn's user message wrapper, the only clock the
-        // transcript has. Cursor's tool_use parts carry only type, name and
-        // input, so there is still no call id.
+        // Inherited from the turn's wrapper. Cursor records no call id.
         ts_ms,
         prompt_index,
         name,
@@ -1711,7 +1607,6 @@ fn cursor_push_tool_event(
     events.tools.push(event);
 }
 
-/// Join the `text` parts of a Cursor message record.
 fn cursor_text_of(record: &Value) -> String {
     let Some(parts) = record
         .get("message")
@@ -3098,28 +2993,12 @@ fn extract_path_groups(
     groups.into_iter().filter(|v| v != "none").collect()
 }
 
-/// A token in a position where the command has already told us a path belongs.
-///
-/// `cp`, `mv`, `rm`, `touch`, `tee`, a redirection target, and the operands
-/// after a `find` root or a `sed`/`grep` expression are all path positions by
-/// definition, so anything that survives the shared rejections below is a path.
-/// Requiring a known file extension on top of that loses real work: `rm
-/// build.sh`, `mv notes.txt archive.txt` and `rm Dockerfile` all recorded
-/// nothing, which under-reports file activity for any project not written in
-/// the handful of languages the extension list happens to name.
 fn plausible_path_operand(part: &str) -> bool {
     let part = part.trim_matches(['"', '\'']);
-    // A bare number in operand position is a file descriptor, not a file. The
-    // tokenizer splits `cat x 2>&1` into `x` and `2` and `>&1`, so without this
-    // every redirected command records a read of a file called "2".
+    // A bare number here is a file descriptor: `cat x 2>&1` splits out a lone `2`.
     !part.is_empty() && !part.chars().all(|c| c.is_ascii_digit()) && !definitely_not_a_path(part)
 }
 
-/// A token found by scanning a whole command, where it could be anything.
-///
-/// Here the extension check earns its place: without it `curl example.com` or a
-/// bare version like `1.2.3` would register as paths. Evidence of being a path
-/// is required, either a separator or a recognised extension.
 fn plausible_path_token(part: &str) -> bool {
     let part = part.trim_matches(['"', '\'']);
     if definitely_not_a_path(part) {
@@ -3137,9 +3016,6 @@ fn plausible_path_token(part: &str) -> bool {
         .contains(&suffix)
 }
 
-/// Shapes that are never a path, whatever position they appear in: flags, shell
-/// variables, URLs, git refs and ranges, sed expressions, and anything carrying
-/// whitespace or shell metacharacters.
 fn definitely_not_a_path(part: &str) -> bool {
     let part = part.trim_matches(['"', '\'']);
     let lower = part.to_ascii_lowercase();
@@ -3649,9 +3525,7 @@ mod tests {
     use serde_json::json;
     use std::time::UNIX_EPOCH;
 
-    /// A Cursor parent transcript that both delegates and works directly.
-    /// Sessions mix the two per turn, so a fixture with only one pattern passes
-    /// while the other silently breaks.
+    // A parent transcript that both delegates and works directly, since Cursor mixes both.
     fn cursor_parent_fixture() -> String {
         [
             // Cursor wraps every user message, parent and child alike.
@@ -3665,12 +3539,10 @@ mod tests {
         .join("\n")
     }
 
-    /// The child spawned by the `Task` call above. All of the first turn's real
-    /// work lives here, none of it in the parent.
+    // The child spawned by the Task call above; all of that turn's real work is here.
     fn cursor_subagent_fixture() -> String {
         [
-            // Cursor seeds the child's first message with the Task prompt
-            // wrapped in metadata, which is the only link back to the parent.
+            // The Task prompt in the child's first message is the only link to the parent.
             r#"{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>\n<user_query>\nmake it\n</user_query>"}]}}"#,
             r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/repo/hello.py","contents":"print(1)\n"}},{"type":"text","text":"written"}]}}"#,
             r#"{"type":"turn_ended","status":"success"}"#,
@@ -3826,10 +3698,7 @@ mod tests {
             session.events.tools[0].command,
             "cd /repo && mv hello.py greet.py"
         );
-        // command_name is the first token of a compound command, so Cursor's
-        // habit of prefixing with cd surfaces as "cd" rather than "mv". That is
-        // pre-existing behaviour shared with the other agents, not Cursor
-        // specific, so it stays as is here.
+        // command_name is the first token of a compound command, so `cd` wins here.
         assert_eq!(session.events.tools[0].command_name, "cd");
         assert!(
             !session.events.tools[0].process_chain.is_empty(),
@@ -3839,9 +3708,7 @@ mod tests {
 
     #[test]
     fn cursor_shell_working_directory_resolves_relative_paths() {
-        // Cursor names this key working_directory, where Claude and Codex use
-        // workdir or cwd. Without it the relative paths below resolve against
-        // nothing and the session records no files at all.
+        // Cursor names this working_directory where Claude and Codex use workdir.
         let content = [
             r#"{"role":"user","message":{"content":[{"type":"text","text":"move it"}]}}"#,
             r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"mv hello.py archive/greet.py","working_directory":"/repo","description":"move"}}]}}"#,
@@ -3946,7 +3813,7 @@ mod tests {
         .join("\n");
         let session = parse_session_content(
             AGENT_CURSOR,
-            &PathBuf::from("/tmp/projects/Users-alec-cursor-test/agent-transcripts/a/a.jsonl"),
+            &PathBuf::from("/tmp/projects/Users-user-cursor-test/agent-transcripts/a/a.jsonl"),
             UNIX_EPOCH,
             &bare,
         )

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1330,20 +1330,29 @@ fn parse_cursor_jsonl(
     let mut events = SessionEvents::default();
     let mut current_prompt_index = 0usize;
 
+    let mut delegations = Vec::new();
     cursor_absorb_transcript(
         content,
         CursorScope::Parent,
         &mut acc,
         &mut events,
         &mut current_prompt_index,
+        &mut delegations,
     );
     for (_, child_content) in children {
+        // Attribute the child's work to the prompt that delegated it, not to
+        // whichever prompt happened to be last. A session that delegates early
+        // and works directly later would otherwise pin all delegated file
+        // activity on the final prompt.
+        let mut index = cursor_delegating_prompt_index(child_content, &delegations)
+            .unwrap_or(current_prompt_index);
         cursor_absorb_transcript(
             child_content,
             CursorScope::Subagent,
             &mut acc,
             &mut events,
-            &mut current_prompt_index,
+            &mut index,
+            &mut Vec::new(),
         );
     }
 
@@ -1369,6 +1378,7 @@ fn cursor_absorb_transcript(
     acc: &mut SessionAccumulator,
     events: &mut SessionEvents,
     current_prompt_index: &mut usize,
+    delegations: &mut Vec<(usize, String)>,
 ) {
     for line in content.lines() {
         let line = line.trim();
@@ -1393,6 +1403,16 @@ fn cursor_absorb_transcript(
             }
             Some("assistant") => {
                 for part in cursor_tool_uses(&record) {
+                    if scope == CursorScope::Parent
+                        && part.get("name").and_then(Value::as_str) == Some("Task")
+                        && let Some(prompt) = part
+                            .get("input")
+                            .and_then(|input| input.get("prompt"))
+                            .and_then(Value::as_str)
+                            .filter(|prompt| !prompt.trim().is_empty())
+                    {
+                        delegations.push((*current_prompt_index, prompt.trim().to_string()));
+                    }
                     cursor_push_tool_event(part, acc, events, *current_prompt_index);
                 }
                 let text = cursor_text_of(&record);
@@ -1420,6 +1440,38 @@ fn cursor_absorb_transcript(
             _ => {}
         }
     }
+}
+
+/// Find which parent prompt delegated a given sub-agent transcript.
+///
+/// A `Task` call records no child id, but Cursor seeds the child's first user
+/// message with the `Task` prompt wrapped in `<timestamp>` and `<user_query>`
+/// metadata, so the prompt text appears verbatim inside it. Matching on
+/// containment recovered all eight parent-child pairs on a real session with no
+/// ambiguity. Falling back to the caller's current index keeps a session that
+/// changes this shape merely imprecise rather than broken.
+fn cursor_delegating_prompt_index(
+    child_content: &str,
+    delegations: &[(usize, String)],
+) -> Option<usize> {
+    if delegations.is_empty() {
+        return None;
+    }
+    let opening = cursor_first_user_text(child_content)?;
+    delegations
+        .iter()
+        .find(|(_, prompt)| opening.contains(prompt.as_str()))
+        .map(|(index, _)| *index)
+}
+
+/// The text of the first user record in a transcript.
+fn cursor_first_user_text(content: &str) -> Option<String> {
+    content.lines().find_map(|line| {
+        let record = serde_json::from_str::<Value>(line.trim()).ok()?;
+        (record.get("role").and_then(Value::as_str) == Some("user"))
+            .then(|| cursor_text_of(&record))
+            .filter(|text| !text.is_empty())
+    })
 }
 
 /// The `tool_use` parts of a Cursor message record.
@@ -3396,7 +3448,9 @@ mod tests {
     /// work lives here, none of it in the parent.
     fn cursor_subagent_fixture() -> String {
         [
-            r#"{"role":"user","message":{"content":[{"type":"text","text":"make it"}]}}"#,
+            // Cursor seeds the child's first message with the Task prompt
+            // wrapped in metadata, which is the only link back to the parent.
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>\n<user_query>\nmake it\n</user_query>"}]}}"#,
             r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/repo/hello.py","contents":"print(1)\n"}},{"type":"text","text":"written"}]}}"#,
             r#"{"type":"turn_ended","status":"success"}"#,
         ]
@@ -3582,6 +3636,42 @@ mod tests {
             .expect("rename");
         assert_eq!(renamed.path, "/repo/archive/greet.py");
         assert_eq!(renamed.previous_path.as_deref(), Some("/repo/hello.py"));
+    }
+
+    #[test]
+    fn cursor_subagent_work_folds_into_the_delegating_prompt() {
+        let children = vec![(
+            PathBuf::from("/tmp/subagents/child.jsonl"),
+            cursor_subagent_fixture(),
+        )];
+        let session = parse_cursor_jsonl(
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &cursor_parent_fixture(),
+            &children,
+        )
+        .expect("session");
+
+        // Counts span parent and children. Reading the parent alone would miss
+        // the Write entirely, since that turn only issued a Task.
+        assert_eq!(session.tools.get("Task"), Some(&1));
+        assert_eq!(session.tools.get("Delete"), Some(&1));
+        assert_eq!(session.tools.get("Write"), Some(&1));
+        assert_eq!(session.files.get("/repo/hello.py"), Some(&2));
+
+        let tool_at = |name: &str| {
+            session
+                .events
+                .tools
+                .iter()
+                .find(|tool| tool.tool_name == name)
+                .unwrap_or_else(|| panic!("{name} missing"))
+                .prompt_index
+        };
+        // The child ran under prompt 0, which delegated. Without the Task
+        // prompt match its work would land on prompt 1, the last one seen.
+        assert_eq!(tool_at("Write"), 0);
+        assert_eq!(tool_at("Delete"), 1);
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1407,7 +1407,10 @@ fn cursor_absorb_transcript(
                 .get("status")
                 .and_then(Value::as_str)
                 .is_some_and(|status| {
-                    matches!(status, "error" | "failed" | "fail" | "cancelled" | "canceled")
+                    matches!(
+                        status,
+                        "error" | "failed" | "fail" | "cancelled" | "canceled"
+                    )
                 });
             if failed {
                 for tool in events.tools.iter_mut().skip(turn_start) {
@@ -1450,13 +1453,7 @@ fn cursor_absorb_transcript(
                     {
                         delegations.push((*current_prompt_index, prompt.trim().to_string()));
                     }
-                    cursor_push_tool_event(
-                        part,
-                        acc,
-                        events,
-                        *current_prompt_index,
-                        current_ts_ms,
-                    );
+                    cursor_push_tool_event(part, acc, events, *current_prompt_index, current_ts_ms);
                 }
                 let text = cursor_text_of(&record);
                 if !text.is_empty() {
@@ -1614,8 +1611,7 @@ fn cursor_wrapper_ts_ms(text: &str) -> Option<i64> {
         }
         None => (raw, 0),
     };
-    let naive =
-        chrono::NaiveDateTime::parse_from_str(stamp, "%A, %b %d, %Y, %I:%M %p").ok()?;
+    let naive = chrono::NaiveDateTime::parse_from_str(stamp, "%A, %b %d, %Y, %I:%M %p").ok()?;
     Some(naive.and_utc().timestamp_millis() - offset_hours * 3_600_000)
 }
 
@@ -1687,7 +1683,11 @@ fn cursor_push_tool_event(
     prompt_index: usize,
     ts_ms: Option<i64>,
 ) {
-    let Some(name) = part.get("name").and_then(Value::as_str).filter(|n| !n.is_empty()) else {
+    let Some(name) = part
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|n| !n.is_empty())
+    else {
         return;
     };
     let input = part.get("input").cloned().unwrap_or(Value::Null);
@@ -3645,9 +3645,6 @@ mod tests {
         .join("\n")
     }
 
-
-
-
     #[test]
     fn cursor_transcript_counts_prompts_and_responses() {
         let session = parse_session_content(
@@ -3806,7 +3803,6 @@ mod tests {
             "Shell events must carry a process chain"
         );
     }
-
 
     #[test]
     fn cursor_shell_working_directory_resolves_relative_paths() {

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1383,6 +1383,8 @@ fn cursor_absorb_transcript(
     current_prompt_index: &mut usize,
     delegations: &mut Vec<(usize, String)>,
 ) {
+    // Tools recorded since the last turn marker, so a failed turn can mark them.
+    let mut turn_start = events.tools.len();
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -1393,6 +1395,26 @@ fn cursor_absorb_transcript(
         let Ok(record) = serde_json::from_str::<Value>(line) else {
             continue;
         };
+
+        // Cursor records no per-tool result, so the only outcome signal is the
+        // turn marker. A failed turn marks every tool call it contained, which
+        // is the same shape as the other agents' tool_result handling, just at
+        // turn granularity rather than per call.
+        if record.get("type").and_then(Value::as_str) == Some("turn_ended") {
+            let failed = record
+                .get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| {
+                    matches!(status, "error" | "failed" | "fail" | "cancelled" | "canceled")
+                });
+            if failed {
+                for tool in events.tools.iter_mut().skip(turn_start) {
+                    tool.status = "fail".to_string();
+                }
+            }
+            turn_start = events.tools.len();
+            continue;
+        }
 
         match record.get("role").and_then(Value::as_str) {
             Some("user") if scope == CursorScope::Parent => {
@@ -3566,6 +3588,7 @@ mod tests {
 
 
 
+
     #[test]
     fn cursor_transcript_counts_prompts_and_responses() {
         let session = parse_session_content(
@@ -3719,6 +3742,10 @@ mod tests {
         // pre-existing behaviour shared with the other agents, not Cursor
         // specific, so it stays as is here.
         assert_eq!(session.events.tools[0].command_name, "cd");
+        assert!(
+            !session.events.tools[0].process_chain.is_empty(),
+            "Shell events must carry a process chain"
+        );
     }
 
 
@@ -3769,6 +3796,9 @@ mod tests {
         assert_eq!(session.tools.get("Task"), Some(&1));
         assert_eq!(session.tools.get("Delete"), Some(&1));
         assert_eq!(session.tools.get("Write"), Some(&1));
+        // Exactly once: two calls in the parent, one in the child, no more.
+        assert_eq!(session.events.tools.len(), 3);
+        assert_eq!(session.tools.values().sum::<usize>(), 3);
         assert_eq!(session.files.get("/repo/hello.py"), Some(&2));
 
         let tool_at = |name: &str| {
@@ -3857,10 +3887,23 @@ mod tests {
         assert_eq!(session.events.prompts.len(), 1);
         assert_eq!(session.tools.get("Read"), Some(&1));
 
-        // A transcript holding nothing but a turn marker has no prompt, no
-        // tools and no tokens, so it yields None. That is the same treatment
-        // every other agent gets for an empty session, and it keeps abandoned
-        // sessions out of `top` rather than showing blank rows.
+        // A single record with no tool calls is still a real session and comes
+        // back valid, just with nothing in it.
+        let one_prompt =
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"just asking"}]}}"#;
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            one_prompt,
+        )
+        .expect("a lone prompt is still a session");
+        assert!(session.events.tools.is_empty());
+        assert_eq!(session.prompt_preview.as_deref(), Some("just asking"));
+
+        // A fragment with no user message at all is a different thing: nothing
+        // was asked, so there is no session to report. Same treatment every
+        // other agent gets, and it keeps blank rows out of `top`.
         for empty in [
             "",
             "\n\n",
@@ -3897,6 +3940,42 @@ mod tests {
         )
         .expect("session");
         assert_eq!(session.tools.get("Write"), Some(&1));
+    }
+
+    #[test]
+    fn cursor_failed_turn_marks_its_tool_calls() {
+        let content = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"first"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/repo/ok.rs"}}]}}"#,
+            r#"{"type":"turn_ended","status":"success"}"#,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"second"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Shell","input":{"command":"cat /repo/missing.rs"}}]}}"#,
+            r#"{"type":"turn_ended","status":"error","error":"command failed"}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &content,
+        )
+        .expect("session");
+
+        let status_of = |name: &str| {
+            session
+                .events
+                .tools
+                .iter()
+                .find(|tool| tool.tool_name == name)
+                .unwrap_or_else(|| panic!("{name} missing"))
+                .status
+                .clone()
+        };
+        // Cursor has no per-tool results, so a failed turn is the only outcome
+        // signal there is, and it applies to that turn's calls only.
+        assert_eq!(status_of("Read"), "observed");
+        assert_eq!(status_of("Shell"), "fail");
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1385,6 +1385,8 @@ fn cursor_absorb_transcript(
 ) {
     // Tools recorded since the last turn marker, so a failed turn can mark them.
     let mut turn_start = events.tools.len();
+    // Clock carried forward from the most recent user message wrapper.
+    let mut current_ts_ms: Option<i64> = None;
     for line in content.lines() {
         let line = line.trim();
         if line.is_empty() {
@@ -1417,12 +1419,22 @@ fn cursor_absorb_transcript(
         }
 
         match record.get("role").and_then(Value::as_str) {
-            Some("user") if scope == CursorScope::Parent => {
-                let text = cursor_user_query(&cursor_text_of(&record));
-                if !text.is_empty() {
-                    *current_prompt_index = events.upsert_prompt(None, &text, Vec::new());
-                    if acc.prompt_preview.is_none() {
-                        acc.prompt_preview = Some(truncate_clean(&text, 180));
+            Some("user") => {
+                let raw = cursor_text_of(&record);
+                // The wrapper's timestamp is the only clock in the transcript,
+                // and sub-agent messages carry one too, so read it in both
+                // scopes even though only the parent contributes prompts.
+                if let Some(ts) = cursor_wrapper_ts_ms(&raw) {
+                    current_ts_ms = Some(ts);
+                }
+                if scope == CursorScope::Parent {
+                    let text = cursor_user_query(&raw);
+                    if !text.is_empty() {
+                        *current_prompt_index =
+                            events.upsert_prompt(current_ts_ms, &text, Vec::new());
+                        if acc.prompt_preview.is_none() {
+                            acc.prompt_preview = Some(truncate_clean(&text, 180));
+                        }
                     }
                 }
             }
@@ -1438,12 +1450,18 @@ fn cursor_absorb_transcript(
                     {
                         delegations.push((*current_prompt_index, prompt.trim().to_string()));
                     }
-                    cursor_push_tool_event(part, acc, events, *current_prompt_index);
+                    cursor_push_tool_event(
+                        part,
+                        acc,
+                        events,
+                        *current_prompt_index,
+                        current_ts_ms,
+                    );
                 }
                 let text = cursor_text_of(&record);
                 if !text.is_empty() {
                     events.llm_responses.push(LlmResponse {
-                        ts_ms: None,
+                        ts_ms: current_ts_ms,
                         prompt_index: *current_prompt_index,
                         // Model, tokens, and timestamps live in state.vscdb, not
                         // the transcript. The SQLite enrichment fills them in.
@@ -1562,6 +1580,45 @@ fn cursor_delegating_prompt_index(
         .map(|(index, _)| *index)
 }
 
+/// Read the clock out of Cursor's user message wrapper.
+///
+/// Cursor writes no timestamp fields anywhere in a transcript. The one clock it
+/// does record is inside the wrapper on each user message:
+///
+/// ```text
+/// <timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>
+/// ```
+///
+/// Resolution is one minute, so several turns commonly share a value. Checked
+/// against `state.vscdb`, where the matching bubble records `createdAt` of
+/// `2026-08-08T03:11:58.512Z` against this parsing to `03:12:00Z`, so the value
+/// is right and simply rounded. The database is the better source when a
+/// consumer can reach it, but `agent-session` cannot, and without this every
+/// Cursor tool event is dropped by anything that requires a timestamp.
+fn cursor_wrapper_ts_ms(text: &str) -> Option<i64> {
+    const OPEN: &str = "<timestamp>";
+    const CLOSE: &str = "</timestamp>";
+    let start = text.find(OPEN)? + OPEN.len();
+    let rest = &text[start..];
+    let raw = rest[..rest.find(CLOSE)?].trim();
+
+    // Trailing "(UTC-5)" gives the offset the local time was written in.
+    let (stamp, offset_hours) = match raw.rfind("(UTC") {
+        Some(index) => {
+            let hours = raw[index + 4..]
+                .trim_end_matches(')')
+                .trim()
+                .parse::<i64>()
+                .unwrap_or(0);
+            (raw[..index].trim(), hours)
+        }
+        None => (raw, 0),
+    };
+    let naive =
+        chrono::NaiveDateTime::parse_from_str(stamp, "%A, %b %d, %Y, %I:%M %p").ok()?;
+    Some(naive.and_utc().timestamp_millis() - offset_hours * 3_600_000)
+}
+
 /// Strip Cursor's user message wrapper.
 ///
 /// Every user record Cursor writes, in parent and sub-agent transcripts alike,
@@ -1628,6 +1685,7 @@ fn cursor_push_tool_event(
     acc: &mut SessionAccumulator,
     events: &mut SessionEvents,
     prompt_index: usize,
+    ts_ms: Option<i64>,
 ) {
     let Some(name) = part.get("name").and_then(Value::as_str).filter(|n| !n.is_empty()) else {
         return;
@@ -1637,9 +1695,10 @@ fn cursor_push_tool_event(
     acc.add_tool(name);
     let event = tool_event_from_input(
         acc.cwd.as_deref(),
-        // Cursor records no timestamps in the transcript, and its tool_use parts
-        // carry only type, name and input, so there is no call id either.
-        None,
+        // Inherited from the turn's user message wrapper, the only clock the
+        // transcript has. Cursor's tool_use parts carry only type, name and
+        // input, so there is still no call id.
+        ts_ms,
         prompt_index,
         name,
         &input,
@@ -3976,6 +4035,49 @@ mod tests {
         // signal there is, and it applies to that turn's calls only.
         assert_eq!(status_of("Read"), "observed");
         assert_eq!(status_of("Shell"), "fail");
+    }
+
+    #[test]
+    fn cursor_wrapper_timestamp_becomes_the_event_clock() {
+        // Cursor writes no timestamp fields anywhere. The wrapper on each user
+        // message is the only clock, and without it every consumer that
+        // requires ts_ms drops all Cursor events. agentvis is one of those.
+        let content = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"<timestamp>Friday, Aug 7, 2026, 10:12 PM (UTC-5)</timestamp>\n<user_query>\ngo\n</user_query>"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"text","text":"reading it"},{"type":"tool_use","name":"Read","input":{"path":"/repo/a.rs"}}]}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &content,
+        )
+        .expect("session");
+
+        // 10:12 PM at UTC-5 is 03:12 UTC the next day. Cross-checked against
+        // state.vscdb, where the matching bubble records 03:11:58.512Z, so the
+        // value is correct and simply rounded to the minute.
+        const EXPECTED_MS: i64 = 1_786_158_720_000;
+        assert_eq!(session.events.prompts[0].ts_ms, Some(EXPECTED_MS));
+        assert_eq!(session.events.tools[0].ts_ms, Some(EXPECTED_MS));
+        assert_eq!(session.events.llm_responses[0].ts_ms, Some(EXPECTED_MS));
+
+        // A message with no wrapper leaves the clock unset rather than guessing.
+        let bare = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"no wrapper here"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/repo/b.rs"}}]}}"#,
+        ]
+        .join("\n");
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &bare,
+        )
+        .expect("session");
+        assert_eq!(session.events.tools[0].ts_ms, None);
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -3112,9 +3112,7 @@ fn plausible_path_operand(part: &str) -> bool {
     // A bare number in operand position is a file descriptor, not a file. The
     // tokenizer splits `cat x 2>&1` into `x` and `2` and `>&1`, so without this
     // every redirected command records a read of a file called "2".
-    !part.is_empty()
-        && !part.chars().all(|c| c.is_ascii_digit())
-        && !definitely_not_a_path(part)
+    !part.is_empty() && !part.chars().all(|c| c.is_ascii_digit()) && !definitely_not_a_path(part)
 }
 
 /// A token found by scanning a whole command, where it could be anything.
@@ -4589,7 +4587,6 @@ mod tests {
         assert_eq!(heredoc.paths[0].path, "src/real.rs");
     }
 
-
     #[test]
     fn shell_path_operands_are_not_limited_to_known_extensions() {
         let paths_of = |command: &str| {
@@ -4607,7 +4604,11 @@ mod tests {
             ("rm main.go", "/repo/main.go", "delete"),
             ("rm Dockerfile", "/repo/Dockerfile", "delete"),
             ("mv notes.txt archive.txt", "/repo/archive.txt", "rename"),
-            ("mv conf.yaml conf.bak.yaml", "/repo/conf.bak.yaml", "rename"),
+            (
+                "mv conf.yaml conf.bak.yaml",
+                "/repo/conf.bak.yaml",
+                "rename",
+            ),
             ("touch schema.sql", "/repo/schema.sql", "create"),
         ] {
             assert!(
@@ -4641,9 +4642,7 @@ mod tests {
         // numeric guard, every `2>&1` recorded a read of a file called "2".
         let redirected = paths_of("cat notes.txt 2>&1");
         assert!(
-            redirected
-                .iter()
-                .any(|(path, _)| path == "/repo/notes.txt"),
+            redirected.iter().any(|(path, _)| path == "/repo/notes.txt"),
             "the real file should still be recorded, got {redirected:?}"
         );
         assert!(

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1453,39 +1453,23 @@ fn cursor_push_tool_event(
         return;
     };
     let input = part.get("input").cloned().unwrap_or(Value::Null);
-    // Only Shell carries a command; everything else leaves these empty.
-    let command = input
-        .get("command")
-        .and_then(Value::as_str)
-        .unwrap_or_default()
-        .to_string();
 
     acc.add_tool(name);
-    events.tools.push(ToolEvent {
-        ts_ms: None,
+    let event = tool_event_from_input(
+        acc.cwd.as_deref(),
+        // Cursor records no timestamps in the transcript, and its tool_use parts
+        // carry only type, name and input, so there is no call id either.
+        None,
         prompt_index,
-        tool_name: name.to_string(),
-        category: tool_category(name, &command),
-        command_name: basename_from_command(&command),
-        effect: if command.is_empty() {
-            String::new()
-        } else {
-            command_effect(&command)
-        },
-        command,
-        process_chain: Vec::new(),
-        // Cursor writes no tool_result records. The only signal is turn-level
-        // turn_ended.status, so per-tool status stays unset rather than guessed.
-        status: String::new(),
-        path_groups: Vec::new(),
-        paths: Vec::new(),
-        domains: Vec::new(),
-        // Cursor's tool_use parts carry only type, name and input. No id.
-        call_id: None,
-        invoked_skill: String::new(),
-        skill: String::new(),
-        task_path: Vec::new(),
-    });
+        name,
+        &input,
+        None,
+        Vec::new(),
+    );
+    for path in &event.paths {
+        acc.add_file(&path.path);
+    }
+    events.tools.push(event);
 }
 
 /// Join the `text` parts of a Cursor message record.
@@ -1821,6 +1805,10 @@ fn extract_tool_paths(name: &str, input: &Value, command: &str, effect: &str) ->
         || lower.contains("patch")
     {
         "write"
+    } else if lower.contains("delete") {
+        // Cursor deletes files through a dedicated Delete tool rather than a
+        // patch or a shell rm, so without this the deletion records no path.
+        "delete"
     } else if is_shell {
         if effect == "read" { "read" } else { "write" }
     } else {
@@ -2163,6 +2151,17 @@ fn collect_path_fields(
                     let path = clean_path_token(path);
                     if !path.is_empty() {
                         out.insert(path, (access.to_string(), None));
+                    }
+                } else if matches!(key.as_str(), "paths" | "file_paths" | "filepaths")
+                    && let Some(items) = value.as_array()
+                {
+                    // Cursor's ReadLints takes a list rather than a single path.
+                    // Generic array recursion below never reaches bare strings.
+                    for item in items.iter().filter_map(Value::as_str) {
+                        let path = clean_path_token(item);
+                        if !path.is_empty() {
+                            out.insert(path, (access.to_string(), None));
+                        }
                     }
                 } else if value.is_object() || value.is_array() {
                     collect_path_fields(value, access, out);
@@ -3456,10 +3455,55 @@ mod tests {
         assert_eq!(named("ReadLints").category, "read");
         // An unfamiliar name still produces an event, in the catch-all category.
         assert_eq!(named("SomeToolWeHaveNeverSeen").category, "tool");
-        // Cursor has no per-tool result records and no tool call ids.
+        // Cursor has no tool call ids, and no tool_result records to upgrade a
+        // call's status, so every Cursor tool event stays "observed".
         assert!(named("Shell").call_id.is_none());
-        assert!(named("Shell").status.is_empty());
+        assert_eq!(named("Shell").status, "observed");
         assert_eq!(session.tools.get("Shell"), Some(&1));
+    }
+
+    #[test]
+    fn cursor_file_tools_map_to_access_kinds() {
+        let content = [
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"work"}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{"path":"/repo/a.rs"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Write","input":{"path":"/repo/b.rs","contents":"fn main() {}"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"StrReplace","input":{"path":"/repo/c.rs","old_string":"x","new_string":"y"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Delete","input":{"path":"/repo/d.rs"}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"ReadLints","input":{"paths":["/repo/e.rs","/repo/f.rs"]}}]}}"#,
+            r#"{"role":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"timeout","path":"/repo","-i":true}}]}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CURSOR,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &content,
+        )
+        .expect("session");
+
+        let access_of = |path: &str| {
+            session
+                .events
+                .tools
+                .iter()
+                .flat_map(|tool| tool.paths.iter())
+                .find(|candidate| candidate.path == path)
+                .unwrap_or_else(|| panic!("{path} missing"))
+                .access
+                .clone()
+        };
+        assert_eq!(access_of("/repo/a.rs"), "read");
+        assert_eq!(access_of("/repo/b.rs"), "write");
+        assert_eq!(access_of("/repo/c.rs"), "write");
+        assert_eq!(access_of("/repo/d.rs"), "delete");
+        // ReadLints takes a list, not a single path.
+        assert_eq!(access_of("/repo/e.rs"), "read");
+        assert_eq!(access_of("/repo/f.rs"), "read");
+        // Flag-shaped keys such as "-i" are not paths.
+        assert_eq!(access_of("/repo"), "read");
+        assert_eq!(session.files.get("/repo/d.rs"), Some(&1));
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -14,7 +14,7 @@ use crate::types::{
     AgentSession, LlmResponse, SessionCandidate, SessionDirStat, SessionEvents, TokenUsage,
     ToolEvent, ToolPath, UserPrompt,
 };
-use crate::{AGENT_CLAUDE, AGENT_CODEX, AGENT_GEMINI};
+use crate::{AGENT_CLAUDE, AGENT_CODEX, AGENT_CURSOR, AGENT_GEMINI};
 
 /// Discover all session files in the user's home directory.
 pub fn discover_session_files() -> Vec<SessionCandidate> {
@@ -30,6 +30,7 @@ pub fn discover_session_files_in_home(home: &Path) -> Vec<SessionCandidate> {
         (AGENT_CLAUDE, home.join(".claude/projects")),
         (AGENT_CODEX, home.join(".codex/sessions")),
         (AGENT_GEMINI, home.join(".gemini/tmp")),
+        (AGENT_CURSOR, home.join(".cursor/projects")),
     ];
     let mut out = Vec::new();
     for (agent, dir) in roots {
@@ -37,10 +38,11 @@ pub fn discover_session_files_in_home(home: &Path) -> Vec<SessionCandidate> {
             out.push(SessionCandidate {
                 agent,
                 path: path.to_path_buf(),
-                updated: meta.modified().unwrap_or(UNIX_EPOCH),
+                updated: candidate_updated(agent, path, meta),
             });
         });
     }
+    dedupe_cursor_candidates(&mut out);
     out
 }
 
@@ -50,10 +52,90 @@ pub fn discover_session_files_in_dir(agent: &'static str, dir: &Path) -> Vec<Ses
         out.push(SessionCandidate {
             agent,
             path: path.to_path_buf(),
-            updated: meta.modified().unwrap_or(UNIX_EPOCH),
+            updated: candidate_updated(agent, path, meta),
         });
     });
+    dedupe_cursor_candidates(&mut out);
     out
+}
+
+fn candidate_updated(agent: &str, path: &Path, meta: &fs::Metadata) -> SystemTime {
+    let updated = meta.modified().unwrap_or(UNIX_EPOCH);
+    if agent == AGENT_CURSOR {
+        cursor_candidate_updated(path, updated)
+    } else {
+        updated
+    }
+}
+
+/// A Cursor candidate is the parent transcript, but its session includes any
+/// `subagents/*.jsonl` siblings, so `updated` is the max mtime across all of
+/// them. This is what lets a child-only write invalidate the cached session.
+fn cursor_candidate_updated(path: &Path, parent_updated: SystemTime) -> SystemTime {
+    let mut updated = parent_updated;
+    let Some(subagents) = path.parent().map(|dir| dir.join("subagents")) else {
+        return updated;
+    };
+    let Ok(entries) = fs::read_dir(subagents) else {
+        return updated;
+    };
+    for entry in entries.flatten() {
+        if entry.path().extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+            && let Ok(meta) = entry.metadata()
+        {
+            updated = updated.max(meta.modified().unwrap_or(UNIX_EPOCH));
+        }
+    }
+    updated
+}
+
+/// One Cursor session can appear under both its real workspace directory and
+/// `empty-window` (a stale fork left behind when a window later opened a
+/// folder). Keep one candidate per composer id: a real workspace beats
+/// `empty-window`, then the newer file wins.
+fn dedupe_cursor_candidates(out: &mut Vec<SessionCandidate>) {
+    let mut best: BTreeMap<String, (bool, SystemTime, usize)> = BTreeMap::new();
+    let mut drop = vec![false; out.len()];
+    for (idx, candidate) in out.iter().enumerate() {
+        if candidate.agent != AGENT_CURSOR {
+            continue;
+        }
+        let Some(stem) = candidate.path.file_stem().and_then(|stem| stem.to_str()) else {
+            continue;
+        };
+        let rank = (
+            !cursor_is_empty_window(&candidate.path),
+            candidate.updated,
+            idx,
+        );
+        match best.get_mut(stem) {
+            None => {
+                best.insert(stem.to_string(), rank);
+            }
+            Some(entry) => {
+                if (rank.0, rank.1) > (entry.0, entry.1) {
+                    drop[entry.2] = true;
+                    *entry = rank;
+                } else {
+                    drop[idx] = true;
+                }
+            }
+        }
+    }
+    let mut drop = drop.into_iter();
+    out.retain(|_| !drop.next().unwrap_or_default());
+}
+
+fn cursor_is_empty_window(path: &Path) -> bool {
+    let mut previous = None;
+    for component in path.components() {
+        let name = component.as_os_str();
+        if name == "agent-transcripts" {
+            return previous.is_some_and(|project| project == "empty-window");
+        }
+        previous = Some(name);
+    }
+    false
 }
 
 /// Count sessions and bytes per agent directory.
@@ -65,6 +147,7 @@ pub fn count_session_dirs() -> Vec<SessionDirStat> {
         (AGENT_CLAUDE, home.join(".claude/projects")),
         (AGENT_CODEX, home.join(".codex/sessions")),
         (AGENT_GEMINI, home.join(".gemini/tmp")),
+        (AGENT_CURSOR, home.join(".cursor/projects")),
     ]
     .into_iter()
     .filter_map(|(agent, dir)| {
@@ -166,9 +249,34 @@ pub fn agent_source_for_path(path: &Path) -> Option<&'static str> {
         && path.extension().and_then(|ext| ext.to_str()) == Some("json")
     {
         Some(AGENT_GEMINI)
+    } else if value.contains("/.cursor/") && is_cursor_transcript(path) {
+        Some(AGENT_CURSOR)
     } else {
         None
     }
+}
+
+/// Cursor transcripts live under `agent-transcripts/`; other `.jsonl` files in
+/// a project directory (vendored dependencies under `canvases/`, for example)
+/// are not sessions. Matches parent and subagent transcripts alike, so process
+/// matching can classify any fd path Cursor holds open.
+fn is_cursor_transcript(path: &Path) -> bool {
+    path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
+        && path.to_string_lossy().contains("/agent-transcripts/")
+}
+
+/// Discovery emits one candidate per Cursor session: the parent transcript,
+/// whose file stem equals its directory name (`<composerId>/<composerId>.jsonl`).
+/// A `subagents/<childId>.jsonl` file never matches, so delegated runs cannot
+/// surface as standalone sessions or crowd the session cache's parse window;
+/// the parser folds them into the parent instead.
+fn is_cursor_parent_transcript(path: &Path) -> bool {
+    is_cursor_transcript(path)
+        && path.file_stem().is_some_and(|stem| {
+            path.parent()
+                .and_then(|dir| dir.file_name())
+                .is_some_and(|dir| dir == stem)
+        })
 }
 
 fn loose_agent_source_for_path(path: &Path) -> Option<&'static str> {
@@ -177,6 +285,8 @@ fn loose_agent_source_for_path(path: &Path) -> Option<&'static str> {
         Some(AGENT_CODEX)
     } else if value.contains("/claude/") && value.contains("projects") {
         Some(AGENT_CLAUDE)
+    } else if value.contains("/cursor/") && value.contains("agent-transcripts") {
+        Some(AGENT_CURSOR)
     } else {
         None
     }
@@ -188,6 +298,9 @@ pub fn fixture_session_path(agent: &str, home: &Path) -> Option<PathBuf> {
         AGENT_CLAUDE => Some(home.join(".claude/projects/test/session.jsonl")),
         AGENT_CODEX => Some(home.join(".codex/sessions/2026/06/02/session.jsonl")),
         AGENT_GEMINI => Some(home.join(".gemini/tmp/test/chats/session-test.json")),
+        AGENT_CURSOR => {
+            Some(home.join(".cursor/projects/test/agent-transcripts/session/session.jsonl"))
+        }
         _ => None,
     }
 }
@@ -1344,6 +1457,7 @@ fn is_agent_file_for(agent: &str, path: &Path) -> bool {
                     .is_some_and(|name| name.starts_with("session-"))
                 && path.to_string_lossy().contains("/chats/")
         }
+        AGENT_CURSOR => is_cursor_parent_transcript(path),
         _ => false,
     }
 }
@@ -3025,6 +3139,37 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::time::UNIX_EPOCH;
+
+    #[test]
+    fn cursor_paths_classify_but_only_parents_discover() {
+        let home = PathBuf::from("/home/dev");
+        let parent = home.join(".cursor/projects/repo/agent-transcripts/abc/abc.jsonl");
+        let subagent = home.join(".cursor/projects/repo/agent-transcripts/abc/subagents/def.jsonl");
+        let vendored = home.join(".cursor/projects/repo/canvases/node_modules/pkg/data.jsonl");
+
+        // Classification accepts any transcript path: process matching hands
+        // it arbitrary fd paths, children included.
+        assert_eq!(agent_source_for_path(&parent), Some(AGENT_CURSOR));
+        assert_eq!(agent_source_for_path(&subagent), Some(AGENT_CURSOR));
+        assert_eq!(agent_source_for_path(&vendored), None);
+
+        // Discovery emits parents only: stem must equal the directory name.
+        assert!(is_agent_file_for(AGENT_CURSOR, &parent));
+        assert!(!is_agent_file_for(AGENT_CURSOR, &subagent));
+        assert!(!is_agent_file_for(AGENT_CURSOR, &vendored));
+        assert!(!is_agent_file_for(
+            AGENT_CURSOR,
+            &home.join(".cursor/projects/repo/agent-transcripts/abc/other.jsonl")
+        ));
+
+        assert!(cursor_is_empty_window(
+            &home.join(".cursor/projects/empty-window/agent-transcripts/abc/abc.jsonl")
+        ));
+        assert!(!cursor_is_empty_window(&parent));
+
+        let fixture = fixture_session_path(AGENT_CURSOR, &home).expect("fixture");
+        assert!(is_agent_file_for(AGENT_CURSOR, &fixture));
+    }
 
     #[test]
     fn local_session_ids_keep_distinct_conversation_id() {

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -2242,7 +2242,7 @@ fn shell_segment_actions(
     while index < operands.len() {
         if is_redirection_token(&operands[index]) {
             if let Some(path) = operands.get(index + 1)
-                && plausible_path_token(path)
+                && plausible_path_operand(path)
             {
                 let access = if [">", ">>", "&>", "&>>"].contains(&operands[index].as_str()) {
                     "write"
@@ -2263,7 +2263,7 @@ fn shell_segment_actions(
     let paths = |items: &[String]| {
         items
             .iter()
-            .filter(|value| !value.starts_with('-') && plausible_path_token(value))
+            .filter(|value| !value.starts_with('-') && plausible_path_operand(value))
             .cloned()
             .collect::<Vec<_>>()
     };
@@ -2329,7 +2329,7 @@ fn shell_segment_actions(
                 }
                 if !script_seen {
                     script_seen = true;
-                } else if plausible_path_token(value) {
+                } else if plausible_path_operand(value) {
                     rows.push((
                         value.clone(),
                         if in_place { "write" } else { "read" }.into(),
@@ -2342,7 +2342,7 @@ fn shell_segment_actions(
             values
                 .iter()
                 .take_while(|value| !value.starts_with('-') && value.as_str() != "!")
-                .filter(|value| plausible_path_token(value))
+                .filter(|value| plausible_path_operand(value))
                 .cloned()
                 .map(|path| (path, "read".into(), None)),
         ),
@@ -2354,7 +2354,7 @@ fn shell_segment_actions(
                 }
                 if !expression_seen {
                     expression_seen = true;
-                } else if plausible_path_token(value) {
+                } else if plausible_path_operand(value) {
                     rows.push((value.clone(), "read".into(), None));
                 }
             }
@@ -3098,7 +3098,45 @@ fn extract_path_groups(
     groups.into_iter().filter(|v| v != "none").collect()
 }
 
+/// A token in a position where the command has already told us a path belongs.
+///
+/// `cp`, `mv`, `rm`, `touch`, `tee`, a redirection target, and the operands
+/// after a `find` root or a `sed`/`grep` expression are all path positions by
+/// definition, so anything that survives the shared rejections below is a path.
+/// Requiring a known file extension on top of that loses real work: `rm
+/// build.sh`, `mv notes.txt archive.txt` and `rm Dockerfile` all recorded
+/// nothing, which under-reports file activity for any project not written in
+/// the handful of languages the extension list happens to name.
+fn plausible_path_operand(part: &str) -> bool {
+    !definitely_not_a_path(part)
+}
+
+/// A token found by scanning a whole command, where it could be anything.
+///
+/// Here the extension check earns its place: without it `curl example.com` or a
+/// bare version like `1.2.3` would register as paths. Evidence of being a path
+/// is required, either a separator or a recognised extension.
 fn plausible_path_token(part: &str) -> bool {
+    let part = part.trim_matches(['"', '\'']);
+    if definitely_not_a_path(part) {
+        return false;
+    }
+    let suffix = Path::new(part)
+        .extension()
+        .and_then(|value| value.to_str())
+        .unwrap_or("");
+    part.contains('/')
+        || [
+            "rs", "py", "md", "json", "ts", "tsx", "toml", "lock", "js", "c", "h", "svg", "html",
+            "css",
+        ]
+        .contains(&suffix)
+}
+
+/// Shapes that are never a path, whatever position they appear in: flags, shell
+/// variables, URLs, git refs and ranges, sed expressions, and anything carrying
+/// whitespace or shell metacharacters.
+fn definitely_not_a_path(part: &str) -> bool {
     let part = part.trim_matches(['"', '\'']);
     let lower = part.to_ascii_lowercase();
     let components = part.split('/').collect::<Vec<_>>();
@@ -3129,18 +3167,9 @@ fn plausible_path_token(part: &str) -> bool {
         || part.chars().any(char::is_whitespace)
         || part.chars().any(|c| "{}()=;<>|`*?[]\"#$,:@^!".contains(c))
     {
-        return false;
+        return true;
     }
-    let suffix = Path::new(part)
-        .extension()
-        .and_then(|v| v.to_str())
-        .unwrap_or("");
-    part.contains('/')
-        || [
-            "rs", "py", "md", "json", "ts", "tsx", "toml", "lock", "js", "c", "h", "svg", "html",
-            "css",
-        ]
-        .contains(&suffix)
+    false
 }
 
 pub fn path_group(path: &str, project_root: &Path) -> String {
@@ -4556,6 +4585,75 @@ mod tests {
         );
         assert_eq!(heredoc.paths.len(), 1);
         assert_eq!(heredoc.paths[0].path, "src/real.rs");
+    }
+
+    #[test]
+    fn shell_path_operands_are_not_limited_to_known_extensions() {
+        let paths_of = |command: &str| {
+            shell_file_actions(command, &json!({"cwd": "/repo"}), 0)
+                .into_iter()
+                .map(|(path, access, _)| (path, access))
+                .collect::<Vec<_>>()
+        };
+
+        // A path operand is a path whatever it is called. Before this, only the
+        // fourteen extensions the list happened to name were recorded, so a Go,
+        // shell or SQL project got no file activity from its shell commands.
+        for (command, expected, access) in [
+            ("rm build.sh", "/repo/build.sh", "delete"),
+            ("rm main.go", "/repo/main.go", "delete"),
+            ("rm Dockerfile", "/repo/Dockerfile", "delete"),
+            ("mv notes.txt archive.txt", "/repo/archive.txt", "rename"),
+            ("mv conf.yaml conf.bak.yaml", "/repo/conf.bak.yaml", "rename"),
+            ("touch schema.sql", "/repo/schema.sql", "create"),
+        ] {
+            assert!(
+                paths_of(command)
+                    .iter()
+                    .any(|(path, kind)| path == expected && kind == access),
+                "{command} should record {expected} as {access}, got {:?}",
+                paths_of(command)
+            );
+        }
+
+        // The shared rejections still hold, so refs, ranges, globs, URLs and
+        // sed expressions do not become files.
+        for command in [
+            "rm origin/main",
+            "rm HEAD",
+            "rm *.log",
+            "rm https://example.com/x",
+            "rm s/foo/bar/g",
+            "rm $TARGET",
+            "rm -rf",
+        ] {
+            assert!(
+                paths_of(command).is_empty(),
+                "{command} should record nothing, got {:?}",
+                paths_of(command)
+            );
+        }
+    }
+
+    #[test]
+    fn scanned_command_tokens_still_need_evidence_of_being_a_path() {
+        // extract_path_groups walks every token of a command rather than a known
+        // path position, so there the extension check still earns its place. A
+        // bare hostname or version must not become a file.
+        let event = tool_event_from_input(
+            Some("/repo"),
+            Some(1),
+            0,
+            "exec_command",
+            &json!({"cmd": "curl example.com && echo 1.2.3"}),
+            None,
+            Vec::new(),
+        );
+        assert!(
+            event.path_groups.is_empty(),
+            "hostname and version should not become path groups, got {:?}",
+            event.path_groups
+        );
     }
 
     #[test]

--- a/agentsight-capture/src/binary_resolver.rs
+++ b/agentsight-capture/src/binary_resolver.rs
@@ -1032,6 +1032,7 @@ mod tests {
         assert_eq!(parse_crictl_pid(&json!({"info": {"pid": 0}})), None);
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn canonicalize_attach_path_resolves_proc_root_when_available() {
         assert_eq!(

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -1079,6 +1079,8 @@ pub fn write_cursor_state_db_for_test(home: &Path) {
         ('def00000-0000-0000-0000-000000000def', 'ws1', 1750000, NULL, 1),
         ('aaa00000-0000-0000-0000-000000000aaa', 'ws2', 1600000, 1650000, 0);
         INSERT INTO cursorDiskKV (key, value) VALUES
+        ('composerData:bbb00000-0000-0000-0000-000000000bbb',
+         '{"composerId":"bbb00000-0000-0000-0000-000000000bbb","modelConfig":{"modelName":"claude-4.6-sonnet-medium-thinking","maxMode":false}}'),
         ('composerData:abc00000-0000-0000-0000-000000000abc',
          '{"composerId":"abc00000-0000-0000-0000-000000000abc","modelConfig":{"modelName":"claude-sonnet-4-6","maxMode":false},"workspaceIdentifier":{"uri":{"fsPath":"/work/repo"}}}'),
         ('composerData:aaa00000-0000-0000-0000-000000000aaa',
@@ -1235,6 +1237,38 @@ mod tests {
                 .map(|usage| usage.total_tokens),
             Some(150)
         );
+    }
+
+    #[test]
+    fn cursor_enrichment_reads_model_when_header_row_is_missing() {
+        // Real installs have composers with composerData but no
+        // composerHeaders row. The model must still come through, and the
+        // timestamps must stay on their transcript-derived fallbacks.
+        let temp = tempfile::tempdir().unwrap();
+        write_cursor_state_db_for_test(temp.path());
+        let transcripts = temp
+            .path()
+            .join(".cursor/projects/repo/agent-transcripts/bbb00000-0000-0000-0000-000000000bbb");
+        fs::create_dir_all(&transcripts).unwrap();
+        let parent = transcripts.join("bbb00000-0000-0000-0000-000000000bbb.jsonl");
+        fs::write(
+            &parent,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"check the build"}]}}"#,
+        )
+        .unwrap();
+
+        let parsed = agent_session::parse_session_path(&parent).expect("parsed");
+        let mut sessions = vec![parsed.clone()];
+        enrich_cursor_sessions_in_home(temp.path(), &mut sessions);
+
+        assert_eq!(
+            sessions[0].model.as_deref(),
+            Some("claude-4.6-sonnet-medium-thinking")
+        );
+        assert_eq!(sessions[0].start_timestamp_ms, parsed.start_timestamp_ms);
+        assert_eq!(sessions[0].end_timestamp_ms, parsed.end_timestamp_ms);
+        assert_eq!(sessions[0].last_message_at, parsed.last_message_at);
+        assert_eq!(sessions[0].usage.total_tokens, parsed.usage.total_tokens);
     }
 
     #[test]

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -901,6 +901,78 @@ mod tests {
     }
 
     #[test]
+    fn cursor_discovery_emits_parent_candidates_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let project = temp.path().join(".cursor/projects/repo");
+        let transcripts = project.join("agent-transcripts/abc");
+        fs::create_dir_all(transcripts.join("subagents")).unwrap();
+        fs::create_dir_all(project.join("canvases/node_modules/pkg")).unwrap();
+        fs::write(transcripts.join("abc.jsonl"), "{}\n").unwrap();
+        fs::write(transcripts.join("subagents/def.jsonl"), "{}\n").unwrap();
+        fs::write(project.join("canvases/node_modules/pkg/data.jsonl"), "{}\n").unwrap();
+
+        let candidates: Vec<_> = agent_session::discover_session_files_in_home(temp.path())
+            .into_iter()
+            .filter(|candidate| candidate.agent == agent_session::AGENT_CURSOR)
+            .collect();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].path, transcripts.join("abc.jsonl"));
+    }
+
+    #[test]
+    fn cursor_candidate_updated_tracks_subagent_writes() {
+        let temp = tempfile::tempdir().unwrap();
+        let transcripts = temp
+            .path()
+            .join(".cursor/projects/repo/agent-transcripts/abc");
+        fs::create_dir_all(transcripts.join("subagents")).unwrap();
+        fs::write(transcripts.join("abc.jsonl"), "{}\n").unwrap();
+        let child = transcripts.join("subagents/def.jsonl");
+        fs::write(&child, "{}\n").unwrap();
+
+        // Bump only the child's mtime well past the parent's.
+        let bumped = std::time::SystemTime::now() + std::time::Duration::from_secs(120);
+        let handle = fs::File::options().write(true).open(&child).unwrap();
+        handle.set_modified(bumped).unwrap();
+
+        let candidates: Vec<_> = agent_session::discover_session_files_in_home(temp.path())
+            .into_iter()
+            .filter(|candidate| candidate.agent == agent_session::AGENT_CURSOR)
+            .collect();
+
+        assert_eq!(candidates.len(), 1);
+        let parent_mtime = fs::metadata(transcripts.join("abc.jsonl"))
+            .unwrap()
+            .modified()
+            .unwrap();
+        assert!(candidates[0].updated > parent_mtime);
+    }
+
+    #[test]
+    fn cursor_duplicate_composer_prefers_real_workspace() {
+        let temp = tempfile::tempdir().unwrap();
+        let real = temp
+            .path()
+            .join(".cursor/projects/repo/agent-transcripts/abc");
+        let stale = temp
+            .path()
+            .join(".cursor/projects/empty-window/agent-transcripts/abc");
+        fs::create_dir_all(&real).unwrap();
+        fs::create_dir_all(&stale).unwrap();
+        fs::write(real.join("abc.jsonl"), "{}\n").unwrap();
+        fs::write(stale.join("abc.jsonl"), "{}\n{}\n").unwrap();
+
+        let candidates: Vec<_> = agent_session::discover_session_files_in_home(temp.path())
+            .into_iter()
+            .filter(|candidate| candidate.agent == agent_session::AGENT_CURSOR)
+            .collect();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].path, real.join("abc.jsonl"));
+    }
+
+    #[test]
     fn codex_state_db_uses_rollout_token_usage() {
         let temp = tempfile::tempdir().unwrap();
         write_codex_state_db_for_test(temp.path());

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -1361,6 +1361,28 @@ mod tests {
     }
 
     #[test]
+    fn count_session_dirs_reports_cursor_root() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(agent_session::count_session_dirs_in_home(temp.path()).is_empty());
+
+        let transcripts = temp
+            .path()
+            .join(".cursor/projects/repo/agent-transcripts/abc");
+        fs::create_dir_all(transcripts.join("subagents")).unwrap();
+        fs::write(transcripts.join("abc.jsonl"), "{}\n").unwrap();
+        fs::write(transcripts.join("subagents/def.jsonl"), "{}\n").unwrap();
+
+        let stats = agent_session::count_session_dirs_in_home(temp.path());
+        assert_eq!(stats.len(), 1);
+        assert_eq!(stats[0].agent, agent_session::AGENT_CURSOR);
+        assert!(stats[0].dir.ends_with(".cursor/projects"));
+        // Parents only: the subagent file folds into its parent session, so it
+        // adds neither a session nor bytes.
+        assert_eq!(stats[0].sessions, 1);
+        assert_eq!(stats[0].bytes, 3);
+    }
+
+    #[test]
     fn cursor_discovery_emits_parent_candidates_only() {
         let temp = tempfile::tempdir().unwrap();
         let project = temp.path().join(".cursor/projects/repo");

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -24,6 +24,10 @@ pub type SessionCache = agent_session::SessionCache;
 const CODEX_EXEC_DEDUPE_WINDOW_MS: u64 = 2_000;
 const CODEX_FALLBACK_TIME_SLOP_MS: u64 = 30_000;
 const CODEX_ROLLOUT_TAIL_BYTES: u64 = 1024 * 1024;
+// Local copy of agent_session::AGENT_CURSOR. cargo package verifies this crate
+// against the published agent-session, which lags behind the workspace copy, so
+// production code here cannot reference constants the registry version lacks.
+const CURSOR_AGENT_TYPE: &str = "cursor";
 
 #[derive(Clone, Debug)]
 struct ObservedCodexPrompt {
@@ -331,7 +335,7 @@ fn cursor_subagent_ids(parent_transcript: &Path) -> Vec<String> {
 fn enrich_cursor_sessions(sessions: &mut [LocalSession]) {
     if !sessions
         .iter()
-        .any(|session| session.agent_type == agent_session::AGENT_CURSOR)
+        .any(|session| session.agent_type == CURSOR_AGENT_TYPE)
     {
         return;
     }
@@ -350,7 +354,7 @@ fn enrich_cursor_sessions_in_home(home: &Path, sessions: &mut [LocalSession]) {
     };
     for session in sessions
         .iter_mut()
-        .filter(|session| session.agent_type == agent_session::AGENT_CURSOR)
+        .filter(|session| session.agent_type == CURSOR_AGENT_TYPE)
     {
         enrich_cursor_session(&conn, session);
     }

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -195,8 +195,6 @@ const CURSOR_STATE_DB_CANDIDATES: [&str; 3] = [
     "AppData/Roaming/Cursor/User/globalStorage/state.vscdb",
 ];
 
-/// Locate Cursor's state database under a home directory. Candidates are the
-/// macOS, Linux, and Windows layouts, in that order; first existing file wins.
 fn cursor_state_db_path(home: &Path) -> Option<PathBuf> {
     CURSOR_STATE_DB_CANDIDATES
         .iter()
@@ -204,8 +202,6 @@ fn cursor_state_db_path(home: &Path) -> Option<PathBuf> {
         .find(|path| path.is_file())
 }
 
-/// Cursor is usually running with an active WAL on this database, so open it
-/// strictly read-only and treat any failure as absence rather than an error.
 fn open_cursor_state_db(path: &Path) -> Option<rusqlite::Connection> {
     rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()
 }
@@ -215,9 +211,6 @@ struct CursorComposerHeader {
     updated_at_ms: Option<u64>,
 }
 
-/// Read one composer's header row. `lastUpdatedAt` is NULL on every subagent
-/// header, so both timestamps stay optional. A missing row is normal:
-/// `composerHeaders` is not a 1:1 index of the transcripts on disk.
 fn cursor_composer_header(
     conn: &rusqlite::Connection,
     composer_id: &str,
@@ -237,8 +230,6 @@ fn cursor_composer_header(
     .ok()
 }
 
-/// `cursorDiskKV` values are BLOBs on real installs but land as TEXT when
-/// written from SQL literals, so accept either shape.
 fn cursor_kv_bytes(value: rusqlite::types::Value) -> Option<Vec<u8>> {
     match value {
         rusqlite::types::Value::Blob(bytes) => Some(bytes),
@@ -252,10 +243,6 @@ struct CursorComposerData {
     workspace_path: Option<String>,
 }
 
-/// Read the `composerData:<id>` blob. `modelName` is the literal string
-/// "default" when the user never pinned a model, which means unknown, not a
-/// model called "default". `workspaceIdentifier.uri.fsPath` carries the real
-/// working directory when present (a minority of records).
 fn cursor_composer_data(
     conn: &rusqlite::Connection,
     composer_id: &str,
@@ -284,10 +271,6 @@ fn cursor_composer_data(
     })
 }
 
-/// Sum legacy token counts for one composer's bubbles. The key range is
-/// `bubbleId:<id>:` to `bubbleId:<id>;` (';' is ':' + 1), which stays on the
-/// key index instead of scanning the table. Cursor stopped writing usage
-/// events around March 2026, so zero on a current session is the normal case.
 fn cursor_bubble_tokens(conn: &rusqlite::Connection, composer_id: &str) -> TokenUsage {
     let mut usage = TokenUsage::default();
     let Ok(mut stmt) = conn.prepare("SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2")
@@ -324,9 +307,6 @@ fn cursor_bubble_tokens(conn: &rusqlite::Connection, composer_id: &str) -> Token
     usage
 }
 
-/// Composer ids of a parent transcript's delegated runs, read from the
-/// `subagents/` directory next to it. `Task` calls carry no child id, so the
-/// directory layout is the only parent-child link.
 fn cursor_subagent_ids(parent_transcript: &Path) -> Vec<String> {
     let Some(subagents) = parent_transcript.parent().map(|dir| dir.join("subagents")) else {
         return Vec::new();
@@ -348,10 +328,6 @@ fn cursor_subagent_ids(parent_transcript: &Path) -> Vec<String> {
     ids
 }
 
-/// Fill Cursor session metadata from Cursor's own state database. The
-/// transcript carries no model, tokens, or wall-clock session timing; those
-/// live in `state.vscdb`, joined on the transcript's composer id. A missing,
-/// locked, or unreadable database leaves the sessions exactly as parsed.
 fn enrich_cursor_sessions(sessions: &mut [LocalSession]) {
     if !sessions
         .iter()
@@ -402,9 +378,7 @@ fn enrich_cursor_session(conn: &rusqlite::Connection, session: &mut LocalSession
             session.cwd = data.workspace_path;
         }
     }
-    // Tokens roll up across the parent and its delegated runs; the sessions
-    // that delegated most would otherwise under-report worst. Zero stays zero:
-    // current Cursor versions record no usage events at all.
+    // Roll up across delegated runs, or the sessions that delegated most under-report.
     let mut usage = cursor_bubble_tokens(conn, &composer_id);
     for child_id in cursor_subagent_ids(&session.path) {
         let child = cursor_bubble_tokens(conn, &child_id);
@@ -1245,9 +1219,7 @@ mod tests {
 
     #[test]
     fn cursor_enrichment_reads_model_when_header_row_is_missing() {
-        // Real installs have composers with composerData but no
-        // composerHeaders row. The model must still come through, and the
-        // timestamps must stay on their transcript-derived fallbacks.
+        // Real installs have composerData with no composerHeaders row.
         let temp = tempfile::tempdir().unwrap();
         write_cursor_state_db_for_test(temp.path());
         let transcripts = temp

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -10,7 +10,6 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[cfg(any(test, feature = "test-support"))]
 use std::fs;
 
 use crate::model::{
@@ -70,6 +69,7 @@ pub fn discover_sessions(
     };
     let mut seen = HashSet::new();
     sessions.retain(|session| seen.insert(session.display_id.clone()));
+    enrich_cursor_sessions(&mut sessions);
     sessions
         .into_iter()
         .filter(|s| matches_filter(s, pid_filter, text_filter))
@@ -189,7 +189,6 @@ fn codex_rollout_usage(path: &Path) -> Option<TokenUsage> {
     agent_session::codex_total_token_usage(&String::from_utf8_lossy(&data))
 }
 
-#[cfg(any(test, feature = "test-support"))]
 const CURSOR_STATE_DB_CANDIDATES: [&str; 3] = [
     "Library/Application Support/Cursor/User/globalStorage/state.vscdb",
     ".config/Cursor/User/globalStorage/state.vscdb",
@@ -198,7 +197,6 @@ const CURSOR_STATE_DB_CANDIDATES: [&str; 3] = [
 
 /// Locate Cursor's state database under a home directory. Candidates are the
 /// macOS, Linux, and Windows layouts, in that order; first existing file wins.
-#[cfg(any(test, feature = "test-support"))]
 fn cursor_state_db_path(home: &Path) -> Option<PathBuf> {
     CURSOR_STATE_DB_CANDIDATES
         .iter()
@@ -208,12 +206,10 @@ fn cursor_state_db_path(home: &Path) -> Option<PathBuf> {
 
 /// Cursor is usually running with an active WAL on this database, so open it
 /// strictly read-only and treat any failure as absence rather than an error.
-#[cfg(any(test, feature = "test-support"))]
 fn open_cursor_state_db(path: &Path) -> Option<rusqlite::Connection> {
     rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()
 }
 
-#[cfg(any(test, feature = "test-support"))]
 struct CursorComposerHeader {
     created_at_ms: Option<u64>,
     updated_at_ms: Option<u64>,
@@ -222,7 +218,6 @@ struct CursorComposerHeader {
 /// Read one composer's header row. `lastUpdatedAt` is NULL on every subagent
 /// header, so both timestamps stay optional. A missing row is normal:
 /// `composerHeaders` is not a 1:1 index of the transcripts on disk.
-#[cfg(any(test, feature = "test-support"))]
 fn cursor_composer_header(
     conn: &rusqlite::Connection,
     composer_id: &str,
@@ -244,7 +239,6 @@ fn cursor_composer_header(
 
 /// `cursorDiskKV` values are BLOBs on real installs but land as TEXT when
 /// written from SQL literals, so accept either shape.
-#[cfg(any(test, feature = "test-support"))]
 fn cursor_kv_bytes(value: rusqlite::types::Value) -> Option<Vec<u8>> {
     match value {
         rusqlite::types::Value::Blob(bytes) => Some(bytes),
@@ -253,7 +247,6 @@ fn cursor_kv_bytes(value: rusqlite::types::Value) -> Option<Vec<u8>> {
     }
 }
 
-#[cfg(any(test, feature = "test-support"))]
 struct CursorComposerData {
     model: Option<String>,
     workspace_path: Option<String>,
@@ -263,7 +256,6 @@ struct CursorComposerData {
 /// "default" when the user never pinned a model, which means unknown, not a
 /// model called "default". `workspaceIdentifier.uri.fsPath` carries the real
 /// working directory when present (a minority of records).
-#[cfg(any(test, feature = "test-support"))]
 fn cursor_composer_data(
     conn: &rusqlite::Connection,
     composer_id: &str,
@@ -296,7 +288,6 @@ fn cursor_composer_data(
 /// `bubbleId:<id>:` to `bubbleId:<id>;` (';' is ':' + 1), which stays on the
 /// key index instead of scanning the table. Cursor stopped writing usage
 /// events around March 2026, so zero on a current session is the normal case.
-#[cfg(any(test, feature = "test-support"))]
 fn cursor_bubble_tokens(conn: &rusqlite::Connection, composer_id: &str) -> TokenUsage {
     let mut usage = TokenUsage::default();
     let Ok(mut stmt) = conn.prepare("SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2")
@@ -336,7 +327,6 @@ fn cursor_bubble_tokens(conn: &rusqlite::Connection, composer_id: &str) -> Token
 /// Composer ids of a parent transcript's delegated runs, read from the
 /// `subagents/` directory next to it. `Task` calls carry no child id, so the
 /// directory layout is the only parent-child link.
-#[cfg(any(test, feature = "test-support"))]
 fn cursor_subagent_ids(parent_transcript: &Path) -> Vec<String> {
     let Some(subagents) = parent_transcript.parent().map(|dir| dir.join("subagents")) else {
         return Vec::new();
@@ -356,6 +346,78 @@ fn cursor_subagent_ids(parent_transcript: &Path) -> Vec<String> {
         .collect();
     ids.sort();
     ids
+}
+
+/// Fill Cursor session metadata from Cursor's own state database. The
+/// transcript carries no model, tokens, or wall-clock session timing; those
+/// live in `state.vscdb`, joined on the transcript's composer id. A missing,
+/// locked, or unreadable database leaves the sessions exactly as parsed.
+fn enrich_cursor_sessions(sessions: &mut [LocalSession]) {
+    if !sessions
+        .iter()
+        .any(|session| session.agent_type == agent_session::AGENT_CURSOR)
+    {
+        return;
+    }
+    let Some(home) = user_home_dir() else {
+        return;
+    };
+    enrich_cursor_sessions_in_home(&home, sessions);
+}
+
+fn enrich_cursor_sessions_in_home(home: &Path, sessions: &mut [LocalSession]) {
+    let Some(db_path) = cursor_state_db_path(home) else {
+        return;
+    };
+    let Some(conn) = open_cursor_state_db(&db_path) else {
+        return;
+    };
+    for session in sessions
+        .iter_mut()
+        .filter(|session| session.agent_type == agent_session::AGENT_CURSOR)
+    {
+        enrich_cursor_session(&conn, session);
+    }
+}
+
+fn enrich_cursor_session(conn: &rusqlite::Connection, session: &mut LocalSession) {
+    let composer_id = session.session_id.clone();
+    if let Some(header) = cursor_composer_header(conn, &composer_id) {
+        if header.created_at_ms.is_some() {
+            session.start_timestamp_ms = header.created_at_ms;
+        }
+        if let Some(updated_ms) = header.updated_at_ms {
+            session.end_timestamp_ms = Some(updated_ms);
+            session.last_message_at = Some(iso_utc_from_ms(updated_ms));
+        }
+        if let (Some(start), Some(end)) = (session.start_timestamp_ms, session.end_timestamp_ms) {
+            session.duration_ms = end.saturating_sub(start);
+        }
+    }
+    if let Some(data) = cursor_composer_data(conn, &composer_id) {
+        if data.model.is_some() {
+            session.model = data.model;
+        }
+        if data.workspace_path.is_some() {
+            session.cwd = data.workspace_path;
+        }
+    }
+    // Tokens roll up across the parent and its delegated runs; the sessions
+    // that delegated most would otherwise under-report worst. Zero stays zero:
+    // current Cursor versions record no usage events at all.
+    let mut usage = cursor_bubble_tokens(conn, &composer_id);
+    for child_id in cursor_subagent_ids(&session.path) {
+        let child = cursor_bubble_tokens(conn, &child_id);
+        usage.input_tokens += child.input_tokens;
+        usage.output_tokens += child.output_tokens;
+        usage.total_tokens += child.total_tokens;
+    }
+    if usage.total_tokens > 0 {
+        if let Some(model) = session.model.as_deref() {
+            session.model_usage.insert(model.to_string(), usage.clone());
+        }
+        session.usage = usage;
+    }
 }
 
 fn user_home_dir() -> Option<PathBuf> {
@@ -1003,6 +1065,9 @@ pub fn write_cursor_state_db_for_test(home: &Path) {
     let db_dir = home.join("Library/Application Support/Cursor/User/globalStorage");
     fs::create_dir_all(&db_dir).unwrap();
     let conn = rusqlite::Connection::open(db_dir.join("state.vscdb")).unwrap();
+    // Real installs run WAL, which is what lets a read-only connection work
+    // while Cursor holds a write transaction.
+    conn.pragma_update(None, "journal_mode", "WAL").unwrap();
     conn.execute_batch(
         r#"CREATE TABLE composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT,
             createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER,
@@ -1122,6 +1187,93 @@ mod tests {
             [],
         );
         assert!(denied.is_err());
+    }
+
+    fn cursor_fixture_transcripts(home: &Path) -> PathBuf {
+        let transcripts = home
+            .join(".cursor/projects/repo/agent-transcripts/abc00000-0000-0000-0000-000000000abc");
+        fs::create_dir_all(transcripts.join("subagents")).unwrap();
+        let parent = transcripts.join("abc00000-0000-0000-0000-000000000abc.jsonl");
+        fs::write(
+            &parent,
+            r#"{"role":"user","message":{"content":[{"type":"text","text":"check the build"}]}}"#,
+        )
+        .unwrap();
+        fs::write(
+            transcripts.join("subagents/def00000-0000-0000-0000-000000000def.jsonl"),
+            "{}\n",
+        )
+        .unwrap();
+        parent
+    }
+
+    #[test]
+    fn cursor_enrichment_fills_metadata_and_rolls_up_subagents() {
+        let temp = tempfile::tempdir().unwrap();
+        write_cursor_state_db_for_test(temp.path());
+        let parent = cursor_fixture_transcripts(temp.path());
+
+        let mut sessions = vec![agent_session::parse_session_path(&parent).expect("parsed")];
+        enrich_cursor_sessions_in_home(temp.path(), &mut sessions);
+
+        let session = &sessions[0];
+        assert_eq!(session.model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(session.start_timestamp_ms, Some(1_700_000));
+        assert_eq!(session.end_timestamp_ms, Some(1_900_000));
+        assert_eq!(session.duration_ms, 200_000);
+        assert_eq!(session.cwd.as_deref(), Some("/work/repo"));
+        assert_eq!(
+            session.last_message_at.as_deref(),
+            Some("1970-01-01T00:31:40.000Z")
+        );
+        // 140 from the parent's bubbles plus 10 from the delegated run.
+        assert_eq!(session.usage.total_tokens, 150);
+        assert_eq!(
+            session
+                .model_usage
+                .get("claude-sonnet-4-6")
+                .map(|usage| usage.total_tokens),
+            Some(150)
+        );
+    }
+
+    #[test]
+    fn cursor_enrichment_missing_db_changes_nothing() {
+        let temp = tempfile::tempdir().unwrap();
+        let parent = cursor_fixture_transcripts(temp.path());
+
+        let parsed = agent_session::parse_session_path(&parent).expect("parsed");
+        let mut sessions = vec![parsed.clone()];
+        enrich_cursor_sessions_in_home(temp.path(), &mut sessions);
+
+        assert_eq!(sessions[0].model, parsed.model);
+        assert_eq!(sessions[0].usage.total_tokens, parsed.usage.total_tokens);
+        assert_eq!(sessions[0].cwd, parsed.cwd);
+        assert_eq!(sessions[0].start_timestamp_ms, parsed.start_timestamp_ms);
+    }
+
+    #[test]
+    fn cursor_enrichment_reads_while_writer_holds_wal() {
+        let temp = tempfile::tempdir().unwrap();
+        write_cursor_state_db_for_test(temp.path());
+        let parent = cursor_fixture_transcripts(temp.path());
+
+        let writer =
+            rusqlite::Connection::open(cursor_state_db_path(temp.path()).unwrap()).unwrap();
+        writer.execute_batch("BEGIN IMMEDIATE;").unwrap();
+        writer
+            .execute(
+                "INSERT INTO cursorDiskKV (key, value) VALUES ('agentKv:x', 'held open')",
+                [],
+            )
+            .unwrap();
+
+        let mut sessions = vec![agent_session::parse_session_path(&parent).expect("parsed")];
+        enrich_cursor_sessions_in_home(temp.path(), &mut sessions);
+        writer.execute_batch("ROLLBACK;").unwrap();
+
+        assert_eq!(sessions[0].model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(sessions[0].usage.total_tokens, 150);
     }
 
     #[test]

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -485,7 +485,11 @@ pub fn materialized_view(sessions: &[LocalSession]) -> MaterializedView {
 }
 
 pub fn import_recent(view: &mut MaterializedView, limit: usize) {
-    let sessions = SessionCache::new().discover_cached(limit, Duration::ZERO);
+    let mut sessions = SessionCache::new().discover_cached(limit, Duration::ZERO);
+    // `discover_sessions` enriches on its way out, but this is a second entry
+    // point into the same data and every `report` subcommand without a --db
+    // goes through here, as does the snapshot the frontend renders.
+    enrich_cursor_sessions(&mut sessions);
     import_into_view(view, &sessions);
 }
 

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -242,6 +242,122 @@ fn cursor_composer_header(
     .ok()
 }
 
+/// `cursorDiskKV` values are BLOBs on real installs but land as TEXT when
+/// written from SQL literals, so accept either shape.
+#[cfg(any(test, feature = "test-support"))]
+fn cursor_kv_bytes(value: rusqlite::types::Value) -> Option<Vec<u8>> {
+    match value {
+        rusqlite::types::Value::Blob(bytes) => Some(bytes),
+        rusqlite::types::Value::Text(text) => Some(text.into_bytes()),
+        _ => None,
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+struct CursorComposerData {
+    model: Option<String>,
+    workspace_path: Option<String>,
+}
+
+/// Read the `composerData:<id>` blob. `modelName` is the literal string
+/// "default" when the user never pinned a model, which means unknown, not a
+/// model called "default". `workspaceIdentifier.uri.fsPath` carries the real
+/// working directory when present (a minority of records).
+#[cfg(any(test, feature = "test-support"))]
+fn cursor_composer_data(
+    conn: &rusqlite::Connection,
+    composer_id: &str,
+) -> Option<CursorComposerData> {
+    let raw: rusqlite::types::Value = conn
+        .query_row(
+            "SELECT value FROM cursorDiskKV WHERE key = ?1",
+            [format!("composerData:{composer_id}")],
+            |row| row.get(0),
+        )
+        .ok()?;
+    let value: Value = serde_json::from_slice(&cursor_kv_bytes(raw)?).ok()?;
+    let model = value
+        .pointer("/modelConfig/modelName")
+        .and_then(Value::as_str)
+        .filter(|name| !name.is_empty() && *name != "default")
+        .map(str::to_string);
+    let workspace_path = value
+        .pointer("/workspaceIdentifier/uri/fsPath")
+        .and_then(Value::as_str)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string);
+    Some(CursorComposerData {
+        model,
+        workspace_path,
+    })
+}
+
+/// Sum legacy token counts for one composer's bubbles. The key range is
+/// `bubbleId:<id>:` to `bubbleId:<id>;` (';' is ':' + 1), which stays on the
+/// key index instead of scanning the table. Cursor stopped writing usage
+/// events around March 2026, so zero on a current session is the normal case.
+#[cfg(any(test, feature = "test-support"))]
+fn cursor_bubble_tokens(conn: &rusqlite::Connection, composer_id: &str) -> TokenUsage {
+    let mut usage = TokenUsage::default();
+    let Ok(mut stmt) = conn.prepare("SELECT value FROM cursorDiskKV WHERE key >= ?1 AND key < ?2")
+    else {
+        return usage;
+    };
+    let lower = format!("bubbleId:{composer_id}:");
+    let upper = format!("bubbleId:{composer_id};");
+    let Ok(rows) = stmt.query_map([lower, upper], |row| {
+        row.get::<_, rusqlite::types::Value>(0)
+    }) else {
+        return usage;
+    };
+    for raw in rows.filter_map(Result::ok).filter_map(cursor_kv_bytes) {
+        let Ok(value) = serde_json::from_slice::<Value>(&raw) else {
+            continue;
+        };
+        let input = value
+            .pointer("/tokenCount/inputTokens")
+            .and_then(Value::as_i64)
+            .unwrap_or_default()
+            .max(0);
+        let output = value
+            .pointer("/tokenCount/outputTokens")
+            .and_then(Value::as_i64)
+            .unwrap_or_default()
+            .max(0);
+        if input + output > 0 {
+            usage.input_tokens += input;
+            usage.output_tokens += output;
+            usage.total_tokens += input + output;
+        }
+    }
+    usage
+}
+
+/// Composer ids of a parent transcript's delegated runs, read from the
+/// `subagents/` directory next to it. `Task` calls carry no child id, so the
+/// directory layout is the only parent-child link.
+#[cfg(any(test, feature = "test-support"))]
+fn cursor_subagent_ids(parent_transcript: &Path) -> Vec<String> {
+    let Some(subagents) = parent_transcript.parent().map(|dir| dir.join("subagents")) else {
+        return Vec::new();
+    };
+    let Ok(entries) = fs::read_dir(subagents) else {
+        return Vec::new();
+    };
+    let mut ids: Vec<String> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().and_then(|ext| ext.to_str()) == Some("jsonl"))
+        .filter_map(|path| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(str::to_string)
+        })
+        .collect();
+    ids.sort();
+    ids
+}
+
 fn user_home_dir() -> Option<PathBuf> {
     std::env::var("SUDO_USER")
         .ok()
@@ -1006,6 +1122,61 @@ mod tests {
             [],
         );
         assert!(denied.is_err());
+    }
+
+    #[test]
+    fn cursor_composer_data_reads_model_and_workspace() {
+        let temp = tempfile::tempdir().unwrap();
+        write_cursor_state_db_for_test(temp.path());
+        let conn = open_cursor_state_db(&cursor_state_db_path(temp.path()).unwrap()).unwrap();
+
+        let pinned = cursor_composer_data(&conn, "abc00000-0000-0000-0000-000000000abc")
+            .expect("pinned composer");
+        assert_eq!(pinned.model.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(pinned.workspace_path.as_deref(), Some("/work/repo"));
+
+        let unpinned = cursor_composer_data(&conn, "aaa00000-0000-0000-0000-000000000aaa")
+            .expect("default composer");
+        assert_eq!(unpinned.model, None);
+        assert_eq!(unpinned.workspace_path, None);
+
+        assert!(cursor_composer_data(&conn, "not-a-composer").is_none());
+    }
+
+    #[test]
+    fn cursor_bubble_tokens_sums_by_bounded_range() {
+        let temp = tempfile::tempdir().unwrap();
+        write_cursor_state_db_for_test(temp.path());
+        let conn = open_cursor_state_db(&cursor_state_db_path(temp.path()).unwrap()).unwrap();
+
+        let parent = cursor_bubble_tokens(&conn, "abc00000-0000-0000-0000-000000000abc");
+        assert_eq!(parent.input_tokens, 100);
+        assert_eq!(parent.output_tokens, 40);
+        assert_eq!(parent.total_tokens, 140);
+
+        let child = cursor_bubble_tokens(&conn, "def00000-0000-0000-0000-000000000def");
+        assert_eq!(child.total_tokens, 10);
+
+        let none = cursor_bubble_tokens(&conn, "aaa00000-0000-0000-0000-000000000aaa");
+        assert_eq!(none.total_tokens, 0);
+    }
+
+    #[test]
+    fn cursor_subagent_ids_come_from_directory_layout() {
+        let temp = tempfile::tempdir().unwrap();
+        let transcripts = temp
+            .path()
+            .join(".cursor/projects/repo/agent-transcripts/abc");
+        fs::create_dir_all(transcripts.join("subagents")).unwrap();
+        let parent = transcripts.join("abc.jsonl");
+        fs::write(&parent, "{}\n").unwrap();
+        fs::write(transcripts.join("subagents/def.jsonl"), "{}\n").unwrap();
+        fs::write(transcripts.join("subagents/aaa.jsonl"), "{}\n").unwrap();
+        fs::write(transcripts.join("subagents/notes.txt"), "x").unwrap();
+
+        assert_eq!(cursor_subagent_ids(&parent), vec!["aaa", "def"]);
+        let no_subagents = temp.path().join("elsewhere/abc.jsonl");
+        assert!(cursor_subagent_ids(&no_subagents).is_empty());
     }
 
     #[test]

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -189,6 +189,59 @@ fn codex_rollout_usage(path: &Path) -> Option<TokenUsage> {
     agent_session::codex_total_token_usage(&String::from_utf8_lossy(&data))
 }
 
+#[cfg(any(test, feature = "test-support"))]
+const CURSOR_STATE_DB_CANDIDATES: [&str; 3] = [
+    "Library/Application Support/Cursor/User/globalStorage/state.vscdb",
+    ".config/Cursor/User/globalStorage/state.vscdb",
+    "AppData/Roaming/Cursor/User/globalStorage/state.vscdb",
+];
+
+/// Locate Cursor's state database under a home directory. Candidates are the
+/// macOS, Linux, and Windows layouts, in that order; first existing file wins.
+#[cfg(any(test, feature = "test-support"))]
+fn cursor_state_db_path(home: &Path) -> Option<PathBuf> {
+    CURSOR_STATE_DB_CANDIDATES
+        .iter()
+        .map(|candidate| home.join(candidate))
+        .find(|path| path.is_file())
+}
+
+/// Cursor is usually running with an active WAL on this database, so open it
+/// strictly read-only and treat any failure as absence rather than an error.
+#[cfg(any(test, feature = "test-support"))]
+fn open_cursor_state_db(path: &Path) -> Option<rusqlite::Connection> {
+    rusqlite::Connection::open_with_flags(path, rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY).ok()
+}
+
+#[cfg(any(test, feature = "test-support"))]
+struct CursorComposerHeader {
+    created_at_ms: Option<u64>,
+    updated_at_ms: Option<u64>,
+}
+
+/// Read one composer's header row. `lastUpdatedAt` is NULL on every subagent
+/// header, so both timestamps stay optional. A missing row is normal:
+/// `composerHeaders` is not a 1:1 index of the transcripts on disk.
+#[cfg(any(test, feature = "test-support"))]
+fn cursor_composer_header(
+    conn: &rusqlite::Connection,
+    composer_id: &str,
+) -> Option<CursorComposerHeader> {
+    conn.query_row(
+        "SELECT createdAt, lastUpdatedAt FROM composerHeaders WHERE composerId = ?1",
+        [composer_id],
+        |row| {
+            let created: Option<i64> = row.get(0)?;
+            let updated: Option<i64> = row.get(1)?;
+            Ok(CursorComposerHeader {
+                created_at_ms: created.and_then(non_negative_i64_to_u64),
+                updated_at_ms: updated.and_then(non_negative_i64_to_u64),
+            })
+        },
+    )
+    .ok()
+}
+
 fn user_home_dir() -> Option<PathBuf> {
     std::env::var("SUDO_USER")
         .ok()
@@ -826,6 +879,39 @@ pub fn parse_content_for_test(
     agent_session::parse_session_content(agent, path, updated, content)
 }
 
+/// Fixture mirroring Cursor's `state.vscdb` on 3.15.6: one parent composer
+/// with model, workspace, and legacy token bubbles, one subagent composer with
+/// a NULL `lastUpdatedAt`, and one composer left on the "default" model.
+#[cfg(any(test, feature = "test-support"))]
+pub fn write_cursor_state_db_for_test(home: &Path) {
+    let db_dir = home.join("Library/Application Support/Cursor/User/globalStorage");
+    fs::create_dir_all(&db_dir).unwrap();
+    let conn = rusqlite::Connection::open(db_dir.join("state.vscdb")).unwrap();
+    conn.execute_batch(
+        r#"CREATE TABLE composerHeaders (composerId TEXT PRIMARY KEY, workspaceId TEXT,
+            createdAt INTEGER, lastUpdatedAt INTEGER, isArchived INTEGER,
+            isSubagent INTEGER, recency INTEGER, checkpointAt INTEGER, value TEXT);
+        CREATE TABLE cursorDiskKV (key TEXT UNIQUE ON CONFLICT REPLACE, value BLOB);
+        INSERT INTO composerHeaders (composerId, workspaceId, createdAt, lastUpdatedAt, isSubagent)
+        VALUES
+        ('abc00000-0000-0000-0000-000000000abc', 'ws1', 1700000, 1900000, 0),
+        ('def00000-0000-0000-0000-000000000def', 'ws1', 1750000, NULL, 1),
+        ('aaa00000-0000-0000-0000-000000000aaa', 'ws2', 1600000, 1650000, 0);
+        INSERT INTO cursorDiskKV (key, value) VALUES
+        ('composerData:abc00000-0000-0000-0000-000000000abc',
+         '{"composerId":"abc00000-0000-0000-0000-000000000abc","modelConfig":{"modelName":"claude-sonnet-4-6","maxMode":false},"workspaceIdentifier":{"uri":{"fsPath":"/work/repo"}}}'),
+        ('composerData:aaa00000-0000-0000-0000-000000000aaa',
+         '{"composerId":"aaa00000-0000-0000-0000-000000000aaa","modelConfig":{"modelName":"default","maxMode":false}}'),
+        ('bubbleId:abc00000-0000-0000-0000-000000000abc:b1',
+         '{"tokenCount":{"inputTokens":100,"outputTokens":40}}'),
+        ('bubbleId:abc00000-0000-0000-0000-000000000abc:b2',
+         '{"tokenCount":{"inputTokens":0,"outputTokens":0}}'),
+        ('bubbleId:def00000-0000-0000-0000-000000000def:b1',
+         '{"tokenCount":{"inputTokens":7,"outputTokens":3}}');"#,
+    )
+    .unwrap();
+}
+
 #[cfg(any(test, feature = "test-support"))]
 pub fn write_codex_state_db_for_test(home: &Path) {
     let codex_dir = home.join(".codex");
@@ -898,6 +984,47 @@ mod tests {
             sessions[0].last_message_at.as_deref(),
             Some("1970-01-01T00:31:40.000Z")
         );
+    }
+
+    #[test]
+    fn cursor_state_db_path_checks_platform_layouts() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(cursor_state_db_path(temp.path()).is_none());
+        write_cursor_state_db_for_test(temp.path());
+        let path = cursor_state_db_path(temp.path()).unwrap();
+        assert!(path.ends_with("Cursor/User/globalStorage/state.vscdb"));
+    }
+
+    #[test]
+    fn cursor_state_db_open_is_read_only_and_fails_closed() {
+        let temp = tempfile::tempdir().unwrap();
+        assert!(open_cursor_state_db(&temp.path().join("missing.vscdb")).is_none());
+        write_cursor_state_db_for_test(temp.path());
+        let conn = open_cursor_state_db(&cursor_state_db_path(temp.path()).unwrap()).unwrap();
+        let denied = conn.execute(
+            "INSERT INTO cursorDiskKV (key, value) VALUES ('x', 'y')",
+            [],
+        );
+        assert!(denied.is_err());
+    }
+
+    #[test]
+    fn cursor_composer_header_reads_parent_and_subagent_rows() {
+        let temp = tempfile::tempdir().unwrap();
+        write_cursor_state_db_for_test(temp.path());
+        let conn = open_cursor_state_db(&cursor_state_db_path(temp.path()).unwrap()).unwrap();
+
+        let parent = cursor_composer_header(&conn, "abc00000-0000-0000-0000-000000000abc")
+            .expect("parent header");
+        assert_eq!(parent.created_at_ms, Some(1_700_000));
+        assert_eq!(parent.updated_at_ms, Some(1_900_000));
+
+        let child = cursor_composer_header(&conn, "def00000-0000-0000-0000-000000000def")
+            .expect("subagent header");
+        assert_eq!(child.created_at_ms, Some(1_750_000));
+        assert_eq!(child.updated_at_ms, None);
+
+        assert!(cursor_composer_header(&conn, "not-a-composer").is_none());
     }
 
     #[test]

--- a/agentvis/src/export.rs
+++ b/agentvis/src/export.rs
@@ -96,7 +96,7 @@ pub fn run_vis(
     let outputs = requested_outputs(outputs)?;
     eprintln!("[agentvis 1/5] repository  {}", repo.display());
     eprintln!(
-        "[agentvis 2/5] sessions    scanning Claude + Codex + Gemini{}",
+        "[agentvis 2/5] sessions    scanning Claude + Codex + Gemini + Cursor{}",
         if global { " globally" } else { "" }
     );
     let scan = Instant::now();

--- a/agentvis/src/repository.rs
+++ b/agentvis/src/repository.rs
@@ -774,7 +774,8 @@ mod tests {
             Some(encoded_cursor_root(root))
         );
         assert_eq!(
-            cursor_project_name(Path::new("/home/user/.claude/projects/x/session.jsonl")).as_deref(),
+            cursor_project_name(Path::new("/home/user/.claude/projects/x/session.jsonl"))
+                .as_deref(),
             Some("x"),
             "helper reads the segment after `projects`, callers gate on agent"
         );
@@ -793,16 +794,12 @@ mod tests {
         // Before this, Cursor fell through to the catch-all arm and every
         // candidate was discarded before it was ever parsed.
         assert!(candidate_may_match_repo(
-            &candidate(
-                "/home/user/.cursor/projects/home-user-my-repo/agent-transcripts/a/a.jsonl"
-            ),
+            &candidate("/home/user/.cursor/projects/home-user-my-repo/agent-transcripts/a/a.jsonl"),
             &roots,
             None
         ));
         assert!(!candidate_may_match_repo(
-            &candidate(
-                "/home/user/.cursor/projects/home-user-other/agent-transcripts/a/a.jsonl"
-            ),
+            &candidate("/home/user/.cursor/projects/home-user-other/agent-transcripts/a/a.jsonl"),
             &roots,
             None
         ));

--- a/agentvis/src/repository.rs
+++ b/agentvis/src/repository.rs
@@ -156,10 +156,7 @@ fn parse_candidates(candidates: &[SessionCandidate]) -> Vec<(AgentSession, usize
 }
 
 fn repository_session(candidate: &SessionCandidate) -> Option<(AgentSession, usize)> {
-    // Gemini and Cursor are read whole. The streaming filter below keys on a
-    // top-level "type" field, which neither writes on message records, so it
-    // would hand the parser an empty string. Their transcripts are small enough
-    // that parsing in full costs little, unlike Claude and Codex rollouts.
+    // Read whole: the filter below keys on a top-level "type" neither writes.
     if candidate.agent == AGENT_GEMINI || candidate.agent == AGENT_CURSOR {
         let content = std::fs::read_to_string(&candidate.path).ok()?;
         let session = parse_session_content(
@@ -278,9 +275,7 @@ fn append_session(
         }
         used = true;
         batch.0.push(RepositoryEvent {
-            // Zero padded because events are ordered by (ts_ms, id) and the id
-            // is compared as a string. Agents with coarse clocks tie often, and
-            // an unpadded ordinal would sort 1, 10, 11, 2 within a tie.
+            // Zero padded: ids compare as strings, so ties would sort 1, 10, 11, 2.
             id: format!("{session_id}:{ordinal:06}"),
             session_id: session_id.clone(),
             vendor: session.agent_type.clone(),
@@ -372,11 +367,6 @@ fn candidate_may_match_repo(
     }
 }
 
-/// Cursor names a project directory after the workspace path with separators
-/// replaced, the same scheme Claude uses without the leading separator. That
-/// encoding cannot be inverted, since a hyphen in a real directory name looks
-/// exactly like a separator, but it does not need to be: encoding the root and
-/// comparing works and stays unambiguous.
 fn encoded_cursor_root(root: &Path) -> String {
     root.to_string_lossy()
         .replace('/', "-")
@@ -384,8 +374,6 @@ fn encoded_cursor_root(root: &Path) -> String {
         .to_string()
 }
 
-/// The project directory of a Cursor transcript, from
-/// `~/.cursor/projects/<project>/agent-transcripts/<id>/...`.
 fn cursor_project_name(path: &Path) -> Option<String> {
     let mut components = path.components().peekable();
     while let Some(component) = components.next() {
@@ -763,9 +751,7 @@ mod tests {
         );
         assert_eq!(encoded_cursor_root(root), "home-user-my-repo");
 
-        // The encoding cannot be inverted, since the hyphen in `my-repo` is
-        // indistinguishable from a separator. Encoding the root and comparing
-        // sidesteps that, and still keeps a sibling directory from matching.
+        // The encoding cannot be inverted, so encode the root and compare instead.
         let sibling = Path::new(
             "/home/user/.cursor/projects/home-user-my-repo-x/agent-transcripts/abc/abc.jsonl",
         );
@@ -807,9 +793,7 @@ mod tests {
 
     #[test]
     fn tied_timestamps_keep_event_order() {
-        // Cursor's only clock is minute resolution, so many events share a
-        // timestamp and the id breaks the tie. Ids compare as strings, so an
-        // unpadded ordinal would order 1, 10, 11, 2.
+        // Minute-resolution clocks tie often, and ids compare as strings.
         let mut ids: Vec<String> = (0..12).map(|ordinal| format!("s:{ordinal:06}")).collect();
         let expected = ids.clone();
         ids.sort();

--- a/agentvis/src/repository.rs
+++ b/agentvis/src/repository.rs
@@ -4,7 +4,7 @@
 //! Repository-scoped file actions from native coding-agent sessions.
 
 use agent_session::{
-    AGENT_CLAUDE, AGENT_CODEX, AGENT_GEMINI, AgentSession, SessionCandidate,
+    AGENT_CLAUDE, AGENT_CODEX, AGENT_CURSOR, AGENT_GEMINI, AgentSession, SessionCandidate,
     discover_session_files, parse_session_content, session_candidate_from_path,
 };
 use serde::{Deserialize, Serialize};
@@ -156,7 +156,11 @@ fn parse_candidates(candidates: &[SessionCandidate]) -> Vec<(AgentSession, usize
 }
 
 fn repository_session(candidate: &SessionCandidate) -> Option<(AgentSession, usize)> {
-    if candidate.agent == AGENT_GEMINI {
+    // Gemini and Cursor are read whole. The streaming filter below keys on a
+    // top-level "type" field, which neither writes on message records, so it
+    // would hand the parser an empty string. Their transcripts are small enough
+    // that parsing in full costs little, unlike Claude and Codex rollouts.
+    if candidate.agent == AGENT_GEMINI || candidate.agent == AGENT_CURSOR {
         let content = std::fs::read_to_string(&candidate.path).ok()?;
         let session = parse_session_content(
             candidate.agent,
@@ -274,7 +278,10 @@ fn append_session(
         }
         used = true;
         batch.0.push(RepositoryEvent {
-            id: format!("{session_id}:{ordinal}"),
+            // Zero padded because events are ordered by (ts_ms, id) and the id
+            // is compared as a string. Agents with coarse clocks tie often, and
+            // an unpadded ordinal would sort 1, 10, 11, 2 within a tie.
+            id: format!("{session_id}:{ordinal:06}"),
             session_id: session_id.clone(),
             vendor: session.agent_type.clone(),
             ts_ms,
@@ -356,8 +363,39 @@ fn candidate_may_match_repo(
         }),
         AGENT_GEMINI => gemini_project_hash(&candidate.path)
             .is_some_and(|project| roots.iter().any(|root| repository_hash(root) == project)),
+        AGENT_CURSOR => cursor_project_name(&candidate.path).is_some_and(|project| {
+            roots
+                .iter()
+                .any(|root| encoded_cursor_root(root) == project)
+        }),
         _ => false,
     }
+}
+
+/// Cursor names a project directory after the workspace path with separators
+/// replaced, the same scheme Claude uses without the leading separator. That
+/// encoding cannot be inverted, since a hyphen in a real directory name looks
+/// exactly like a separator, but it does not need to be: encoding the root and
+/// comparing works and stays unambiguous.
+fn encoded_cursor_root(root: &Path) -> String {
+    root.to_string_lossy()
+        .replace('/', "-")
+        .trim_start_matches('-')
+        .to_string()
+}
+
+/// The project directory of a Cursor transcript, from
+/// `~/.cursor/projects/<project>/agent-transcripts/<id>/...`.
+fn cursor_project_name(path: &Path) -> Option<String> {
+    let mut components = path.components().peekable();
+    while let Some(component) = components.next() {
+        if component.as_os_str() == "projects"
+            && let Some(project) = components.peek()
+        {
+            return Some(project.as_os_str().to_string_lossy().into_owned());
+        }
+    }
+    None
 }
 
 fn encoded_claude_root(root: &Path) -> String {
@@ -711,6 +749,74 @@ mod tests {
             claude_project_name(sibling),
             Some(encoded_claude_root(root))
         );
+    }
+
+    #[test]
+    fn cursor_project_directories_match_roots_by_encoding_not_inversion() {
+        let root = Path::new("/home/user/my-repo");
+        let transcript = Path::new(
+            "/home/user/.cursor/projects/home-user-my-repo/agent-transcripts/abc/abc.jsonl",
+        );
+        assert_eq!(
+            cursor_project_name(transcript).as_deref(),
+            Some("home-user-my-repo")
+        );
+        assert_eq!(encoded_cursor_root(root), "home-user-my-repo");
+
+        // The encoding cannot be inverted, since the hyphen in `my-repo` is
+        // indistinguishable from a separator. Encoding the root and comparing
+        // sidesteps that, and still keeps a sibling directory from matching.
+        let sibling = Path::new(
+            "/home/user/.cursor/projects/home-user-my-repo-x/agent-transcripts/abc/abc.jsonl",
+        );
+        assert_ne!(
+            cursor_project_name(sibling),
+            Some(encoded_cursor_root(root))
+        );
+        assert_eq!(
+            cursor_project_name(Path::new("/home/user/.claude/projects/x/session.jsonl")).as_deref(),
+            Some("x"),
+            "helper reads the segment after `projects`, callers gate on agent"
+        );
+    }
+
+    #[test]
+    fn cursor_candidates_reach_the_repository_matcher() {
+        let root = PathBuf::from("/home/user/my-repo");
+        let roots = vec![root.clone()];
+        let candidate = |path: &str| SessionCandidate {
+            agent: AGENT_CURSOR,
+            path: PathBuf::from(path),
+            updated: SystemTime::UNIX_EPOCH,
+        };
+
+        // Before this, Cursor fell through to the catch-all arm and every
+        // candidate was discarded before it was ever parsed.
+        assert!(candidate_may_match_repo(
+            &candidate(
+                "/home/user/.cursor/projects/home-user-my-repo/agent-transcripts/a/a.jsonl"
+            ),
+            &roots,
+            None
+        ));
+        assert!(!candidate_may_match_repo(
+            &candidate(
+                "/home/user/.cursor/projects/home-user-other/agent-transcripts/a/a.jsonl"
+            ),
+            &roots,
+            None
+        ));
+    }
+
+    #[test]
+    fn tied_timestamps_keep_event_order() {
+        // Cursor's only clock is minute resolution, so many events share a
+        // timestamp and the id breaks the tie. Ids compare as strings, so an
+        // unpadded ordinal would order 1, 10, 11, 2.
+        let mut ids: Vec<String> = (0..12).map(|ordinal| format!("s:{ordinal:06}")).collect();
+        let expected = ids.clone();
+        ids.sort();
+        assert_eq!(ids, expected);
     }
 
     #[test]

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -104,6 +104,36 @@ sudo ./agentsight record -c node --binary-path ~/.nvm/versions/node/v20.0.0/bin/
 > Node process (the proxy only tunnels it), so AgentSight captures it the same
 > way — at the `SSL_read`/`SSL_write` calls before encryption.
 
+## IDE-Based Agents (Cursor, Antigravity, Windsurf)
+
+Agents built into Electron IDEs do not work with `record` or `debug trace`, and
+pointing `--binary-path` at the app does not change that. Three separate things
+get in the way, and only the first one is obvious:
+
+1. **Platform.** These are desktop apps, and most installs run on macOS or
+   Windows. The eBPF probes are Linux-only, so on those systems there is
+   nothing to attach to in the first place.
+
+2. **Attach.** Electron bundles BoringSSL inside its framework binary
+   (`Electron Framework`, hundreds of megabytes, stripped). The launcher that
+   `--binary-path` auto-discovery resolves is a small stub with no SSL code in
+   it, and the network stack runs in a helper process, so a `--comm` filter on
+   the app name drops the traffic. This is the same class of problem as the
+   Claude Code "HTTP Client" thread described above, only across processes
+   instead of threads.
+
+3. **Payload.** Even with probes attached to the right binary, capture alone
+   is not enough. Cursor, for example, talks to its backend over the Connect
+   protocol: HTTP/2 with protobuf message bodies. AgentSight handles HTTP/2
+   framing, but it recognizes LLM calls by their JSON bodies, so protobuf
+   traffic produces no LLM events. The capture succeeds and the timeline stays
+   empty anyway.
+
+For these agents, use the agent-native session path instead: AgentSight reads
+the session files the IDE itself writes on disk, the same way it reads local
+Claude Code, Codex, and Gemini CLI sessions. That route needs no eBPF, no
+`sudo`, and works on macOS and Windows.
+
 ## Containers and Kubernetes Pods
 
 For an agent running inside a Docker container, pass the container to

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -132,7 +132,41 @@ get in the way, and only the first one is obvious:
 For these agents, use the agent-native session path instead: AgentSight reads
 the session files the IDE itself writes on disk, the same way it reads local
 Claude Code, Codex, and Gemini CLI sessions. That route needs no eBPF, no
-`sudo`, and works on macOS and Windows.
+`sudo`, and works on macOS and Windows. Cursor is supported this way today;
+the next section covers it.
+
+## Cursor
+
+There is nothing to launch or attach. If Cursor has run on the machine, its
+agent sessions show up next to Claude Code, Codex, and Gemini CLI ones:
+
+```bash
+agentsight top             # live ranked view includes Cursor sessions
+agentsight report --local  # summarize native sessions without a recorded DB
+agentsight vis             # replay Cursor file activity in a repository
+```
+
+AgentSight reads two local sources, both strictly read-only and safe while
+Cursor is running:
+
+- **Transcripts** under `~/.cursor/projects/<workspace>/agent-transcripts/`:
+  prompts, assistant output, tool calls, file activity, and per-event
+  timestamps. When Cursor delegates work through its `Task` tool, the
+  delegated runs are folded into the parent session, so a session that split
+  its work across sub-agents still reports everything it did.
+- **Cursor's state database** (`state.vscdb` under Cursor's user data
+  directory): session start and end times, the model, and the working
+  directory when the transcript doesn't carry one.
+
+Two things not to expect:
+
+- **Live request and response bodies.** That is TLS capture, which does not
+  work on Electron IDEs for the reasons above. Cursor sessions show what the
+  agent did, not the raw API traffic.
+- **Token counts on current versions.** Cursor stopped recording per-turn
+  usage locally around March 2026. Sessions old enough to carry usage events
+  show token totals; newer ones show none, and that is expected rather than a
+  capture failure.
 
 ## Containers and Kubernetes Pods
 

--- a/script/cursor_scan.py
+++ b/script/cursor_scan.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Scan local Cursor agent transcripts and report their structure.
+
+Built while working out the Cursor session format for eunomia-bpf/agentsight#24.
+Useful for building parser fixtures and for checking whether a Cursor release has
+changed the on-disk shape.
+
+Reads:
+    ~/.cursor/projects/<collapsed-cwd>/agent-transcripts/<composerId>/<composerId>.jsonl
+    ~/.cursor/projects/<collapsed-cwd>/agent-transcripts/<composerId>/subagents/<childId>.jsonl
+    <globalStorage>/state.vscdb          (optional, --db)
+
+Default output is structure only: record counts, tool names, and argument KEY names.
+Transcripts contain real prompts and real file paths, so content stays off unless you
+ask for it with --paths or --commands. Check what you're about to share.
+
+Usage:
+    python3 script/cursor_scan.py                  # summary
+    python3 script/cursor_scan.py --args           # per-tool argument schemas
+    python3 script/cursor_scan.py --db             # join to state.vscdb metadata
+    python3 script/cursor_scan.py --paths          # include file paths (sensitive)
+    python3 script/cursor_scan.py --commands       # include shell commands (sensitive)
+    python3 script/cursor_scan.py --json out.json  # machine-readable dump
+"""
+
+import argparse
+import collections
+import glob
+import json
+import os
+import sqlite3
+import sys
+
+PROJECTS = os.path.expanduser("~/.cursor/projects")
+
+DB_CANDIDATES = [
+    "~/Library/Application Support/Cursor/User/globalStorage/state.vscdb",  # macOS
+    "~/.config/Cursor/User/globalStorage/state.vscdb",  # Linux
+    os.path.join(os.environ.get("APPDATA", ""), "Cursor/User/globalStorage/state.vscdb"),
+]
+
+
+def find_db():
+    for path in DB_CANDIDATES:
+        expanded = os.path.expanduser(path)
+        if expanded and os.path.exists(expanded):
+            return expanded
+    return None
+
+
+def transcripts():
+    """Yield (composer_id, parent_id_or_None, project_dir, path).
+
+    A subagent's parent is just the directory that contains subagents/, which is the
+    only link between them. The Task tool call that spawned the child does not record
+    the child's id.
+    """
+    for path in sorted(glob.glob(f"{PROJECTS}/*/agent-transcripts/*/*.jsonl")):
+        parts = path.split(os.sep)
+        composer = parts[-2]
+        yield composer, None, parts[-4], path
+    for path in sorted(glob.glob(f"{PROJECTS}/*/agent-transcripts/*/subagents/*.jsonl")):
+        parts = path.split(os.sep)
+        child = os.path.basename(path)[: -len(".jsonl")]
+        yield child, parts[-3], parts[-5], path
+
+
+def scan_file(path):
+    """Parse one transcript. Tolerates truncation since Cursor appends while running."""
+    out = {
+        "records": 0,
+        "bad_lines": 0,
+        "roles": collections.Counter(),
+        "turn_status": collections.Counter(),
+        "tools": collections.Counter(),
+        "args": collections.defaultdict(collections.Counter),
+        "paths": [],
+        "commands": [],
+    }
+    with open(path, encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                out["bad_lines"] += 1
+                continue
+            out["records"] += 1
+            if rec.get("role"):
+                out["roles"][rec["role"]] += 1
+            if rec.get("type") == "turn_ended":
+                out["turn_status"][rec.get("status", "?")] += 1
+            for part in (rec.get("message") or {}).get("content") or []:
+                if not isinstance(part, dict) or part.get("type") != "tool_use":
+                    continue
+                name = part.get("name") or "?"
+                args = part.get("input") or part.get("args") or {}
+                out["tools"][name] += 1
+                out["args"][name].update(args.keys())
+                # path is a string on most tools; ReadLints uses paths as a list
+                for key in ("path", "paths"):
+                    value = args.get(key)
+                    if isinstance(value, str):
+                        out["paths"].append(value)
+                    elif isinstance(value, list):
+                        out["paths"].extend(str(item) for item in value)
+                if name == "Shell" and args.get("command"):
+                    out["commands"].append(args["command"])
+    return out
+
+
+def db_metadata(db_path, composer_ids):
+    """Pull header, model, and token totals for the given composers. Read only."""
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    meta = {}
+    tables = {r[0] for r in con.execute("select name from sqlite_master where type='table'")}
+    for cid in composer_ids:
+        row = {}
+        if "composerHeaders" in tables:
+            header = con.execute(
+                "select createdAt, lastUpdatedAt, isSubagent, isArchived, workspaceId"
+                " from composerHeaders where composerId = ?",
+                (cid,),
+            ).fetchone()
+            if header:
+                row.update(
+                    created=header[0],
+                    updated=header[1],
+                    is_subagent=header[2],
+                    archived=header[3],
+                    workspace=header[4],
+                )
+        blob = con.execute(
+            "select value from cursorDiskKV where key = ?", (f"composerData:{cid}",)
+        ).fetchone()
+        if blob:
+            try:
+                data = json.loads(blob[0])
+                model = (data.get("modelConfig") or {}).get("modelName")
+                # the literal string "default" means the user never pinned a model
+                row["model"] = None if model == "default" else model
+                ident = (data.get("workspaceIdentifier") or {}).get("uri") or {}
+                row["fs_path"] = ident.get("fsPath")
+                row["newly_created"] = len(data.get("newlyCreatedFiles") or [])
+            except (json.JSONDecodeError, AttributeError, TypeError):
+                pass
+        tokens_in = tokens_out = bubbles = 0
+        for (value,) in con.execute(
+            "select value from cursorDiskKV where key >= ? and key < ?",
+            (f"bubbleId:{cid}:", f"bubbleId:{cid};"),
+        ):
+            bubbles += 1
+            try:
+                counts = json.loads(value).get("tokenCount") or {}
+            except (json.JSONDecodeError, AttributeError):
+                continue
+            tokens_in += counts.get("inputTokens") or 0
+            tokens_out += counts.get("outputTokens") or 0
+        row.update(bubbles=bubbles, input_tokens=tokens_in, output_tokens=tokens_out)
+        meta[cid] = row
+    con.close()
+    return meta
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--args", action="store_true", help="per-tool argument key schemas")
+    ap.add_argument("--db", action="store_true", help="join to state.vscdb metadata")
+    ap.add_argument("--paths", action="store_true", help="include file paths (sensitive)")
+    ap.add_argument("--commands", action="store_true", help="include shell commands (sensitive)")
+    ap.add_argument("--json", metavar="FILE", help="write the full result as JSON")
+    opts = ap.parse_args()
+
+    if not os.path.isdir(PROJECTS):
+        sys.exit(f"no Cursor projects directory at {PROJECTS}")
+
+    found = list(transcripts())
+    if not found:
+        sys.exit("no transcripts found under agent-transcripts/")
+
+    sessions = {}
+    totals = collections.Counter()
+    all_args = collections.defaultdict(collections.Counter)
+    parents = collections.Counter()
+    children = collections.Counter()
+
+    for composer, parent, project, path in found:
+        data = scan_file(path)
+        sessions[path] = dict(data, composer=composer, parent=parent, project=project)
+        totals.update(data["tools"])
+        for name, keys in data["args"].items():
+            all_args[name].update(keys)
+        (children if parent else parents).update(data["tools"])
+
+    print(f"transcripts: {len(found)}  "
+          f"({sum(1 for _, p, _, _ in found if not p)} parent, "
+          f"{sum(1 for _, p, _, _ in found if p)} subagent)")
+    print()
+    for path, s in sessions.items():
+        kind = "SUB" if s["parent"] else "PAR"
+        note = f"  parent={s['parent'][:8]}" if s["parent"] else ""
+        bad = f"  bad_lines={s['bad_lines']}" if s["bad_lines"] else ""
+        print(f"{kind}  {s['composer'][:8]}  {s['records']:4} rec  "
+              f"turns={dict(s['turn_status'])}  {dict(s['tools'])}{note}{bad}")
+
+    print()
+    print(f"tools, all transcripts : {dict(totals.most_common())}")
+    print(f"tools, parents only    : {dict(parents.most_common())}")
+    print(f"tools, subagents only  : {dict(children.most_common())}")
+
+    if opts.args:
+        print("\nargument keys per tool (a key missing from some calls is optional):")
+        for name in sorted(all_args):
+            keys = dict(all_args[name])
+            flags = [k for k in keys if k.startswith("-")]
+            print(f"  {name}: {keys}")
+            if flags:
+                print(f"      flag-shaped keys, not data: {flags}")
+
+    if opts.paths:
+        seen = sorted({p for s in sessions.values() for p in s["paths"]})
+        print(f"\npaths ({len(seen)}):")
+        for p in seen:
+            print(f"  {p}")
+
+    if opts.commands:
+        print("\nshell commands:")
+        for s in sessions.values():
+            for c in s["commands"]:
+                print(f"  {c}")
+
+    if opts.db:
+        db_path = find_db()
+        if not db_path:
+            print("\nno state.vscdb found")
+        else:
+            print(f"\nstate.vscdb: {db_path}")
+            meta = db_metadata(db_path, [s["composer"] for s in sessions.values()])
+            for cid, row in meta.items():
+                print(f"  {cid[:8]}  {row}")
+
+    if opts.json:
+        payload = {
+            "sessions": [
+                {k: (dict(v) if isinstance(v, collections.Counter) else
+                     {kk: dict(vv) for kk, vv in v.items()} if isinstance(v, dict) and k == "args"
+                     else v)
+                 for k, v in s.items()
+                 if k not in (() if opts.paths else ("paths",)) + (() if opts.commands else ("commands",))}
+                for s in sessions.values()
+            ],
+            "tool_totals": dict(totals),
+            "arg_keys": {k: dict(v) for k, v in all_args.items()},
+        }
+        with open(opts.json, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, default=str)
+        print(f"\nwrote {opts.json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds Cursor as a supported agent through the agent-native session path. Addresses the Cursor half of #24. Co-authored with @AlecAsdourian.

- discover Cursor transcripts under `~/.cursor/projects/<workspace>/agent-transcripts/`; one candidate per session (the parent transcript), with `updated` taken as the max mtime across the parent and its `subagents/*.jsonl` so a delegated write invalidates the session cache
- parse prompts, tool calls, file activity, and per-event timestamps; Cursor delegates per turn through a `Task` tool, and delegated transcripts fold into the parent session
- enrich sessions from Cursor's `state.vscdb`, joined on the transcript's composer id: session timing, model, working-directory upgrade, and legacy token totals; read-only open, indexed queries only, degrades to the parsed session when the database is missing or locked
- render Cursor sessions in `agentvis`
- document capture scope and limitations in `docs/agents.md`, the README table, and the FAQ
- record shell path operands regardless of file extension (previous allowlist dropped most of them; affects all agents)
- gate the `/proc/self/root` test to Linux so `cargo test` passes on macOS

## Why the agent-native path

TLS capture cannot reach Cursor. Most installs run on macOS or Windows, where the eBPF probes cannot load; the SSL code sits inside the stripped Electron framework in a helper process rather than the binary that `--binary-path` auto-discovery resolves; and the API traffic is protobuf over the Connect protocol, which the JSON-based LLM extraction does not parse. All three causes are documented in `docs/agents.md`.

## Behavior and limitations

- No `sudo` and no launch step. Existing Cursor sessions appear in `top`, `report --local`, `vis`, and the web UI.
- Current Cursor versions stopped recording per-turn token usage locally around March 2026 (verified on two installs). Token totals appear only on sessions old enough to carry usage events; zero on a recent session is expected and documented.
- Session-level timing comes from `state.vscdb`; per-event timestamps come from the transcript at minute resolution. Database-derived per-event times were deliberately not applied so consumers without database access stay consistent.
- Enrichment lives in `agentsight-capture` to keep `agent-session` free of rusqlite, per the discussion on #24. `agentpprof` and `agentvis` therefore see transcript-derived data only.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` across `agent-session`, `agentsight-capture`, `agentvis`, `agentpprof`, and `collector` (300 tests)
- verified against real installs on two machines, including sessions with delegation, composers without header rows, and the database held open by a running Cursor with an active WAL
- `top --plain --once`, `report --local`, and the exported snapshot show model, timing, and workspace populated on real sessions

https://github.com/user-attachments/assets/3aae6644-7213-4ce6-9448-1e4264b8246c

<img width="865" height="617" alt="image" src="https://github.com/user-attachments/assets/e8611a30-d178-416a-ac35-31544418d688" />
<img width="870" height="163" alt="image" src="https://github.com/user-attachments/assets/2eb8035e-8f95-425b-b42d-56bbd9df7417" />
<img width="842" height="639" alt="image" src="https://github.com/user-attachments/assets/c0300a0e-d265-417b-8143-d0b73b05b62f" />
<img width="863" height="442" alt="image" src="https://github.com/user-attachments/assets/55a58c09-ea01-4914-a2f7-daa253e2e42a" />
<img width="860" height="529" alt="image" src="https://github.com/user-attachments/assets/3e1a7bd3-3596-4cd6-8e3a-9e27bc6fe89b" />
<img width="861" height="630" alt="image" src="https://github.com/user-attachments/assets/13b7c84a-af39-4bf3-b206-deb7fc1be5f3" />
