### PR TITLE
fix: exclude threads from process snapshots

### DIFF
--- a/agentsight-capture/src/sources/proc.rs
+++ b/agentsight-capture/src/sources/proc.rs
@@ -84,7 +84,7 @@ impl ProcSnapshot {
         let procs = system
             .processes()
             .values()
-            .filter(|process| process.thread_kind().is_none())
+            .filter(|process| process.thread_kind() != Some(sysinfo::ThreadKind::Userland))
             .map(|process| proc_info_from_sysinfo(process, boot_time_s))
             .map(|info| (info.pid, info))
             .collect();
@@ -453,7 +453,7 @@ mod tests {
         #[cfg(target_os = "linux")]
         assert!(!snapshot.procs.contains_key(&tid));
         assert!(current.starttime_ticks > 0);
-        assert!(current.threads > 0);
+        assert!(current.threads > if cfg!(target_os = "linux") { 1 } else { 0 });
         assert!(!current.comm.is_empty() || !current.command.is_empty());
     }
 

--- a/agentsight-capture/src/sources/proc.rs
+++ b/agentsight-capture/src/sources/proc.rs
@@ -84,10 +84,9 @@ impl ProcSnapshot {
         let procs = system
             .processes()
             .values()
-            .map(|process| {
-                let info = proc_info_from_sysinfo(process, boot_time_s);
-                (info.pid, info)
-            })
+            .filter(|process| process.thread_kind().is_none())
+            .map(|process| proc_info_from_sysinfo(process, boot_time_s))
+            .map(|info| (info.pid, info))
             .collect();
 
         Ok(Self {
@@ -441,6 +440,7 @@ fn ticks_per_second() -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
 
     #[test]
     fn snapshot_collects_current_process() {
@@ -448,6 +448,10 @@ mod tests {
         let current = snapshot.procs.get(&std::process::id()).unwrap();
 
         assert_eq!(current.pid, std::process::id());
+        #[cfg(target_os = "linux")]
+        let tid = unsafe { libc::gettid() } as u32;
+        #[cfg(target_os = "linux")]
+        assert!(!snapshot.procs.contains_key(&tid));
         assert!(current.starttime_ticks > 0);
         assert!(current.threads > 0);
         assert!(!current.comm.is_empty() || !current.command.is_empty());
@@ -456,15 +460,9 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn snapshot_counts_single_thread_process() {
-        let mut child = std::process::Command::new("sleep")
-            .arg("5")
-            .spawn()
-            .unwrap();
+        let mut child = Command::new("sleep").arg("5").spawn().unwrap();
         let snapshot = ProcSnapshot::collect().unwrap();
-        let threads = snapshot
-            .procs
-            .get(&child.id())
-            .map(|proc_info| proc_info.threads);
+        let threads = snapshot.procs.get(&child.id()).map(|p| p.threads);
         let _ = child.kill();
         let _ = child.wait();
 


### PR DESCRIPTION
## Summary

- keep sysinfo task collection so per-process thread counts remain available
- exclude only duplicated userland task/thread entries from the materialized process snapshot
- preserve top-level kernel-process entries
- cover the regression by asserting that the test worker TID is not exposed as a process while its thread still contributes to the leader count
- simplify the touched iterator and test setup so the patch is net-negative in LOC

## Root cause

On Linux, enabling sysinfo task collection also exposes userland threads through System::processes(). AgentSight copied every entry into ProcSnapshot.procs, so live top and monitor treated threads as processes and repeatedly scanned shared /proc state for each thread. RSS was also counted once per thread.

## Impact

The public CLI, output schema, sampling interval, matching rules, kernel-process handling, and thread-count field are unchanged. On the affected host, one live Codex family changed from 521 reported process entries to 38 actual process entries.

Five warm runs of `agentsight top --once --plain -n 25` on the same host:

| Metric (median) | master | patched |
| --- | ---: | ---: |
| wall time | 0.91 s | 0.79 s |
| user CPU | 0.23 s | 0.18 s |
| system CPU | 0.31 s | 0.23 s |

## Validation

- `cargo fmt --check`
- `cargo clippy --manifest-path agentsight-capture/Cargo.toml --all-targets -- -D warnings`
- `cargo test` in `agentsight-capture`
- `cargo test` in `collector`
- `make test`
- release build plus five-run before/after live benchmark

Diff: one file, 11 insertions and 13 deletions.