### PR TITLE
Fix static workspace routes

### DIFF
--- a/frontend/src/app/[view]/page.tsx
+++ b/frontend/src/app/[view]/page.tsx
@@ -1,0 +1,16 @@
+import Home from '../page';
+
+export function generateStaticParams() {
+  return [
+    { view: 'sessions' },
+    { view: 'overview' },
+    { view: 'timeline' },
+    { view: 'tree' },
+    { view: 'logs' },
+    { view: 'metrics' },
+  ];
+}
+
+export const dynamicParams = false;
+
+export default Home;


### PR DESCRIPTION
Fix the hosted static app returning Next.js Not Found when switching workspace tabs after #160.

The app records workspace state in paths such as `/sessions`, `/overview`, and `/timeline`, while the static export previously generated only `/`. Add one dynamic static route with `generateStaticParams()` for the six supported workspace paths and reuse the existing Home client component.

This preserves the current view/path behavior and makes direct reloads/deep links valid on the GitHub Pages deployment.