### PR TITLE
perf: shrink the release binary by 44%

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -21,6 +21,10 @@ include = [
     "vendor/frontend/dist/**",
 ]
 
+[profile.release]
+codegen-units = 1
+strip = "symbols"
+
 [dependencies]
 agentsight-capture = { version = "1.0.6", path = "../agentsight-capture" }
 agent-session = { version = "0.4.35", path = "../agent-session" }


### PR DESCRIPTION
## Summary

Build the shipped AgentSight collector with a single codegen unit and strip release symbols. This changes only the release profile; CLI behavior, embedded frontend/eBPF assets, storage formats, capture paths, debug builds, and test builds are unchanged.

## Measurements

Linux x86_64, Rust 1.90.0, same machine:

| Artifact | Default release reference | This PR | Change |
| --- | ---: | ---: | ---: |
| Raw binary | 39,981,384 B | 22,377,344 B | -44.0% |
| gzip -9 | 15,379,170 B | 9,464,627 B | -38.5% |

The optimized ELF is stripped. The separately proposed process-snapshot fix in #155 addresses the dominant long-running CPU overhead; this PR primarily reduces shipped/on-disk size.

## Dependency audit

I audited the collector's direct dependencies and retained the large feature-bearing libraries because they back active commands:

- `headless_chrome` is required by `agentsight vis` media export
- `rusqlite` is required by session persistence
- Brotli/zstd/flate dependencies are required by captured HTTP decompression
- embedded eBPF programs and frontend assets are product payloads, not accidental dependency bloat

I initially replaced `num_cpus` with `std::thread::available_parallelism()`, then reverted that change after review. `num_cpus` caches Linux cgroup discovery and rounds fractional CPU quotas differently, so removing it would not strictly preserve telemetry behavior and could amplify cgroup filesystem reads in target-heavy monitoring.

## Validation

- `cargo fmt --check`
- capture tests: 155 passed, 1 ignored; public API and doc tests passed
- collector tests: 66 unit + 5 export snapshot + 3 system runner tests passed in the initial isolated run
- capture and collector `cargo clippy --all-targets -- -D warnings`
- final release build
- byte-for-byte identical output for `--help`, `top --help`, and `vis --help` versus installed v1.0.6
- full eBPF C/runtime suite passed
- macOS smoke passed on the initial head; CI is rerunning on the final head

A later full `make test` run on this heavily loaded development host hit two existing live-snapshot fixture failures: more than 20 real Codex process families displaced the synthetic agent session from `top --limit 20`. That is the process enumeration issue fixed separately by #155, not a failure in the file changed here. GitHub CI remains the clean-host gate.

## Tradeoffs

- a local clean release build increased from about 87 s to 126 s because `codegen-units = 1` serializes more optimization work; debug and test profiles are unchanged
- stripped release binaries retain normal runtime behavior but have less local symbol information in crash backtraces; debug builds remain symbolized
