### PR TITLE
Add direct messaging for native agent sessions

### DIFF
--- a/collector/src/cmd_bind.rs
+++ b/collector/src/cmd_bind.rs
@@ -33,7 +33,7 @@ pub(crate) async fn run_bind(
         None => endpoint_url(ip, port),
     }?;
     let (app_url, allowed_origin) = normalize_app_url(app_url)?;
-    let access_token = random_token();
+    let access_token = local_access_token()?;
     let bind_url = build_bind_url(&app_url, &endpoint, &access_token)?;
     let node = local_node_metadata()?;
     let view = MaterializedView::shared_bounded();
@@ -55,7 +55,7 @@ pub(crate) async fn run_bind(
 
     println!("Bind this device at:\n{bind_url}");
     println!(
-        "The access key lasts only while this command is running and is removed from the browser URL after opening."
+        "The access key is stored locally, survives Node restarts, and is removed from the browser URL after opening."
     );
     if let Some(db_path) = db_path {
         println!("Serving saved AgentSight data from {db_path}.");
@@ -94,13 +94,44 @@ fn random_token() -> String {
     )
 }
 
-fn local_node_metadata()
--> Result<crate::server::NodeMetadata, Box<dyn std::error::Error + Send + Sync>> {
-    let config_dir = dirs::config_dir()
+fn config_dir() -> Result<std::path::PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+    let dir = dirs::config_dir()
         .ok_or("could not find the user configuration directory")?
         .join("agentsight");
-    std::fs::create_dir_all(&config_dir)?;
-    let id_path = config_dir.join("node-id");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+fn local_access_token() -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let path = config_dir()?.join("access-token");
+    match std::fs::read_to_string(&path) {
+        Ok(value) if valid_access_token(value.trim()) => Ok(value.trim().to_string()),
+        Ok(_) => Err(format!("invalid AgentSight access token at {}", path.display()).into()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let token = random_token();
+            let mut file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(path)?;
+            use std::io::Write;
+            writeln!(file, "{token}")?;
+            Ok(token)
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn valid_access_token(value: &str) -> bool {
+    (32..=256).contains(&value.len())
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+}
+
+fn local_node_metadata()
+-> Result<crate::server::NodeMetadata, Box<dyn std::error::Error + Send + Sync>> {
+    let id_path = config_dir()?.join("node-id");
     let id = match std::fs::read_to_string(&id_path) {
         Ok(value) if valid_node_id(value.trim()) => value.trim().to_string(),
         Ok(_) => {
@@ -254,5 +285,12 @@ mod tests {
         assert!(valid_node_id("node_0123abcdef"));
         assert!(!valid_node_id("../../node_secret"));
         assert!(!valid_node_id("machine"));
+    }
+
+    #[test]
+    fn access_tokens_are_narrowly_validated() {
+        assert!(valid_access_token(&"a".repeat(64)));
+        assert!(!valid_access_token("short"));
+        assert!(!valid_access_token(&format!("{}!", "a".repeat(63))));
     }
 }

--- a/collector/src/server/mod.rs
+++ b/collector/src/server/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 eunomia-bpf org.
 
 pub mod assets;
+pub(crate) mod session_runtime;
 pub mod web;
 
 pub use web::{NodeMetadata, WebServer};

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -42,8 +42,8 @@ enum Runtime {
     },
 }
 
-#[derive(Default)]
 struct CodexState {
+    thread_id: String,
     active_turn: Option<String>,
     starting: bool,
 }
@@ -55,14 +55,17 @@ impl Runtime {
                 if child.try_wait().map_err(io_error)?.is_some() {
                     return Err(SubmitError::Failed("Claude live transport exited".to_string()));
                 }
-                let value = json!({
-                    "type": "user",
-                    "message": {
-                        "role": "user",
-                        "content": [{"type": "text", "text": message}]
-                    }
-                });
-                write_json_line(stdin, &value).await?;
+                write_json_line(
+                    stdin,
+                    &json!({
+                        "type": "user",
+                        "message": {
+                            "role": "user",
+                            "content": [{"type": "text", "text": message}]
+                        }
+                    }),
+                )
+                .await?;
                 Ok("claude-stream-json")
             }
             Self::Codex {
@@ -74,9 +77,15 @@ impl Runtime {
                 if child.try_wait().map_err(io_error)?.is_some() {
                     return Err(SubmitError::Failed("Codex app-server exited".to_string()));
                 }
-                let (active_turn, starting) = state
+                let (thread_id, active_turn, starting) = state
                     .lock()
-                    .map(|state| (state.active_turn.clone(), state.starting))
+                    .map(|state| {
+                        (
+                            state.thread_id.clone(),
+                            state.active_turn.clone(),
+                            state.starting,
+                        )
+                    })
                     .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?;
                 if starting {
                     return Err(SubmitError::Conflict(
@@ -90,7 +99,7 @@ impl Runtime {
                         "method": "turn/steer",
                         "id": id,
                         "params": {
-                            "threadId": runtime_thread_id(state)?,
+                            "threadId": thread_id,
                             "expectedTurnId": turn_id,
                             "input": [{"type": "text", "text": message}]
                         }
@@ -104,7 +113,7 @@ impl Runtime {
                         "method": "turn/start",
                         "id": id,
                         "params": {
-                            "threadId": runtime_thread_id(state)?,
+                            "threadId": thread_id,
                             "input": [{"type": "text", "text": message}]
                         }
                     })
@@ -119,19 +128,6 @@ impl Runtime {
             }
         }
     }
-}
-
-// The thread id is stored in active_turn's companion sentinel before the reader starts.
-// Keeping it in one field avoids a second allocation in Runtime.
-fn runtime_thread_id(state: &Arc<StdMutex<CodexState>>) -> Result<String, SubmitError> {
-    state
-        .lock()
-        .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?
-        .active_turn
-        .as_deref()
-        .and_then(|value| value.strip_prefix("thread:"))
-        .map(ToString::to_string)
-        .ok_or_else(|| SubmitError::Failed("Codex thread is not initialized".to_string()))
 }
 
 pub async fn submit_message(
@@ -193,7 +189,10 @@ async fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
         "--verbose",
     ]);
     apply_cwd(&mut command, session);
-    command.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null());
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
     let mut child = command
         .spawn()
         .map_err(|error| SubmitError::Failed(format!("failed to start Claude live session: {error}")))?;
@@ -213,7 +212,10 @@ async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
     let mut command = Command::new("codex");
     command.args(["app-server", "--stdio"]);
     apply_cwd(&mut command, session);
-    command.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null());
+    command
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
     let mut child = command
         .spawn()
         .map_err(|error| SubmitError::Failed(format!("failed to start Codex app-server: {error}")))?;
@@ -259,7 +261,8 @@ async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
     wait_for_response(&mut reader, 2).await?;
 
     let state = Arc::new(StdMutex::new(CodexState {
-        active_turn: Some(format!("thread:{}", session.session_id)),
+        thread_id: session.session_id.clone(),
+        active_turn: None,
         starting: false,
     }));
     let reader_state = Arc::clone(&state);
@@ -296,32 +299,17 @@ where
             .or_else(|| value.pointer("/result/turn/id"))
             .and_then(Value::as_str)
             .map(str::to_string);
-        if method == Some("turn/started") || turn_id.is_some() {
-            if let Some(turn_id) = turn_id
-                && let Ok(mut state) = state.lock()
-            {
-                let thread = state
-                    .active_turn
-                    .as_deref()
-                    .and_then(|value| value.strip_prefix("thread:"))
-                    .map(str::to_string);
-                state.active_turn = Some(turn_id);
-                state.starting = false;
-                if let Some(thread) = thread {
-                    // Preserve the thread id in a form runtime_thread_id can recover after completion.
-                    state.active_turn = Some(format!("{turn_id}\nthread:{thread}"));
-                }
-            }
+        if (method == Some("turn/started") || turn_id.is_some())
+            && let Some(turn_id) = turn_id
+            && let Ok(mut state) = state.lock()
+        {
+            state.active_turn = Some(turn_id);
+            state.starting = false;
         }
         if method == Some("turn/completed")
             && let Ok(mut state) = state.lock()
         {
-            let thread = state
-                .active_turn
-                .as_deref()
-                .and_then(|value| value.split("\nthread:").nth(1))
-                .map(str::to_string);
-            state.active_turn = thread.map(|thread| format!("thread:{thread}"));
+            state.active_turn = None;
             state.starting = false;
         }
     }
@@ -377,7 +365,10 @@ fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitErro
     let mut command = Command::new("gemini");
     command.args(["--resume", &session.session_id, message]);
     apply_cwd(&mut command, session);
-    command.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
     let mut child = command
         .spawn()
         .map_err(|error| SubmitError::Failed(format!("failed to resume Gemini session: {error}")))?;

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -308,8 +308,11 @@ async fn send_json(stdin: &mut ChildStdin, value: Value) -> Result<(), SubmitErr
     stdin
         .write_all(&data)
         .await
-        .and_then(|_| async { stdin.flush().await }.await)
-        .map_err(|error| failed(format!("provider transport write failed: {error}")))
+        .map_err(|error| failed(format!("provider transport write failed: {error}")))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|error| failed(format!("provider transport flush failed: {error}")))
 }
 
 async fn drain<R: tokio::io::AsyncRead + Unpin>(stdout: R) {

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -3,15 +3,16 @@
 
 use agent_session::AgentSession;
 use serde_json::{Value, json};
-use std::collections::HashMap;
-use std::path::Path;
+use std::collections::{HashMap, HashSet};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
 use tokio::sync::Mutex;
 
-use crate::view::live_top::LiveView;
+use crate::sources::proc as procfs;
+use crate::view::process_select;
 
 static RUNTIMES: OnceLock<Mutex<HashMap<String, Runtime>>> = OnceLock::new();
 
@@ -270,15 +271,62 @@ where
 }
 
 fn session_is_running(session: &AgentSession) -> bool {
-    let Ok(sample) = LiveView::default().refresh_monitor_sample(50) else {
+    let Ok(sample) = procfs::ProcSnapshot::collect() else {
         return false;
     };
-    let target = canonical(&session.path);
-    sample
-        .sessions
-        .iter()
-        .filter_map(|live| live.session_path.as_deref())
-        .any(|path| canonical(path) == target)
+    let children = sample.children_by_ppid();
+    let roots = process_select::live_root_pids(&sample, None, None);
+    let root_set = roots.iter().copied().collect::<HashSet<_>>();
+    let candidates = roots
+        .into_iter()
+        .filter_map(|root_pid| {
+            let root = sample.procs.get(&root_pid)?;
+            (process_select::known_agent_label(&root.comm, &root.command)
+                == Some(session.agent_type.as_str()))
+            .then(|| {
+                let family = procfs::process_family_excluding(
+                    root_pid,
+                    &children,
+                    &sample.procs,
+                    &root_set,
+                );
+                let members = family
+                    .into_iter()
+                    .filter_map(|pid| sample.procs.get(&pid).map(procfs::ProcInfo::process_key))
+                    .collect();
+                agent_session::LiveProcessCandidate {
+                    tree: agent_session::ProcessTree {
+                        root: root.process_key(),
+                        members,
+                    },
+                    agent: session.agent_type.clone(),
+                    age_s: Some(procfs::process_age_s(root, &sample)),
+                    cwd: root
+                        .cwd
+                        .as_ref()
+                        .map(|path| path.to_string_lossy().to_string()),
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    let trees = candidates.iter().map(|candidate| candidate.tree.clone()).collect::<Vec<_>>();
+    let fd_paths = procfs::collect_fd_paths(&trees);
+    let input = agent_session::SessionProcessInput {
+        id: session.session_id.clone(),
+        agent: session.agent_type.clone(),
+        path: session.path.clone(),
+        start_timestamp_ms: session.start_timestamp_ms,
+        end_timestamp_ms: session.end_timestamp_ms,
+        cwd: session.cwd.clone(),
+    };
+    let matches = agent_session::SessionProcessMatcher::default().match_sessions(
+        &[input],
+        &candidates,
+        &fd_paths,
+        &HashMap::new(),
+        now_ms(),
+    );
+    matches.by_session_id.contains_key(&session.session_id)
 }
 
 fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
@@ -329,8 +377,11 @@ fn reap(mut child: Child, agent: &'static str, session_id: String) {
     });
 }
 
-fn canonical(path: &Path) -> std::path::PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
 }
 
 fn failed(message: impl Into<String>) -> SubmitError {

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -30,12 +30,8 @@ pub struct SubmitResult {
 }
 
 enum Runtime {
-    Claude {
-        child: Child,
-        stdin: ChildStdin,
-    },
+    Claude(ChildStdin),
     Codex {
-        child: Child,
         stdin: ChildStdin,
         state: Arc<StdMutex<CodexState>>,
         next_id: u64,
@@ -51,74 +47,47 @@ struct CodexState {
 impl Runtime {
     async fn send(&mut self, message: &str) -> Result<&'static str, SubmitError> {
         match self {
-            Self::Claude { child, stdin } => {
-                if child.try_wait().map_err(io_error)?.is_some() {
-                    return Err(SubmitError::Failed("Claude live transport exited".to_string()));
-                }
-                write_json_line(
+            Self::Claude(stdin) => {
+                send_json(
                     stdin,
-                    &json!({
-                        "type": "user",
-                        "message": {
-                            "role": "user",
-                            "content": [{"type": "text", "text": message}]
-                        }
+                    json!({
+                        "type":"user",
+                        "message":{"role":"user","content":[{"type":"text","text":message}]}
                     }),
                 )
                 .await?;
                 Ok("claude-stream-json")
             }
             Self::Codex {
-                child,
                 stdin,
                 state,
                 next_id,
             } => {
-                if child.try_wait().map_err(io_error)?.is_some() {
-                    return Err(SubmitError::Failed("Codex app-server exited".to_string()));
-                }
                 let (thread_id, active_turn, starting) = state
                     .lock()
-                    .map(|state| {
-                        (
-                            state.thread_id.clone(),
-                            state.active_turn.clone(),
-                            state.starting,
-                        )
-                    })
-                    .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?;
+                    .map(|s| (s.thread_id.clone(), s.active_turn.clone(), s.starting))
+                    .map_err(|_| failed("Codex state lock poisoned"))?;
                 if starting {
                     return Err(SubmitError::Conflict(
-                        "Codex is accepting the previous message; retry after the turn starts".to_string(),
+                        "Codex is accepting the previous message; retry after the turn starts".into(),
                     ));
                 }
                 *next_id += 1;
-                let id = *next_id;
                 let request = if let Some(turn_id) = active_turn {
                     json!({
-                        "method": "turn/steer",
-                        "id": id,
-                        "params": {
-                            "threadId": thread_id,
-                            "expectedTurnId": turn_id,
-                            "input": [{"type": "text", "text": message}]
-                        }
+                        "method":"turn/steer","id":*next_id,
+                        "params":{"threadId":thread_id,"expectedTurnId":turn_id,
+                            "input":[{"type":"text","text":message}]}
                     })
                 } else {
-                    state
-                        .lock()
-                        .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?
-                        .starting = true;
+                    state.lock().map_err(|_| failed("Codex state lock poisoned"))?.starting = true;
                     json!({
-                        "method": "turn/start",
-                        "id": id,
-                        "params": {
-                            "threadId": thread_id,
-                            "input": [{"type": "text", "text": message}]
-                        }
+                        "method":"turn/start","id":*next_id,
+                        "params":{"threadId":thread_id,
+                            "input":[{"type":"text","text":message}]}
                     })
                 };
-                if let Err(error) = write_json_line(stdin, &request).await {
+                if let Err(error) = send_json(stdin, request).await {
                     if let Ok(mut state) = state.lock() {
                         state.starting = false;
                     }
@@ -138,47 +107,47 @@ pub async fn submit_message(
     if let Some(runtime) = map.get_mut(&session.session_id) {
         match runtime.send(message).await {
             Ok(transport) => return Ok(SubmitResult { transport }),
+            Err(SubmitError::Conflict(error)) => return Err(SubmitError::Conflict(error)),
             Err(SubmitError::Failed(_)) => {
                 map.remove(&session.session_id);
             }
-            Err(error) => return Err(error),
         }
     }
 
     if session_is_running(session) {
         return Err(SubmitError::Conflict(
-            "this session is already running outside AgentSight; live attachment is not available for that runtime"
-                .to_string(),
+            "session is already running outside AgentSight; this runtime cannot be attached safely"
+                .into(),
         ));
     }
 
-    match session.agent_type.as_str() {
+    let (runtime, transport) = match session.agent_type.as_str() {
         agent_session::AGENT_CLAUDE => {
-            let mut runtime = start_claude(session).await?;
+            let mut runtime = start_claude(session)?;
             let transport = runtime.send(message).await?;
-            map.insert(session.session_id.clone(), runtime);
-            Ok(SubmitResult { transport })
+            (Some(runtime), transport)
         }
         agent_session::AGENT_CODEX => {
             let mut runtime = start_codex(session).await?;
             let transport = runtime.send(message).await?;
-            map.insert(session.session_id.clone(), runtime);
-            Ok(SubmitResult { transport })
+            (Some(runtime), transport)
         }
         agent_session::AGENT_GEMINI => {
             drop(map);
             resume_gemini(session, message)?;
-            Ok(SubmitResult {
+            return Ok(SubmitResult {
                 transport: "gemini-resume",
-            })
+            });
         }
-        other => Err(SubmitError::Failed(format!(
-            "sending messages to {other} sessions is not supported yet"
-        ))),
+        other => return Err(failed(format!("messaging {other} sessions is not supported"))),
+    };
+    if let Some(runtime) = runtime {
+        map.insert(session.session_id.clone(), runtime);
     }
+    Ok(SubmitResult { transport })
 }
 
-async fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
+fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
     let mut command = Command::new("claude");
     command.args([
         "-p",
@@ -188,165 +157,121 @@ async fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
         "--output-format=stream-json",
         "--verbose",
     ]);
-    apply_cwd(&mut command, session);
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+    configure(&mut command, session, true);
     let mut child = command
         .spawn()
-        .map_err(|error| SubmitError::Failed(format!("failed to start Claude live session: {error}")))?;
-    let stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| SubmitError::Failed("Claude stdin was not available".to_string()))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| SubmitError::Failed("Claude stdout was not available".to_string()))?;
-    tokio::spawn(drain_lines(stdout, "claude"));
-    Ok(Runtime::Claude { child, stdin })
+        .map_err(|error| failed(format!("failed to start Claude live session: {error}")))?;
+    let stdin = child.stdin.take().ok_or_else(|| failed("Claude stdin unavailable"))?;
+    let stdout = child.stdout.take().ok_or_else(|| failed("Claude stdout unavailable"))?;
+    tokio::spawn(drain(stdout));
+    reap(child, "claude", session.session_id.clone());
+    Ok(Runtime::Claude(stdin))
 }
 
 async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
     let mut command = Command::new("codex");
     command.args(["app-server", "--stdio"]);
-    apply_cwd(&mut command, session);
-    command
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null());
+    configure(&mut command, session, true);
     let mut child = command
         .spawn()
-        .map_err(|error| SubmitError::Failed(format!("failed to start Codex app-server: {error}")))?;
-    let mut stdin = child
-        .stdin
-        .take()
-        .ok_or_else(|| SubmitError::Failed("Codex stdin was not available".to_string()))?;
-    let stdout = child
-        .stdout
-        .take()
-        .ok_or_else(|| SubmitError::Failed("Codex stdout was not available".to_string()))?;
+        .map_err(|error| failed(format!("failed to start Codex app-server: {error}")))?;
+    let mut stdin = child.stdin.take().ok_or_else(|| failed("Codex stdin unavailable"))?;
+    let stdout = child.stdout.take().ok_or_else(|| failed("Codex stdout unavailable"))?;
     let mut reader = BufReader::new(stdout);
 
-    write_json_line(
+    send_json(
         &mut stdin,
-        &json!({
-            "method": "initialize",
-            "id": 1,
-            "params": {
-                "clientInfo": {
-                    "name": "agentsight",
-                    "title": "AgentSight",
-                    "version": env!("CARGO_PKG_VERSION")
-                }
-            }
-        }),
+        json!({"method":"initialize","id":1,"params":{"clientInfo":{
+            "name":"agentsight","title":"AgentSight","version":env!("CARGO_PKG_VERSION")
+        }}}),
     )
     .await?;
-    wait_for_response(&mut reader, 1).await?;
-    write_json_line(&mut stdin, &json!({"method": "initialized", "params": {}})).await?;
-    write_json_line(
+    wait_response(&mut reader, 1).await?;
+    send_json(&mut stdin, json!({"method":"initialized","params":{}})).await?;
+    send_json(
         &mut stdin,
-        &json!({
-            "method": "thread/resume",
-            "id": 2,
-            "params": {
-                "threadId": session.session_id,
-                "approvalPolicy": "never"
-            }
-        }),
+        json!({"method":"thread/resume","id":2,"params":{
+            "threadId":session.session_id,"approvalPolicy":"never"
+        }}),
     )
     .await?;
-    wait_for_response(&mut reader, 2).await?;
+    wait_response(&mut reader, 2).await?;
 
     let state = Arc::new(StdMutex::new(CodexState {
         thread_id: session.session_id.clone(),
         active_turn: None,
         starting: false,
     }));
-    let reader_state = Arc::clone(&state);
-    tokio::spawn(async move {
-        read_codex_events(reader, reader_state).await;
-    });
+    tokio::spawn(read_codex(reader, Arc::clone(&state)));
+    reap(child, "codex", session.session_id.clone());
     Ok(Runtime::Codex {
-        child,
         stdin,
         state,
         next_id: 2,
     })
 }
 
-async fn read_codex_events<R>(mut reader: BufReader<R>, state: Arc<StdMutex<CodexState>>)
+async fn read_codex<R>(mut reader: BufReader<R>, state: Arc<StdMutex<CodexState>>)
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut line = String::new();
     loop {
         line.clear();
-        let Ok(bytes) = reader.read_line(&mut line).await else {
-            break;
-        };
-        if bytes == 0 {
+        if reader.read_line(&mut line).await.ok().filter(|n| *n > 0).is_none() {
             break;
         }
         let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
             continue;
         };
         let method = value.get("method").and_then(Value::as_str);
-        let turn_id = value
+        let turn = value
             .pointer("/params/turn/id")
             .or_else(|| value.pointer("/result/turn/id"))
-            .and_then(Value::as_str)
-            .map(str::to_string);
-        if (method == Some("turn/started") || turn_id.is_some())
-            && let Some(turn_id) = turn_id
-            && let Ok(mut state) = state.lock()
-        {
-            state.active_turn = Some(turn_id);
-            state.starting = false;
-        }
-        if method == Some("turn/completed")
-            && let Ok(mut state) = state.lock()
-        {
-            state.active_turn = None;
-            state.starting = false;
+            .and_then(Value::as_str);
+        if let Ok(mut state) = state.lock() {
+            if method == Some("turn/completed") {
+                state.active_turn = None;
+                state.starting = false;
+            } else if let Some(turn) = turn {
+                state.active_turn = Some(turn.to_string());
+                state.starting = false;
+            } else if value.get("error").is_some() && value.get("id").is_some() {
+                state.starting = false;
+            }
         }
     }
 }
 
-async fn wait_for_response<R>(reader: &mut BufReader<R>, expected_id: u64) -> Result<(), SubmitError>
+async fn wait_response<R>(reader: &mut BufReader<R>, id: u64) -> Result<(), SubmitError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
     let mut line = String::new();
     loop {
         line.clear();
-        let bytes = reader
+        if reader
             .read_line(&mut line)
             .await
-            .map_err(|error| SubmitError::Failed(format!("failed to read provider response: {error}")))?;
-        if bytes == 0 {
-            return Err(SubmitError::Failed(
-                "provider transport closed during initialization".to_string(),
-            ));
+            .map_err(|error| failed(error.to_string()))?
+            == 0
+        {
+            return Err(failed("provider transport closed during initialization"));
         }
         let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
             continue;
         };
-        if value.get("id").and_then(Value::as_u64) != Some(expected_id) {
-            continue;
+        if value.get("id").and_then(Value::as_u64) == Some(id) {
+            return value
+                .get("error")
+                .map(|error| Err(failed(format!("provider rejected request: {error}"))))
+                .unwrap_or(Ok(()));
         }
-        if let Some(error) = value.get("error") {
-            return Err(SubmitError::Failed(format!("provider rejected request: {error}")));
-        }
-        return Ok(());
     }
 }
 
 fn session_is_running(session: &AgentSession) -> bool {
-    let mut live = LiveView::default();
-    let Ok(sample) = live.refresh_monitor_sample(50) else {
+    let Ok(sample) = LiveView::default().refresh_monitor_sample(50) else {
         return false;
     };
     let target = canonical(&session.path);
@@ -357,23 +282,42 @@ fn session_is_running(session: &AgentSession) -> bool {
         .any(|path| canonical(path) == target)
 }
 
-fn canonical(path: &Path) -> std::path::PathBuf {
-    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-}
-
 fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
     let mut command = Command::new("gemini");
     command.args(["--resume", &session.session_id, message]);
-    apply_cwd(&mut command, session);
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    let mut child = command
+    configure(&mut command, session, false);
+    let child = command
         .spawn()
-        .map_err(|error| SubmitError::Failed(format!("failed to resume Gemini session: {error}")))?;
-    let agent = session.agent_type.clone();
-    let session_id = session.session_id.clone();
+        .map_err(|error| failed(format!("failed to resume Gemini session: {error}")))?;
+    reap(child, "gemini", session.session_id.clone());
+    Ok(())
+}
+
+fn configure(command: &mut Command, session: &AgentSession, piped: bool) {
+    if let Some(cwd) = session.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+        command.current_dir(cwd);
+    }
+    command.stdin(if piped { Stdio::piped() } else { Stdio::null() });
+    command.stdout(if piped { Stdio::piped() } else { Stdio::null() });
+    command.stderr(Stdio::null());
+}
+
+async fn send_json(stdin: &mut ChildStdin, value: Value) -> Result<(), SubmitError> {
+    let mut data = serde_json::to_vec(&value).map_err(|error| failed(error.to_string()))?;
+    data.push(b'\n');
+    stdin
+        .write_all(&data)
+        .await
+        .and_then(|_| async { stdin.flush().await }.await)
+        .map_err(|error| failed(format!("provider transport write failed: {error}")))
+}
+
+async fn drain<R: tokio::io::AsyncRead + Unpin>(stdout: R) {
+    let mut lines = BufReader::new(stdout).lines();
+    while let Ok(Some(_)) = lines.next_line().await {}
+}
+
+fn reap(mut child: Child, agent: &'static str, session_id: String) {
     tokio::spawn(async move {
         match child.wait().await {
             Ok(status) if status.success() => {}
@@ -381,39 +325,12 @@ fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitErro
             Err(error) => log::warn!("{agent} session {session_id} wait failed: {error}"),
         }
     });
-    Ok(())
 }
 
-fn apply_cwd(command: &mut Command, session: &AgentSession) {
-    if let Some(cwd) = session.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
-        command.current_dir(cwd);
-    }
+fn canonical(path: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
-async fn write_json_line(stdin: &mut ChildStdin, value: &Value) -> Result<(), SubmitError> {
-    let mut bytes = serde_json::to_vec(value)
-        .map_err(|error| SubmitError::Failed(format!("failed to encode provider request: {error}")))?;
-    bytes.push(b'\n');
-    stdin
-        .write_all(&bytes)
-        .await
-        .map_err(|error| SubmitError::Failed(format!("failed to write provider request: {error}")))?;
-    stdin
-        .flush()
-        .await
-        .map_err(|error| SubmitError::Failed(format!("failed to flush provider request: {error}")))
-}
-
-async fn drain_lines<R>(stdout: R, agent: &'static str)
-where
-    R: tokio::io::AsyncRead + Unpin,
-{
-    let mut lines = BufReader::new(stdout).lines();
-    while let Ok(Some(line)) = lines.next_line().await {
-        log::trace!("{agent} live session: {line}");
-    }
-}
-
-fn io_error(error: std::io::Error) -> SubmitError {
-    SubmitError::Failed(error.to_string())
+fn failed(message: impl Into<String>) -> SubmitError {
+    SubmitError::Failed(message.into())
 }

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -170,7 +170,7 @@ fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
 
 async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
     let mut command = Command::new("codex");
-    command.args(["app-server", "--stdio"]);
+    command.args(["app-server", "--listen", "stdio://"]);
     configure(&mut command, session, true);
     let mut child = command
         .spawn()
@@ -181,18 +181,17 @@ async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
 
     send_json(
         &mut stdin,
-        json!({"method":"initialize","id":1,"params":{"clientInfo":{
-            "name":"agentsight","title":"AgentSight","version":env!("CARGO_PKG_VERSION")
-        }}}),
+        json!({"method":"initialize","id":1,"params":{
+            "clientInfo":{"name":"agentsight","title":"AgentSight","version":env!("CARGO_PKG_VERSION")},
+            "capabilities":{"experimentalApi":true}
+        }}),
     )
     .await?;
     wait_response(&mut reader, 1).await?;
     send_json(&mut stdin, json!({"method":"initialized","params":{}})).await?;
     send_json(
         &mut stdin,
-        json!({"method":"thread/resume","id":2,"params":{
-            "threadId":session.session_id,"approvalPolicy":"never"
-        }}),
+        json!({"method":"thread/resume","id":2,"params":{"threadId":session.session_id}}),
     )
     .await?;
     wait_response(&mut reader, 2).await?;

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+use agent_session::AgentSession;
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::{Arc, Mutex as StdMutex, OnceLock};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, Command};
+use tokio::sync::Mutex;
+
+use crate::view::live_top::LiveView;
+
+static RUNTIMES: OnceLock<Mutex<HashMap<String, Runtime>>> = OnceLock::new();
+
+fn runtimes() -> &'static Mutex<HashMap<String, Runtime>> {
+    RUNTIMES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+#[derive(Debug)]
+pub enum SubmitError {
+    Conflict(String),
+    Failed(String),
+}
+
+pub struct SubmitResult {
+    pub transport: &'static str,
+}
+
+enum Runtime {
+    Claude {
+        child: Child,
+        stdin: ChildStdin,
+    },
+    Codex {
+        child: Child,
+        stdin: ChildStdin,
+        state: Arc<StdMutex<CodexState>>,
+        next_id: u64,
+    },
+}
+
+#[derive(Default)]
+struct CodexState {
+    active_turn: Option<String>,
+    starting: bool,
+}
+
+impl Runtime {
+    async fn send(&mut self, message: &str) -> Result<&'static str, SubmitError> {
+        match self {
+            Self::Claude { child, stdin } => {
+                if child.try_wait().map_err(io_error)?.is_some() {
+                    return Err(SubmitError::Failed("Claude live transport exited".to_string()));
+                }
+                let value = json!({
+                    "type": "user",
+                    "message": {
+                        "role": "user",
+                        "content": [{"type": "text", "text": message}]
+                    }
+                });
+                write_json_line(stdin, &value).await?;
+                Ok("claude-stream-json")
+            }
+            Self::Codex {
+                child,
+                stdin,
+                state,
+                next_id,
+            } => {
+                if child.try_wait().map_err(io_error)?.is_some() {
+                    return Err(SubmitError::Failed("Codex app-server exited".to_string()));
+                }
+                let (active_turn, starting) = state
+                    .lock()
+                    .map(|state| (state.active_turn.clone(), state.starting))
+                    .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?;
+                if starting {
+                    return Err(SubmitError::Conflict(
+                        "Codex is accepting the previous message; retry after the turn starts".to_string(),
+                    ));
+                }
+                *next_id += 1;
+                let id = *next_id;
+                let request = if let Some(turn_id) = active_turn {
+                    json!({
+                        "method": "turn/steer",
+                        "id": id,
+                        "params": {
+                            "threadId": runtime_thread_id(state)?,
+                            "expectedTurnId": turn_id,
+                            "input": [{"type": "text", "text": message}]
+                        }
+                    })
+                } else {
+                    state
+                        .lock()
+                        .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?
+                        .starting = true;
+                    json!({
+                        "method": "turn/start",
+                        "id": id,
+                        "params": {
+                            "threadId": runtime_thread_id(state)?,
+                            "input": [{"type": "text", "text": message}]
+                        }
+                    })
+                };
+                if let Err(error) = write_json_line(stdin, &request).await {
+                    if let Ok(mut state) = state.lock() {
+                        state.starting = false;
+                    }
+                    return Err(error);
+                }
+                Ok("codex-app-server")
+            }
+        }
+    }
+}
+
+// The thread id is stored in active_turn's companion sentinel before the reader starts.
+// Keeping it in one field avoids a second allocation in Runtime.
+fn runtime_thread_id(state: &Arc<StdMutex<CodexState>>) -> Result<String, SubmitError> {
+    state
+        .lock()
+        .map_err(|_| SubmitError::Failed("Codex state lock poisoned".to_string()))?
+        .active_turn
+        .as_deref()
+        .and_then(|value| value.strip_prefix("thread:"))
+        .map(ToString::to_string)
+        .ok_or_else(|| SubmitError::Failed("Codex thread is not initialized".to_string()))
+}
+
+pub async fn submit_message(
+    session: &AgentSession,
+    message: &str,
+) -> Result<SubmitResult, SubmitError> {
+    let mut map = runtimes().lock().await;
+    if let Some(runtime) = map.get_mut(&session.session_id) {
+        match runtime.send(message).await {
+            Ok(transport) => return Ok(SubmitResult { transport }),
+            Err(SubmitError::Failed(_)) => {
+                map.remove(&session.session_id);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    if session_is_running(session) {
+        return Err(SubmitError::Conflict(
+            "this session is already running outside AgentSight; live attachment is not available for that runtime"
+                .to_string(),
+        ));
+    }
+
+    match session.agent_type.as_str() {
+        agent_session::AGENT_CLAUDE => {
+            let mut runtime = start_claude(session).await?;
+            let transport = runtime.send(message).await?;
+            map.insert(session.session_id.clone(), runtime);
+            Ok(SubmitResult { transport })
+        }
+        agent_session::AGENT_CODEX => {
+            let mut runtime = start_codex(session).await?;
+            let transport = runtime.send(message).await?;
+            map.insert(session.session_id.clone(), runtime);
+            Ok(SubmitResult { transport })
+        }
+        agent_session::AGENT_GEMINI => {
+            drop(map);
+            resume_gemini(session, message)?;
+            Ok(SubmitResult {
+                transport: "gemini-resume",
+            })
+        }
+        other => Err(SubmitError::Failed(format!(
+            "sending messages to {other} sessions is not supported yet"
+        ))),
+    }
+}
+
+async fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
+    let mut command = Command::new("claude");
+    command.args([
+        "-p",
+        "--resume",
+        &session.session_id,
+        "--input-format=stream-json",
+        "--output-format=stream-json",
+        "--verbose",
+    ]);
+    apply_cwd(&mut command, session);
+    command.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|error| SubmitError::Failed(format!("failed to start Claude live session: {error}")))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| SubmitError::Failed("Claude stdin was not available".to_string()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| SubmitError::Failed("Claude stdout was not available".to_string()))?;
+    tokio::spawn(drain_lines(stdout, "claude"));
+    Ok(Runtime::Claude { child, stdin })
+}
+
+async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
+    let mut command = Command::new("codex");
+    command.args(["app-server", "--stdio"]);
+    apply_cwd(&mut command, session);
+    command.stdin(Stdio::piped()).stdout(Stdio::piped()).stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|error| SubmitError::Failed(format!("failed to start Codex app-server: {error}")))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| SubmitError::Failed("Codex stdin was not available".to_string()))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| SubmitError::Failed("Codex stdout was not available".to_string()))?;
+    let mut reader = BufReader::new(stdout);
+
+    write_json_line(
+        &mut stdin,
+        &json!({
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "clientInfo": {
+                    "name": "agentsight",
+                    "title": "AgentSight",
+                    "version": env!("CARGO_PKG_VERSION")
+                }
+            }
+        }),
+    )
+    .await?;
+    wait_for_response(&mut reader, 1).await?;
+    write_json_line(&mut stdin, &json!({"method": "initialized", "params": {}})).await?;
+    write_json_line(
+        &mut stdin,
+        &json!({
+            "method": "thread/resume",
+            "id": 2,
+            "params": {
+                "threadId": session.session_id,
+                "approvalPolicy": "never"
+            }
+        }),
+    )
+    .await?;
+    wait_for_response(&mut reader, 2).await?;
+
+    let state = Arc::new(StdMutex::new(CodexState {
+        active_turn: Some(format!("thread:{}", session.session_id)),
+        starting: false,
+    }));
+    let reader_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        read_codex_events(reader, reader_state).await;
+    });
+    Ok(Runtime::Codex {
+        child,
+        stdin,
+        state,
+        next_id: 2,
+    })
+}
+
+async fn read_codex_events<R>(mut reader: BufReader<R>, state: Arc<StdMutex<CodexState>>)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let Ok(bytes) = reader.read_line(&mut line).await else {
+            break;
+        };
+        if bytes == 0 {
+            break;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        let method = value.get("method").and_then(Value::as_str);
+        let turn_id = value
+            .pointer("/params/turn/id")
+            .or_else(|| value.pointer("/result/turn/id"))
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        if method == Some("turn/started") || turn_id.is_some() {
+            if let Some(turn_id) = turn_id
+                && let Ok(mut state) = state.lock()
+            {
+                let thread = state
+                    .active_turn
+                    .as_deref()
+                    .and_then(|value| value.strip_prefix("thread:"))
+                    .map(str::to_string);
+                state.active_turn = Some(turn_id);
+                state.starting = false;
+                if let Some(thread) = thread {
+                    // Preserve the thread id in a form runtime_thread_id can recover after completion.
+                    state.active_turn = Some(format!("{turn_id}\nthread:{thread}"));
+                }
+            }
+        }
+        if method == Some("turn/completed")
+            && let Ok(mut state) = state.lock()
+        {
+            let thread = state
+                .active_turn
+                .as_deref()
+                .and_then(|value| value.split("\nthread:").nth(1))
+                .map(str::to_string);
+            state.active_turn = thread.map(|thread| format!("thread:{thread}"));
+            state.starting = false;
+        }
+    }
+}
+
+async fn wait_for_response<R>(reader: &mut BufReader<R>, expected_id: u64) -> Result<(), SubmitError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let bytes = reader
+            .read_line(&mut line)
+            .await
+            .map_err(|error| SubmitError::Failed(format!("failed to read provider response: {error}")))?;
+        if bytes == 0 {
+            return Err(SubmitError::Failed(
+                "provider transport closed during initialization".to_string(),
+            ));
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+            continue;
+        };
+        if value.get("id").and_then(Value::as_u64) != Some(expected_id) {
+            continue;
+        }
+        if let Some(error) = value.get("error") {
+            return Err(SubmitError::Failed(format!("provider rejected request: {error}")));
+        }
+        return Ok(());
+    }
+}
+
+fn session_is_running(session: &AgentSession) -> bool {
+    let mut live = LiveView::default();
+    let Ok(sample) = live.refresh_monitor_sample(50) else {
+        return false;
+    };
+    let target = canonical(&session.path);
+    sample
+        .sessions
+        .iter()
+        .filter_map(|live| live.session_path.as_deref())
+        .any(|path| canonical(path) == target)
+}
+
+fn canonical(path: &Path) -> std::path::PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
+    let mut command = Command::new("gemini");
+    command.args(["--resume", &session.session_id, message]);
+    apply_cwd(&mut command, session);
+    command.stdin(Stdio::null()).stdout(Stdio::null()).stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|error| SubmitError::Failed(format!("failed to resume Gemini session: {error}")))?;
+    let agent = session.agent_type.clone();
+    let session_id = session.session_id.clone();
+    tokio::spawn(async move {
+        match child.wait().await {
+            Ok(status) if status.success() => {}
+            Ok(status) => log::warn!("{agent} session {session_id} exited with {status}"),
+            Err(error) => log::warn!("{agent} session {session_id} wait failed: {error}"),
+        }
+    });
+    Ok(())
+}
+
+fn apply_cwd(command: &mut Command, session: &AgentSession) {
+    if let Some(cwd) = session.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+        command.current_dir(cwd);
+    }
+}
+
+async fn write_json_line(stdin: &mut ChildStdin, value: &Value) -> Result<(), SubmitError> {
+    let mut bytes = serde_json::to_vec(value)
+        .map_err(|error| SubmitError::Failed(format!("failed to encode provider request: {error}")))?;
+    bytes.push(b'\n');
+    stdin
+        .write_all(&bytes)
+        .await
+        .map_err(|error| SubmitError::Failed(format!("failed to write provider request: {error}")))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|error| SubmitError::Failed(format!("failed to flush provider request: {error}")))
+}
+
+async fn drain_lines<R>(stdout: R, agent: &'static str)
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut lines = BufReader::new(stdout).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        log::trace!("{agent} live session: {line}");
+    }
+}
+
+fn io_error(error: std::io::Error) -> SubmitError {
+    SubmitError::Failed(error.to_string())
+}

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -6,16 +6,17 @@ use crate::server::assets::FrontendAssets;
 use crate::sources::agent_native::{self as agent_native_sessions, SessionCache};
 use crate::sources::sqlite as sqlite_source;
 use crate::view::SharedMaterializedView;
-use http_body_util::Full;
+use http_body_util::{BodyExt, Full};
 use hyper::header::{AUTHORIZATION, CACHE_CONTROL, HeaderValue, ORIGIN};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode, body::Bytes};
 use hyper_util::rt::TokioIo;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::convert::Infallible;
 use std::net::SocketAddr;
+use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -32,6 +33,11 @@ pub struct NodeMetadata {
     pub id: String,
     pub name: String,
     pub version: String,
+}
+
+#[derive(Deserialize)]
+struct SessionMessageRequest {
+    message: String,
 }
 
 impl DirectAuth {
@@ -100,7 +106,6 @@ impl WebServer {
             .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
         log::info!("🚀 Frontend server running on http://{}", addr);
 
-        // List embedded assets for debugging
         let all_assets = self.assets.list_all_assets();
         log::info!(
             "📦 Embedded {} assets from frontend/dist:",
@@ -153,6 +158,7 @@ async fn handle_request(
     db_path: Option<String>,
     direct_auth: Option<DirectAuth>,
 ) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
+    let method = req.method().clone();
     let path = req.uri().path().to_string();
     let query = req.uri().query().map(str::to_string);
     let origin = req
@@ -160,8 +166,9 @@ async fn handle_request(
         .get(ORIGIN)
         .and_then(|value| value.to_str().ok())
         .map(str::to_string);
+    let authorization = req.headers().get(AUTHORIZATION).cloned();
 
-    log::info!("📨 {} {}", req.method(), path);
+    log::info!("📨 {} {}", method, path);
 
     if origin
         .as_deref()
@@ -174,7 +181,7 @@ async fn handle_request(
         ));
     }
 
-    if req.method() == Method::OPTIONS && path.starts_with("/api/") {
+    if method == Method::OPTIONS && path.starts_with("/api/") {
         return Ok(cors_response(
             plain_response(StatusCode::NO_CONTENT, "text/plain", Vec::new()),
             origin.as_deref(),
@@ -182,28 +189,33 @@ async fn handle_request(
         ));
     }
 
-    let response = match (req.method(), path.as_str()) {
-        (&Method::GET, "/api/v1/info") => {
-            let authorization = req.headers().get(AUTHORIZATION);
-            if !info_access_allowed(direct_auth.as_ref(), authorization) {
+    let session_message_id = session_message_id(&path).map(str::to_string);
+    let session_detail_id = session_detail_id(&path).map(str::to_string);
+    let response = match (method, path.as_str()) {
+        (Method::GET, "/api/v1/info") => {
+            if !info_access_allowed(direct_auth.as_ref(), authorization.as_ref()) {
                 json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
             } else {
-                let node = info_node(direct_auth.as_ref(), authorization);
+                let node = info_node(direct_auth.as_ref(), authorization.as_ref());
                 json_response(
                     StatusCode::OK,
                     &serde_json::json!({
                         "protocol_version": 1,
                         "product": "agentsight",
                         "authorization_required": direct_auth.is_some(),
+                        "capabilities": {
+                            "session_detail": true,
+                            "session_messages": direct_auth.is_some() && db_path.is_none(),
+                        },
                         "node": node,
                     }),
                 )
             }
         }
-        (&Method::GET, "/api/v1/snapshot") => {
+        (Method::GET, "/api/v1/snapshot") => {
             if !snapshot_access_allowed(
                 direct_auth.as_ref(),
-                req.headers().get(AUTHORIZATION),
+                authorization.as_ref(),
                 origin.as_deref(),
             ) {
                 json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
@@ -211,7 +223,38 @@ async fn handle_request(
                 serve_snapshot_api(view, agent_native_sessions, db_path, query.as_deref()).await?
             }
         }
-        (&Method::GET, _) => serve_asset(assets, &path).await?,
+        (Method::GET, _) if session_detail_id.is_some() => {
+            if !snapshot_access_allowed(
+                direct_auth.as_ref(),
+                authorization.as_ref(),
+                origin.as_deref(),
+            ) {
+                json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
+            } else if db_path.is_some() {
+                json_error(StatusCode::CONFLICT, "saved captures do not expose native session messages")
+            } else {
+                serve_session_api(
+                    agent_native_sessions,
+                    session_detail_id.as_deref().unwrap_or_default(),
+                )
+                .await?
+            }
+        }
+        (Method::POST, _) if session_message_id.is_some() => {
+            if !session_control_access_allowed(direct_auth.as_ref(), authorization.as_ref()) {
+                json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
+            } else if db_path.is_some() {
+                json_error(StatusCode::CONFLICT, "saved captures are read-only")
+            } else {
+                serve_session_message_api(
+                    req,
+                    agent_native_sessions,
+                    session_message_id.as_deref().unwrap_or_default(),
+                )
+                .await?
+            }
+        }
+        (Method::GET, _) => serve_asset(assets, &path).await?,
         _ => {
             log::info!("❌ 404 Not Found: {} {}", req.method(), path);
             plain_response(StatusCode::NOT_FOUND, "text/plain", b"Not Found".to_vec())
@@ -223,6 +266,18 @@ async fn handle_request(
         origin.as_deref(),
         direct_auth.as_ref(),
     ))
+}
+
+fn session_detail_id(path: &str) -> Option<&str> {
+    let id = path.strip_prefix("/api/v1/sessions/")?;
+    (!id.is_empty() && !id.contains('/')).then_some(id)
+}
+
+fn session_message_id(path: &str) -> Option<&str> {
+    let id = path
+        .strip_prefix("/api/v1/sessions/")?
+        .strip_suffix("/messages")?;
+    (!id.is_empty() && !id.contains('/')).then_some(id)
 }
 
 async fn serve_asset(
@@ -299,6 +354,166 @@ async fn serve_snapshot_api(
     }
 }
 
+async fn serve_session_api(
+    sessions: Arc<Mutex<SessionCache>>,
+    session_id: &str,
+) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
+    let session_id = session_id.to_string();
+    let result = tokio::task::spawn_blocking(move || {
+        let mut cache = sessions
+            .lock()
+            .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?;
+        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(find_native_session(&mut cache, &session_id))
+    })
+    .await;
+
+    match result {
+        Ok(Ok(Some(session))) => Ok(json_response(StatusCode::OK, &session)),
+        Ok(Ok(None)) => Ok(json_error(StatusCode::NOT_FOUND, "session not found")),
+        Ok(Err(error)) => Ok(json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("failed to load session: {error}"),
+        )),
+        Err(error) => Ok(json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &format!("session query task failed: {error}"),
+        )),
+    }
+}
+
+async fn serve_session_message_api(
+    req: Request<hyper::body::Incoming>,
+    sessions: Arc<Mutex<SessionCache>>,
+    session_id: &str,
+) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
+    let body = match req.into_body().collect().await {
+        Ok(body) => body.to_bytes(),
+        Err(error) => {
+            return Ok(json_error(
+                StatusCode::BAD_REQUEST,
+                &format!("failed to read request body: {error}"),
+            ));
+        }
+    };
+    let request: SessionMessageRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return Ok(json_error(
+                StatusCode::BAD_REQUEST,
+                &format!("invalid JSON body: {error}"),
+            ));
+        }
+    };
+    let message = request.message.trim();
+    if message.is_empty() || message.len() > 65_536 {
+        return Ok(json_error(
+            StatusCode::BAD_REQUEST,
+            "message must contain 1-65536 bytes",
+        ));
+    }
+
+    let session_id = session_id.to_string();
+    let session = {
+        let sessions = Arc::clone(&sessions);
+        let session_id = session_id.clone();
+        match tokio::task::spawn_blocking(move || {
+            let mut cache = sessions
+                .lock()
+                .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?;
+            Ok::<_, Box<dyn std::error::Error + Send + Sync>>(find_native_session(
+                &mut cache,
+                &session_id,
+            ))
+        })
+        .await
+        {
+            Ok(Ok(Some(session))) => session,
+            Ok(Ok(None)) => return Ok(json_error(StatusCode::NOT_FOUND, "session not found")),
+            Ok(Err(error)) => {
+                return Ok(json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("failed to load session: {error}"),
+                ));
+            }
+            Err(error) => {
+                return Ok(json_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    &format!("session query task failed: {error}"),
+                ));
+            }
+        }
+    };
+
+    match launch_session_message(&session, message) {
+        Ok(()) => Ok(json_response(
+            StatusCode::ACCEPTED,
+            &serde_json::json!({
+                "session_id": session.session_id,
+                "agent_type": session.agent_type,
+                "status": "submitted",
+            }),
+        )),
+        Err(error) => Ok(json_error(StatusCode::BAD_GATEWAY, &error)),
+    }
+}
+
+fn find_native_session(cache: &mut SessionCache, session_id: &str) -> Option<agent_session::AgentSession> {
+    agent_native_sessions::discover_sessions(cache, None, None, 25, Duration::ZERO)
+        .into_iter()
+        .find(|session| session.session_id == session_id)
+}
+
+fn launch_session_message(session: &agent_session::AgentSession, message: &str) -> Result<(), String> {
+    let mut command = match session.agent_type.as_str() {
+        agent_session::AGENT_CLAUDE => {
+            let mut command = tokio::process::Command::new("claude");
+            command.args(["-p", "--resume", &session.session_id, message]);
+            command
+        }
+        agent_session::AGENT_CODEX => {
+            let mut command = tokio::process::Command::new("codex");
+            command.args(["exec", "resume", &session.session_id, message]);
+            command
+        }
+        agent_session::AGENT_GEMINI => {
+            let mut command = tokio::process::Command::new("gemini");
+            command.args(["--resume", &session.session_id, "--prompt", message]);
+            command
+        }
+        other => return Err(format!("sending messages to {other} sessions is not supported yet")),
+    };
+    if let Some(cwd) = session.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
+        command.current_dir(cwd);
+    }
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("failed to resume {} session: {error}", session.agent_type))?;
+    let agent = session.agent_type.clone();
+    let session_id = session.session_id.clone();
+    tokio::spawn(async move {
+        match child.wait().await {
+            Ok(status) if status.success() => {}
+            Ok(status) => log::warn!(
+                "{} session {} message process exited with {}",
+                agent,
+                session_id,
+                status
+            ),
+            Err(error) => log::warn!(
+                "{} session {} message process wait failed: {}",
+                agent,
+                session_id,
+                error
+            ),
+        }
+    });
+    Ok(())
+}
+
 fn snapshot_from_sources(
     view: &SharedMaterializedView,
     agent_native_sessions: &Arc<Mutex<SessionCache>>,
@@ -354,6 +569,13 @@ fn snapshot_access_allowed(
     }
 }
 
+fn session_control_access_allowed(
+    direct_auth: Option<&DirectAuth>,
+    authorization: Option<&HeaderValue>,
+) -> bool {
+    direct_auth.is_some_and(|auth| auth.authorizes(authorization))
+}
+
 fn info_access_allowed(
     direct_auth: Option<&DirectAuth>,
     authorization: Option<&HeaderValue>,
@@ -386,7 +608,7 @@ fn cors_response(
     }
     response.headers_mut().insert(
         "Access-Control-Allow-Methods",
-        HeaderValue::from_static("GET, OPTIONS"),
+        HeaderValue::from_static("GET, POST, OPTIONS"),
     );
     response.headers_mut().insert(
         "Access-Control-Allow-Headers",
@@ -441,6 +663,19 @@ mod tests {
 
         assert_eq!(query_param_usize(query, "audit_limit"), Some(9));
         assert_eq!(query_param_usize(query, "missing"), None);
+    }
+
+    #[test]
+    fn parses_session_routes() {
+        assert_eq!(
+            session_detail_id("/api/v1/sessions/session-1"),
+            Some("session-1")
+        );
+        assert_eq!(
+            session_message_id("/api/v1/sessions/session-1/messages"),
+            Some("session-1")
+        );
+        assert_eq!(session_detail_id("/api/v1/sessions/session-1/messages"), None);
     }
 
     #[test]

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -16,7 +16,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::convert::Infallible;
 use std::net::SocketAddr;
-use std::process::Stdio;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::TcpListener;
@@ -231,7 +230,10 @@ async fn handle_request(
             ) {
                 json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
             } else if db_path.is_some() {
-                json_error(StatusCode::CONFLICT, "saved captures do not expose native session messages")
+                json_error(
+                    StatusCode::CONFLICT,
+                    "saved captures do not expose native session messages",
+                )
             } else {
                 serve_session_api(
                     agent_native_sessions,
@@ -363,7 +365,10 @@ async fn serve_session_api(
         let mut cache = sessions
             .lock()
             .map_err(|_| std::io::Error::other("agent-native session cache lock poisoned"))?;
-        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(find_native_session(&mut cache, &session_id))
+        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(find_native_session(
+            &mut cache,
+            &session_id,
+        ))
     })
     .await;
 
@@ -444,74 +449,42 @@ async fn serve_session_message_api(
         }
     };
 
-    match launch_session_message(&session, message) {
-        Ok(()) => Ok(json_response(
+    match launch_session_message(&session, message).await {
+        Ok(result) => Ok(json_response(
             StatusCode::ACCEPTED,
             &serde_json::json!({
                 "session_id": session.session_id,
                 "agent_type": session.agent_type,
                 "status": "submitted",
+                "transport": result.transport,
             }),
         )),
-        Err(error) => Ok(json_error(StatusCode::BAD_GATEWAY, &error)),
+        Err(crate::server::session_runtime::SubmitError::Conflict(error)) => {
+            Ok(json_error(StatusCode::CONFLICT, &error))
+        }
+        Err(crate::server::session_runtime::SubmitError::Failed(error)) => {
+            Ok(json_error(StatusCode::BAD_GATEWAY, &error))
+        }
     }
 }
 
-fn find_native_session(cache: &mut SessionCache, session_id: &str) -> Option<agent_session::AgentSession> {
+fn find_native_session(
+    cache: &mut SessionCache,
+    session_id: &str,
+) -> Option<agent_session::AgentSession> {
     agent_native_sessions::discover_sessions(cache, None, None, 25, Duration::ZERO)
         .into_iter()
         .find(|session| session.session_id == session_id)
 }
 
-fn launch_session_message(session: &agent_session::AgentSession, message: &str) -> Result<(), String> {
-    let mut command = match session.agent_type.as_str() {
-        agent_session::AGENT_CLAUDE => {
-            let mut command = tokio::process::Command::new("claude");
-            command.args(["-p", "--resume", &session.session_id, message]);
-            command
-        }
-        agent_session::AGENT_CODEX => {
-            let mut command = tokio::process::Command::new("codex");
-            command.args(["exec", "resume", &session.session_id, message]);
-            command
-        }
-        agent_session::AGENT_GEMINI => {
-            let mut command = tokio::process::Command::new("gemini");
-            command.args(["--resume", &session.session_id, "--prompt", message]);
-            command
-        }
-        other => return Err(format!("sending messages to {other} sessions is not supported yet")),
-    };
-    if let Some(cwd) = session.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
-        command.current_dir(cwd);
-    }
-    command
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("failed to resume {} session: {error}", session.agent_type))?;
-    let agent = session.agent_type.clone();
-    let session_id = session.session_id.clone();
-    tokio::spawn(async move {
-        match child.wait().await {
-            Ok(status) if status.success() => {}
-            Ok(status) => log::warn!(
-                "{} session {} message process exited with {}",
-                agent,
-                session_id,
-                status
-            ),
-            Err(error) => log::warn!(
-                "{} session {} message process wait failed: {}",
-                agent,
-                session_id,
-                error
-            ),
-        }
-    });
-    Ok(())
+async fn launch_session_message(
+    session: &agent_session::AgentSession,
+    message: &str,
+) -> Result<
+    crate::server::session_runtime::SubmitResult,
+    crate::server::session_runtime::SubmitError,
+> {
+    crate::server::session_runtime::submit_message(session, message).await
 }
 
 fn snapshot_from_sources(
@@ -675,7 +648,10 @@ mod tests {
             session_message_id("/api/v1/sessions/session-1/messages"),
             Some("session-1")
         );
-        assert_eq!(session_detail_id("/api/v1/sessions/session-1/messages"), None);
+        assert_eq!(
+            session_detail_id("/api/v1/sessions/session-1/messages"),
+            None
+        );
     }
 
     #[test]

--- a/frontend/src/components/SessionConsole.tsx
+++ b/frontend/src/components/SessionConsole.tsx
@@ -4,7 +4,7 @@
 'use client';
 
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
-import { loadLocalConnection } from '@/lib/connection';
+import { loadLocalConnection, type LocalConnection } from '@/lib/connection';
 import type { AgentSightSnapshot, SnapshotSession } from '@/types/event';
 
 type SessionDetail = {
@@ -20,25 +20,65 @@ type SessionDetail = {
 };
 
 type Message = { ts: number; kind: 'user' | 'assistant' | 'tool'; text: string };
-type LocalFetchInit = RequestInit & { targetAddressSpace?: 'local' };
+type NodeAddressSpace = 'local' | 'loopback';
+type LocalFetchInit = RequestInit & { targetAddressSpace?: NodeAddressSpace };
+
+const LOCAL_TIMEOUT_MS = 8_000;
 
 function sessionId(session: SnapshotSession): string | null {
   const attrs = session.attributes as { session_id?: unknown } | undefined;
   return typeof attrs?.session_id === 'string' ? attrs.session_id : null;
 }
 
+function expectedNodeAddressSpace(endpoint: URL): NodeAddressSpace {
+  const hostname = endpoint.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')
+    || hostname === '::1' || /^127(?:\.|$)/.test(hostname)) {
+    return 'loopback';
+  }
+  return 'local';
+}
+
+function localFetch(input: string, init: RequestInit = {}, targetAddressSpace: NodeAddressSpace = 'local') {
+  const options: LocalFetchInit = {
+    ...init,
+    mode: 'cors',
+    cache: 'no-store',
+    signal: init.signal || AbortSignal.timeout(LOCAL_TIMEOUT_MS),
+  };
+  options.targetAddressSpace = targetAddressSpace;
+  return fetch(input, options);
+}
+
 async function nodeFetch(input: string, init: RequestInit = {}) {
+  const endpoint = new URL(input);
+  if (endpoint.protocol === 'http:') {
+    return localFetch(input, init, expectedNodeAddressSpace(endpoint));
+  }
+  const options: RequestInit = {
+    ...init,
+    mode: 'cors',
+    cache: 'no-store',
+    signal: init.signal || AbortSignal.timeout(LOCAL_TIMEOUT_MS),
+  };
   try {
-    return await fetch(input, { ...init, mode: 'cors', cache: 'no-store' });
+    return await fetch(input, options);
   } catch (error) {
-    const options: LocalFetchInit = { ...init, mode: 'cors', cache: 'no-store' };
-    options.targetAddressSpace = 'local';
+    if (init.signal?.aborted) throw error;
     try {
-      return await fetch(input, options);
+      return await localFetch(input, init, expectedNodeAddressSpace(endpoint));
     } catch {
       throw error;
     }
   }
+}
+
+function authHeaders(connection: LocalConnection): HeadersInit {
+  return connection.accessToken ? { Authorization: `Bearer ${connection.accessToken}` } : {};
+}
+
+function snapshotSessionIds(snapshot: AgentSightSnapshot): Set<string> {
+  return new Set((snapshot.sessions ?? []).map(sessionId).filter((id): id is string => !!id));
 }
 
 function messages(detail: SessionDetail | null): Message[] {
@@ -67,6 +107,9 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
     () => (snapshot.sessions ?? []).filter((session) => sessionId(session)),
     [snapshot],
   );
+  const visibleSessionIds = useMemo(() => snapshotSessionIds(snapshot), [snapshot]);
+  const connection = useMemo(() => loadLocalConnection(), [snapshot]);
+  const [connectionReady, setConnectionReady] = useState(false);
   const [selected, setSelected] = useState<string>('');
   const [detail, setDetail] = useState<SessionDetail | null>(null);
   const [message, setMessage] = useState('');
@@ -79,23 +122,49 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
     }
   }, [sessions, selected]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setConnectionReady(false);
+    if (!connection || visibleSessionIds.size === 0) return () => { cancelled = true; };
+
+    const verify = async () => {
+      const response = await nodeFetch(
+        `${connection.endpoint}/api/v1/snapshot?audit_limit=1`,
+        { headers: authHeaders(connection) },
+      );
+      if (!response.ok) throw new Error(`AgentSight Node returned ${response.status}.`);
+      const liveSnapshot = await response.json() as AgentSightSnapshot;
+      const liveIds = snapshotSessionIds(liveSnapshot);
+      const matches = [...visibleSessionIds].some((id) => liveIds.has(id));
+      if (!matches) {
+        throw new Error('This page is not showing the Node currently bound to this browser.');
+      }
+      if (!cancelled) {
+        setConnectionReady(true);
+        setError('');
+      }
+    };
+
+    void verify().catch((cause) => {
+      if (!cancelled) {
+        setError(cause instanceof Error ? cause.message : 'Could not verify the bound Node.');
+      }
+    });
+    return () => { cancelled = true; };
+  }, [connection, visibleSessionIds]);
+
   const loadDetail = useCallback(async () => {
-    if (!selected) return;
-    const connection = loadLocalConnection();
-    if (!connection) return;
-    const headers: HeadersInit = connection.accessToken
-      ? { Authorization: `Bearer ${connection.accessToken}` }
-      : {};
+    if (!selected || !connection || !connectionReady) return;
     const response = await nodeFetch(
       `${connection.endpoint}/api/v1/sessions/${encodeURIComponent(selected)}`,
-      { headers },
+      { headers: authHeaders(connection) },
     );
     if (!response.ok) throw new Error(`Session returned ${response.status}.`);
     setDetail(await response.json() as SessionDetail);
-  }, [selected]);
+  }, [connection, connectionReady, selected]);
 
   useEffect(() => {
-    if (!selected) return;
+    if (!selected || !connectionReady) return;
     setDetail(null);
     setError('');
     void loadDetail().catch((cause) => {
@@ -105,13 +174,12 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
       void loadDetail().catch(() => undefined);
     }, 2_000);
     return () => window.clearInterval(timer);
-  }, [selected, loadDetail]);
+  }, [selected, connectionReady, loadDetail]);
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     const text = message.trim();
-    if (!selected || !text || busy) return;
-    const connection = loadLocalConnection();
+    if (!selected || !text || busy || !connectionReady) return;
     if (!connection?.accessToken) {
       setError('Reconnect this Node with agentsight bind before sending messages.');
       return;
@@ -145,7 +213,8 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
 
   if (sessions.length === 0) return null;
   const selectedSession = sessions.find((session) => sessionId(session) === selected);
-  const canSend = !!selectedSession && ['claude', 'codex', 'gemini'].includes(selectedSession.agent_type);
+  const canSend = connectionReady && !!connection?.accessToken && !!selectedSession
+    && ['claude', 'codex', 'gemini'].includes(selectedSession.agent_type);
   const conversation = messages(detail);
 
   return (
@@ -169,7 +238,12 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
         </div>
         <div className="flex min-w-0 flex-col">
           <div className="max-h-[460px] flex-1 space-y-3 overflow-y-auto p-4">
-            {conversation.length === 0 && !error && (
+            {!connection && (
+              <p className="py-10 text-center text-sm text-gray-400">
+                Bind this browser to the Node to load the full conversation.
+              </p>
+            )}
+            {connection && connectionReady && conversation.length === 0 && !error && (
               <p className="py-10 text-center text-sm text-gray-400">Loading conversation…</p>
             )}
             {conversation.map((item, index) => item.kind === 'tool' ? (
@@ -188,7 +262,7 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
             {error && <p className="mb-2 text-xs text-red-600">{error}</p>}
             <div className="flex gap-2">
               <textarea value={message} onChange={(event) => setMessage(event.target.value)} rows={2}
-                placeholder={canSend ? 'Send a follow-up to this session…' : 'Messaging is not supported for this agent yet.'}
+                placeholder={canSend ? 'Send a follow-up to this session…' : 'Connect to this live Node to send messages.'}
                 disabled={!canSend || busy}
                 className="min-h-12 flex-1 resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 disabled:bg-gray-50" />
               <button type="submit" disabled={!canSend || !message.trim() || busy}

--- a/frontend/src/components/SessionConsole.tsx
+++ b/frontend/src/components/SessionConsole.tsx
@@ -108,7 +108,7 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
     [snapshot],
   );
   const visibleSessionIds = useMemo(() => snapshotSessionIds(snapshot), [snapshot]);
-  const connection = useMemo(() => loadLocalConnection(), [snapshot]);
+  const [connection] = useState<LocalConnection | null>(() => loadLocalConnection());
   const [connectionReady, setConnectionReady] = useState(false);
   const [selected, setSelected] = useState<string>('');
   const [detail, setDetail] = useState<SessionDetail | null>(null);
@@ -135,7 +135,7 @@ export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
       if (!response.ok) throw new Error(`AgentSight Node returned ${response.status}.`);
       const liveSnapshot = await response.json() as AgentSightSnapshot;
       const liveIds = snapshotSessionIds(liveSnapshot);
-      const matches = [...visibleSessionIds].some((id) => liveIds.has(id));
+      const matches = Array.from(visibleSessionIds).some((id) => liveIds.has(id));
       if (!matches) {
         throw new Error('This page is not showing the Node currently bound to this browser.');
       }

--- a/frontend/src/components/SessionConsole.tsx
+++ b/frontend/src/components/SessionConsole.tsx
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+'use client';
+
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { loadLocalConnection } from '@/lib/connection';
+import type { AgentSightSnapshot, SnapshotSession } from '@/types/event';
+
+type SessionDetail = {
+  session_id: string;
+  agent_type: string;
+  model?: string | null;
+  cwd?: string | null;
+  events?: {
+    prompts?: Array<{ ts_ms?: number | null; preview?: string }>;
+    llm_responses?: Array<{ ts_ms?: number | null; preview?: string; response_phase?: string }>;
+    tools?: Array<{ ts_ms?: number | null; tool_name?: string; effect?: string; status?: string }>;
+  };
+};
+
+type Message = { ts: number; kind: 'user' | 'assistant' | 'tool'; text: string };
+type LocalFetchInit = RequestInit & { targetAddressSpace?: 'local' };
+
+function sessionId(session: SnapshotSession): string | null {
+  const attrs = session.attributes as { session_id?: unknown } | undefined;
+  return typeof attrs?.session_id === 'string' ? attrs.session_id : null;
+}
+
+async function nodeFetch(input: string, init: RequestInit = {}) {
+  try {
+    return await fetch(input, { ...init, mode: 'cors', cache: 'no-store' });
+  } catch (error) {
+    const options: LocalFetchInit = { ...init, mode: 'cors', cache: 'no-store' };
+    options.targetAddressSpace = 'local';
+    try {
+      return await fetch(input, options);
+    } catch {
+      throw error;
+    }
+  }
+}
+
+function messages(detail: SessionDetail | null): Message[] {
+  if (!detail?.events) return [];
+  return [
+    ...(detail.events.prompts ?? []).map((item) => ({
+      ts: item.ts_ms ?? 0,
+      kind: 'user' as const,
+      text: item.preview ?? '',
+    })),
+    ...(detail.events.llm_responses ?? []).map((item) => ({
+      ts: item.ts_ms ?? 0,
+      kind: 'assistant' as const,
+      text: item.preview ?? '',
+    })),
+    ...(detail.events.tools ?? []).map((item) => ({
+      ts: item.ts_ms ?? 0,
+      kind: 'tool' as const,
+      text: [item.tool_name, item.effect, item.status].filter(Boolean).join(' · '),
+    })),
+  ].filter((item) => item.text).sort((a, b) => a.ts - b.ts);
+}
+
+export function SessionConsole({ snapshot }: { snapshot: AgentSightSnapshot }) {
+  const sessions = useMemo(
+    () => (snapshot.sessions ?? []).filter((session) => sessionId(session)),
+    [snapshot],
+  );
+  const [selected, setSelected] = useState<string>('');
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [message, setMessage] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!sessions.some((session) => sessionId(session) === selected)) {
+      setSelected(sessionId(sessions[0] ?? {} as SnapshotSession) ?? '');
+    }
+  }, [sessions, selected]);
+
+  const loadDetail = useCallback(async () => {
+    if (!selected) return;
+    const connection = loadLocalConnection();
+    if (!connection) return;
+    const headers: HeadersInit = connection.accessToken
+      ? { Authorization: `Bearer ${connection.accessToken}` }
+      : {};
+    const response = await nodeFetch(
+      `${connection.endpoint}/api/v1/sessions/${encodeURIComponent(selected)}`,
+      { headers },
+    );
+    if (!response.ok) throw new Error(`Session returned ${response.status}.`);
+    setDetail(await response.json() as SessionDetail);
+  }, [selected]);
+
+  useEffect(() => {
+    if (!selected) return;
+    setDetail(null);
+    setError('');
+    void loadDetail().catch((cause) => {
+      setError(cause instanceof Error ? cause.message : 'Could not load session.');
+    });
+    const timer = window.setInterval(() => {
+      void loadDetail().catch(() => undefined);
+    }, 2_000);
+    return () => window.clearInterval(timer);
+  }, [selected, loadDetail]);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    const text = message.trim();
+    if (!selected || !text || busy) return;
+    const connection = loadLocalConnection();
+    if (!connection?.accessToken) {
+      setError('Reconnect this Node with agentsight bind before sending messages.');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      const response = await nodeFetch(
+        `${connection.endpoint}/api/v1/sessions/${encodeURIComponent(selected)}/messages`,
+        {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${connection.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ message: text }),
+        },
+      );
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({})) as { error?: string };
+        throw new Error(body.error || `Message submit failed (${response.status}).`);
+      }
+      setMessage('');
+      window.setTimeout(() => { void loadDetail().catch(() => undefined); }, 500);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Could not send message.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (sessions.length === 0) return null;
+  const selectedSession = sessions.find((session) => sessionId(session) === selected);
+  const canSend = !!selectedSession && ['claude', 'codex', 'gemini'].includes(selectedSession.agent_type);
+  const conversation = messages(detail);
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-md">
+      <div className="border-b border-gray-100 px-5 py-4">
+        <h2 className="text-sm font-semibold text-gray-900">Agent sessions</h2>
+        <p className="mt-1 text-xs text-gray-500">Native conversation history with direct follow-up messaging.</p>
+      </div>
+      <div className="grid min-h-[360px] md:grid-cols-[240px_1fr]">
+        <div className="border-b border-gray-100 bg-gray-50 p-2 md:border-b-0 md:border-r">
+          {sessions.map((session) => {
+            const id = sessionId(session)!;
+            return (
+              <button key={session.id} type="button" onClick={() => setSelected(id)}
+                className={`mb-1 w-full rounded-md px-3 py-2 text-left ${selected === id ? 'bg-white shadow-sm' : 'hover:bg-white'}`}>
+                <div className="text-sm font-medium text-gray-900">{session.agent_type}</div>
+                <div className="truncate text-xs text-gray-500">{session.model || id}</div>
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex min-w-0 flex-col">
+          <div className="max-h-[460px] flex-1 space-y-3 overflow-y-auto p-4">
+            {conversation.length === 0 && !error && (
+              <p className="py-10 text-center text-sm text-gray-400">Loading conversation…</p>
+            )}
+            {conversation.map((item, index) => item.kind === 'tool' ? (
+              <div key={`${item.ts}-${index}`} className="text-center text-xs text-gray-400">{item.text}</div>
+            ) : (
+              <div key={`${item.ts}-${index}`} className={`flex ${item.kind === 'user' ? 'justify-end' : 'justify-start'}`}>
+                <div className={`max-w-[85%] whitespace-pre-wrap rounded-xl px-3 py-2 text-sm ${
+                  item.kind === 'user' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-800'
+                }`}>
+                  {item.text}
+                </div>
+              </div>
+            ))}
+          </div>
+          <form onSubmit={submit} className="border-t border-gray-100 p-3">
+            {error && <p className="mb-2 text-xs text-red-600">{error}</p>}
+            <div className="flex gap-2">
+              <textarea value={message} onChange={(event) => setMessage(event.target.value)} rows={2}
+                placeholder={canSend ? 'Send a follow-up to this session…' : 'Messaging is not supported for this agent yet.'}
+                disabled={!canSend || busy}
+                className="min-h-12 flex-1 resize-none rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-blue-500 disabled:bg-gray-50" />
+              <button type="submit" disabled={!canSend || !message.trim() || busy}
+                className="self-end rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50">
+                {busy ? 'Sending…' : 'Send'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -6,15 +6,14 @@
 import { useMemo } from 'react';
 import { useTranslation } from '@/i18n';
 import { AgentSightSnapshot } from '@/types/event';
-import { deriveSessions, deriveSummary, formatDurationMs } from '@/utils/dashboard';
-import { DashboardPanel, RankedRow } from './DashboardPanel';
+import { deriveSummary } from '@/utils/dashboard';
+import { SessionConsole } from '@/components/SessionConsole';
 import { SummaryBand } from './SummaryBand';
 import { ActivityChart } from './ActivityChart';
 import { TokensPanel } from './TokensPanel';
 import { EffectProfile } from './EffectProfile';
 import { ResourceShape } from './ResourceShape';
 import { FrictionSignals } from './FrictionSignals';
-import { categoricalColor } from './colors';
 
 // Re-exported so panel drill-down callbacks stay typed against the app shell's
 // view switcher in page.tsx.
@@ -28,7 +27,6 @@ interface DashboardProps {
 export function Dashboard({ snapshot, onNavigate }: DashboardProps) {
   const { t } = useTranslation();
   const summary = useMemo(() => deriveSummary(snapshot ?? {}), [snapshot]);
-  const sessions = useMemo(() => deriveSessions(snapshot ?? {}), [snapshot]);
 
   if (!snapshot) {
     return (
@@ -41,29 +39,7 @@ export function Dashboard({ snapshot, onNavigate }: DashboardProps) {
   return (
     <div className="space-y-4">
       <SummaryBand summary={summary} onNavigate={onNavigate} />
-
-      {sessions.length > 1 && (
-        <DashboardPanel
-          title={t('dash.sessions.title')}
-          subtitle={t('dash.sessions.subtitle')}
-          bodyClassName="pt-2"
-        >
-          <ul className="divide-y divide-gray-50">
-            {sessions.map((s) => (
-              <RankedRow
-                key={s.id}
-                swatch={categoricalColor(s.id)}
-                label={`${s.agentType} · ${s.model ?? '—'}`}
-                sublabel={`${formatDurationMs(s.durationMs)} · ${s.status}`}
-                count={s.totalTokens}
-                countLabel={s.totalTokens > 0 ? t('dash.sessions.tokens') : undefined}
-              />
-            ))}
-          </ul>
-          <p className="mt-2 text-[11px] text-gray-400">{t('dash.sessions.note')}</p>
-        </DashboardPanel>
-      )}
-
+      <SessionConsole snapshot={snapshot} />
       <ActivityChart snapshot={snapshot} onNavigate={onNavigate} />
 
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">


### PR DESCRIPTION
## What changed

- persist the Direct Node access token so `agentsight bind` remains authorized across Node restarts
- expose native session detail at `GET /api/v1/sessions/{session_id}` using the existing `agent-session` parser
- add `POST /api/v1/sessions/{session_id}/messages` as the single session-native control surface
- replace the overview's summary-only session list with a compact conversation panel and message composer
- keep live transports only for sessions AgentSight owns; detect the exact externally running session with the existing process/session matcher and return `409 Conflict` instead of starting a second runtime

## Runtime behavior

The API addresses native sessions, never PIDs or tasks.

- Claude Code: a stopped session is resumed as one long-lived `stream-json` process. AgentSight keeps only its stdin transport, so later messages go directly into the same running Claude session.
- Codex: a stopped thread is loaded into one long-lived `codex app-server --listen stdio://`. Idle messages use `turn/start`; messages sent while the turn is running use `turn/steer` with the current turn id. The app-server handshake advertises `experimentalApi`, matching the official SDK, and preserves the thread's existing permission settings.
- Gemini CLI: stopped sessions still use the native `--resume <session-id> <message>` path in this slice. If the session is already running externally, AgentSight refuses to start another copy.
- Any native session already owned by an external TUI/runtime is observed but not commandeered unless AgentSight has its own live transport.

Native transcripts remain the source of truth for displayed conversation history. AgentSight does not add a message database, task table, scheduler, PTY layer, OAuth broker, or separate capability/auth API. The same persisted Direct Node bearer authorizes reads and message submission.

## Scope

Six product files, no new dependency and no schema migration. Saved captures remain read-only; messaging is only exposed by a bound Direct Node.

## Validation

Latest-head CI passes frontend build, control-plane tests, collector build, latest-agent CLI canary, strict collector clippy, Rust tests, standalone crates, agentpprof build/clippy/tests, C tests and ASan. The latest-head macOS top smoke also passes. The architecture-specific release packaging job is still running independently.