### PR TITLE
ci: dispatch and monitor npm release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -778,8 +778,10 @@ jobs:
         "$smoke_dir/agentpprof" --version
         "$smoke_dir/agentpprof" --help | grep -F -- '--session-file'
 
-    - name: Dispatch npm package publish
+    - name: Dispatch and monitor npm package publish
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RELEASE_TAG: ${{ needs.release_prepare.outputs.tag }}
-      run: gh workflow run npm-publish.yml --ref "$RELEASE_TAG"
+      run: |
+        npm_run_url="$(gh workflow run npm-publish.yml --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_TAG")"
+        gh run watch "${npm_run_url##*/}" --repo "$GITHUB_REPOSITORY" --exit-status --compact


### PR DESCRIPTION
## Summary

- pass the repository explicitly when dispatching the npm publish workflow
- capture the dispatched run URL and wait for its terminal result
- keep the parent release red if npm publishing fails instead of reporting a false success

## Failure evidence

Release v1.0.6 successfully published and passed its artifact smoke test, but the final dispatch step failed with:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The equivalent explicit command successfully started npm run 31483194952. That run then exposed a separate npm registry Trusted Publisher/permission E404, confirming why the parent release must monitor it.

## Validation

- `git diff --check`
- workflow YAML parse
- shell syntax check
- manual explicit dispatch returned run URL 31483194952 and ran through build/package validation
