### PR TITLE
Make Direct Node access independent of Controller relay

### DIFF
--- a/collector/src/cmd_bind.rs
+++ b/collector/src/cmd_bind.rs
@@ -331,6 +331,22 @@ mod tests {
     }
 
     #[test]
+    fn direct_endpoint_accepts_private_ip_url() {
+        assert_eq!(
+            normalize_endpoint("http://192.168.50.12:7395").unwrap(),
+            "http://192.168.50.12:7395"
+        );
+    }
+
+    #[test]
+    fn direct_endpoint_accepts_https_hostname_and_strips_path() {
+        assert_eq!(
+            normalize_endpoint("https://lab.example.net/agentsight?ignored=1#fragment").unwrap(),
+            "https://lab.example.net"
+        );
+    }
+
+    #[test]
     fn relay_uses_loopback_for_unspecified_bind_addresses() {
         assert_eq!(
             relay_local_endpoint("0.0.0.0".parse().unwrap(), 7395),

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -37,6 +37,7 @@ import {
   directNodeClient,
   forgetDirectConnection,
   loadDirectConnections,
+  probeDirectConnection,
   registerControllerNode,
   relayNodeClient,
   relayOnline,
@@ -183,7 +184,8 @@ export default function Home() {
 
     const token = loadCloudSession();
     const cloudNode = cloudNodes.find((node) => node.id === nodeId);
-    if (token && cloudNode) {
+    const relay = relayStatus[nodeId];
+    if (token && cloudNode && relay === true) {
       try {
         const client = relayNodeClient(cloudNode, token);
         const nextSnapshot = await client.snapshot();
@@ -203,12 +205,48 @@ export default function Home() {
         setNodeError(`${relayMessage}${directMessage}`);
       }
     } else if (directFailure instanceof Error) {
-      setNodeError(directFailure.message);
+      setNodeError(`Direct failed: ${directFailure.message} Relay is unavailable; edit the Direct URL or access key.`);
+    } else if (cloudNode) {
+      setNodeError(relay === null
+        ? 'No Direct path is saved for this browser. Relay is still being checked; configure Direct to connect by IP or URL without relay.'
+        : 'No reachable transport. Configure a Direct URL and access key, or bring Controller relay online.');
     } else {
-      setNodeError('This Node is not reachable from this browser. Run agentsight bind on the Node to reconnect it.');
+      setNodeError('This Node is not reachable from this browser. Configure a Direct URL and access key.');
     }
     setLoadingNodeId(null);
-  }, [cloudNodes, directConnections]);
+  }, [cloudNodes, directConnections, relayStatus]);
+
+  const connectDirect = useCallback(async (
+    nodeId: string,
+    endpoint: string,
+    accessToken: string,
+  ): Promise<boolean> => {
+    setLoadingNodeId(nodeId);
+    setNodeError('');
+    try {
+      const connection = await probeDirectConnection(endpoint, accessToken);
+      if (connection.nodeId !== nodeId) {
+        setNodeError(
+          `That Direct URL belongs to ${connection.nodeName} (${connection.nodeId}), not the selected Node (${nodeId}).`,
+        );
+        return false;
+      }
+      const opened = await activateClient(directNodeClient(connection));
+      if (!opened) return false;
+      saveDirectConnection(connection);
+      setDirectConnections(loadDirectConnections());
+      const cloudToken = loadCloudSession();
+      if (cloudToken) {
+        void registerControllerNode(cloudToken, connection).catch(() => undefined);
+      }
+      return true;
+    } catch (cause) {
+      setNodeError(cause instanceof Error ? cause.message : 'Could not connect to that Direct Node URL.');
+      return false;
+    } finally {
+      setLoadingNodeId(null);
+    }
+  }, [activateClient]);
 
   const enterDemo = useCallback(async () => {
     setSyncing(true);
@@ -414,7 +452,7 @@ export default function Home() {
     <NodeManager identity={identity} nodes={cloudNodes} connections={directConnections}
       relayStatus={relayStatus} activeNodeId={activeClient?.nodeId} activeTransport={activeTransport}
       loadingNodeId={loadingNodeId} loading={syncing || nodesLoading} error={nodeError}
-      onOpenNode={(nodeId) => { void openNode(nodeId); }}
+      onOpenNode={(nodeId) => { void openNode(nodeId); }} onConnectDirect={connectDirect}
       onRefresh={() => { void refreshCloudNodes(); }}
       onForgetNode={(nodeId) => { void forgetNode(nodeId); }} onForgetDirect={forgetDirect}
       onDemo={() => { void enterDemo(); }} onSignOut={signOut} />
@@ -433,7 +471,7 @@ export default function Home() {
           relayStatus={relayStatus} activeNodeId={activeClient?.nodeId} activeTransport={activeTransport}
           loadingNodeId={loadingNodeId} loading={syncing || nodesLoading} error={nodeError} modal
           onClose={() => setDialogOpen(false)}
-          onOpenNode={(nodeId) => { void openNode(nodeId); }}
+          onOpenNode={(nodeId) => { void openNode(nodeId); }} onConnectDirect={connectDirect}
           onRefresh={() => { void refreshCloudNodes(); }}
           onForgetNode={(nodeId) => { void forgetNode(nodeId); }} onForgetDirect={forgetDirect}
           onDemo={() => { void enterDemo(); }} onSignOut={signOut} />

--- a/frontend/src/components/NodeManager.tsx
+++ b/frontend/src/components/NodeManager.tsx
@@ -29,6 +29,7 @@ interface NodeManagerProps {
   modal?: boolean;
   onClose?: () => void;
   onOpenNode: (nodeId: string) => void;
+  onConnectDirect: (nodeId: string, endpoint: string, accessToken: string) => Promise<boolean>;
   onRefresh: () => void;
   onForgetNode: (nodeId: string) => void;
   onForgetDirect: (nodeId: string) => void;
@@ -65,6 +66,7 @@ export function NodeManager({
   modal = false,
   onClose,
   onOpenNode,
+  onConnectDirect,
   onRefresh,
   onForgetNode,
   onForgetDirect,
@@ -72,6 +74,10 @@ export function NodeManager({
   onSignOut,
 }: NodeManagerProps) {
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
+  const [directEditorNodeId, setDirectEditorNodeId] = useState<string | null>(null);
+  const [directEndpoint, setDirectEndpoint] = useState('');
+  const [directAccessKey, setDirectAccessKey] = useState('');
+  const [directConnecting, setDirectConnecting] = useState(false);
 
   const visibleNodes = useMemo(() => {
     const byId = new Map(nodes.map((node) => [node.id, node]));
@@ -100,6 +106,32 @@ export function NodeManager({
     window.setTimeout(() => setCopyState('idle'), 1800);
   };
 
+  const editDirect = (nodeId: string) => {
+    const direct = connections[nodeId];
+    setDirectEditorNodeId(nodeId);
+    setDirectEndpoint(direct?.endpoint || '');
+    setDirectAccessKey(direct?.accessToken || '');
+  };
+
+  const closeDirectEditor = () => {
+    setDirectEditorNodeId(null);
+    setDirectEndpoint('');
+    setDirectAccessKey('');
+  };
+
+  const submitDirect = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!directEditorNodeId || directConnecting) return;
+    setDirectConnecting(true);
+    try {
+      if (await onConnectDirect(directEditorNodeId, directEndpoint, directAccessKey)) {
+        closeDirectEditor();
+      }
+    } finally {
+      setDirectConnecting(false);
+    }
+  };
+
   const content = (
     <section className={`overflow-hidden border border-slate-200 bg-white shadow-sm ${modal ? 'rounded-2xl' : 'rounded-xl'}`}>
       <header className="flex flex-wrap items-start justify-between gap-4 border-b border-slate-200 px-5 py-5 sm:px-6">
@@ -107,7 +139,7 @@ export function NodeManager({
           <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Machines</p>
           <h2 className="mt-1 text-xl font-semibold text-slate-950">AgentSight Nodes</h2>
           <p className="mt-1 text-sm text-slate-500">
-            Signed in as {identity.name || identity.email}. Direct is preferred; Controller relay is the remote fallback.
+            Signed in as {identity.name || identity.email}. Direct URLs work independently; Controller relay is only a fallback.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -140,11 +172,13 @@ export function NodeManager({
               const active = activeNodeId === node.id;
               const opening = loadingNodeId === node.id;
               const online = relay === true || active;
+              const cloudManaged = nodes.some((item) => item.id === node.id);
+              const editingDirect = directEditorNodeId === node.id;
               return (
                 <article key={node.id} className={`group relative rounded-xl border transition ${
                   active ? 'border-slate-950 bg-slate-50' : 'border-slate-200 bg-white hover:border-slate-400'
                 }`}>
-                  <button type="button" onClick={() => onOpenNode(node.id)} disabled={opening}
+                  <button type="button" onClick={() => onOpenNode(node.id)} disabled={opening || directConnecting}
                     className="block w-full p-4 text-left disabled:cursor-wait">
                     <div className="flex items-start justify-between gap-4">
                       <div className="flex min-w-0 items-start gap-3">
@@ -176,7 +210,7 @@ export function NodeManager({
                             : relay === true ? 'Online'
                               : direct ? 'Direct saved'
                                 : relay === null ? 'Checking…'
-                                  : 'Offline'}
+                                  : 'No transport'}
                       </span>
                     </div>
 
@@ -187,23 +221,58 @@ export function NodeManager({
                     </div>
                   </button>
 
-                  <div className="flex items-center justify-end gap-3 border-t border-slate-100 px-4 py-2.5">
+                  <div className="flex flex-wrap items-center justify-end gap-3 border-t border-slate-100 px-4 py-2.5">
+                    <button type="button" onClick={() => editingDirect ? closeDirectEditor() : editDirect(node.id)}
+                      disabled={loading || directConnecting}
+                      className="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:text-blue-900 disabled:opacity-50">
+                      <CommandLineIcon className="h-3.5 w-3.5" />
+                      {editingDirect ? 'Cancel Direct' : direct ? 'Edit Direct' : 'Connect Direct'}
+                    </button>
                     {direct && (
-                      <button type="button" onClick={() => onForgetDirect(node.id)} disabled={loading}
+                      <button type="button" onClick={() => onForgetDirect(node.id)} disabled={loading || directConnecting}
                         className="text-xs font-medium text-slate-500 hover:text-slate-900 disabled:opacity-50">
                         Forget direct path
                       </button>
                     )}
-                    {nodes.some((item) => item.id === node.id) && (
+                    {cloudManaged && (
                       <button type="button" onClick={() => {
                         if (window.confirm(`Remove ${node.name} from this account?`)) onForgetNode(node.id);
-                      }} disabled={loading}
+                      }} disabled={loading || directConnecting}
                         className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 hover:text-red-700 disabled:opacity-50">
                         <TrashIcon className="h-3.5 w-3.5" />
                         Remove
                       </button>
                     )}
                   </div>
+
+                  {editingDirect && (
+                    <form onSubmit={(event) => { void submitDirect(event); }}
+                      className="space-y-3 border-t border-slate-100 bg-slate-50 px-4 py-4">
+                      <div>
+                        <label className="text-xs font-medium text-slate-700" htmlFor={`direct-endpoint-${node.id}`}>Direct URL or IP</label>
+                        <input id={`direct-endpoint-${node.id}`} type="url" required value={directEndpoint}
+                          onChange={(event) => setDirectEndpoint(event.target.value)}
+                          placeholder="http://192.168.1.20:7395"
+                          spellCheck={false} autoCapitalize="none" autoCorrect="off"
+                          className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-blue-500" />
+                      </div>
+                      <div>
+                        <label className="text-xs font-medium text-slate-700" htmlFor={`direct-key-${node.id}`}>Node access key</label>
+                        <input id={`direct-key-${node.id}`} type="password" required value={directAccessKey}
+                          onChange={(event) => setDirectAccessKey(event.target.value)}
+                          placeholder="Persistent access key from agentsight bind"
+                          spellCheck={false} autoCapitalize="none" autoCorrect="off"
+                          className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 outline-none focus:border-blue-500" />
+                      </div>
+                      <p className="text-xs leading-5 text-slate-500">
+                        This browser probes <code>/api/v1/info</code> directly and verifies that the URL belongs to this Node. Relay is not required.
+                      </p>
+                      <button type="submit" disabled={directConnecting || loading}
+                        className="rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50">
+                        {directConnecting ? 'Testing Direct…' : 'Test and connect'}
+                      </button>
+                    </form>
+                  )}
                 </article>
               );
             })}
@@ -221,7 +290,9 @@ export function NodeManager({
             <span className="rounded-lg bg-white p-2 text-slate-700 shadow-sm"><CommandLineIcon className="h-5 w-5" /></span>
             <div>
               <p className="text-sm font-semibold text-slate-900">Add or reconnect a Node</p>
-              <p className="mt-0.5 text-xs text-slate-500">Run once on that machine. The Node identity and access bearer survive restarts.</p>
+              <p className="mt-0.5 text-xs text-slate-500">
+                Keep <code>agentsight bind</code> running to serve the Node. Use <code>--endpoint</code> for a browser-reachable LAN, VPN, or HTTPS URL.
+              </p>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -237,7 +308,7 @@ export function NodeManager({
         <div className="flex flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
           <div className="flex items-center gap-2 text-xs text-slate-500">
             <SignalIcon className="h-4 w-4" />
-            Controller stores identity and Node metadata; runtime evidence stays on the Node.
+            Controller stores identity and Node metadata; Direct and relay are independent Node transports.
           </div>
           <div className="flex items-center gap-4">
             <button type="button" onClick={onDemo} className="text-sm font-medium text-slate-600 hover:text-slate-950">

--- a/frontend/src/lib/nodeClient.ts
+++ b/frontend/src/lib/nodeClient.ts
@@ -72,6 +72,27 @@ function mergedHeaders(base?: HeadersInit, extra?: HeadersInit): Headers {
   return headers;
 }
 
+function normalizeDirectEndpoint(raw: string): string {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(raw.trim());
+  } catch {
+    throw new NodeRequestError(400, 'Direct URL must be a valid http(s) URL.');
+  }
+  if (!['http:', 'https:'].includes(endpoint.protocol)
+      || !endpoint.hostname || endpoint.username || endpoint.password) {
+    throw new NodeRequestError(400, 'Direct URL must be a valid http(s) URL without credentials.');
+  }
+  endpoint.pathname = '';
+  endpoint.search = '';
+  endpoint.hash = '';
+  return endpoint.toString().replace(/\/$/, '');
+}
+
+function validAccessToken(value: string): boolean {
+  return /^[A-Za-z0-9_-]{32,256}$/.test(value);
+}
+
 async function directFetch(input: string, init: RequestInit = {}): Promise<Response> {
   const endpoint = new URL(input);
   const options: RequestInit = {
@@ -101,6 +122,42 @@ async function jsonResponse<T>(response: Response, fallback: string): Promise<T>
     );
   }
   return response.json() as Promise<T>;
+}
+
+export async function probeDirectConnection(
+  rawEndpoint: string,
+  accessToken: string,
+): Promise<LocalConnection> {
+  const endpoint = normalizeDirectEndpoint(rawEndpoint);
+  const token = accessToken.trim();
+  if (!validAccessToken(token)) {
+    throw new NodeRequestError(400, 'Access key must be the persistent AgentSight Node access key.');
+  }
+
+  let response: Response;
+  try {
+    response = await directFetch(`${endpoint}/api/v1/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    throw new NodeRequestError(
+      0,
+      'Could not reach that Direct URL. Check the IP/hostname, Node listen address, and browser local-network permission.',
+    );
+  }
+  const body = await jsonResponse<{
+    node?: { id?: string; name?: string; version?: string };
+  }>(response, 'Direct Node probe failed');
+  if (!body.node?.id || !body.node.name) {
+    throw new NodeRequestError(502, 'The Direct URL did not return valid AgentSight Node metadata.');
+  }
+  return {
+    endpoint,
+    accessToken: token,
+    nodeId: body.node.id,
+    nodeName: body.node.name,
+    version: body.node.version || 'unknown',
+  };
 }
 
 function nodeClient(


### PR DESCRIPTION
## Goal

Make a registered AgentSight Node usable over a browser-reachable IP or URL even when Controller Relay is unavailable or not deployed.

## Changes

- Keep Direct as an independent transport and use Relay only when relay status is actually online.
- Add `probeDirectConnection()` to validate an `http://IP:port` or `https://host` endpoint against `/api/v1/info` with the persistent Node access key.
- Verify the probed Node ID matches the selected Machine before saving the Direct connection.
- Add per-Machine **Connect Direct / Edit Direct** UI for endpoint + access key.
- Persist validated Direct connections in the browser and continue preferring them over Relay.
- Replace raw relay `not_found` behavior with actionable no-transport / Direct configuration errors when Relay is unavailable.
- Clarify that `agentsight bind` must remain running and that `--endpoint` can advertise a LAN, VPN, or HTTPS address.
- Add Rust tests covering private-IP and HTTPS Direct endpoint normalization.

## Boundary

This does not require Controller Relay to be deployed. The Node access key remains browser-local and is not stored as plaintext in Controller/D1.

Connection order remains:

1. saved Direct endpoint;
2. Controller Relay only when reported online.

A cloud-listed Node with neither path can be given a Direct IP/URL explicitly from Machines.

## Validation

Repository CI should cover frontend static build/type checking and the added Rust endpoint tests before merge.