### PR TITLE
feat: support native Windows session management

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,9 +36,16 @@ jobs:
           $env:HOME = Join-Path $env:RUNNER_TEMP "agentsight-home"
           $fixtureDir = Join-Path $env:HOME ".codex/sessions/2026/06/18"
           New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
-          Copy-Item `
-            "agentpprof/examples/codex/sessions/2026/06/18/public-agentpprof-fixture.jsonl" `
-            (Join-Path $fixtureDir "public-agentpprof-fixture.jsonl")
+          $fixturePath = Join-Path $fixtureDir "public-agentpprof-fixture.jsonl"
+          Get-Content "agentpprof/examples/codex/sessions/2026/06/18/public-agentpprof-fixture.jsonl" |
+            ForEach-Object {
+              $record = $_ | ConvertFrom-Json
+              if ($record.payload.cwd) {
+                $record.payload.cwd = $PWD.Path
+              }
+              $record | ConvertTo-Json -Compress -Depth 100
+            } |
+            Set-Content -Encoding utf8NoBOM $fixturePath
           $snapshotPath = Join-Path $env:RUNNER_TEMP "agentsight-snapshot.json"
           & $agentsight report --local export --output $snapshotPath
           if ($LASTEXITCODE -ne 0) {
@@ -50,12 +57,39 @@ jobs:
           }
 
           & $agentsight top --plain --once
+          if ($LASTEXITCODE -ne 0) {
+            throw "agentsight top failed"
+          }
           $visHtml = Join-Path $env:RUNNER_TEMP "agent-nebula.html"
           $visPng = Join-Path $env:RUNNER_TEMP "agent-nebula.png"
           & $agentsight vis . --output $visHtml --output $visPng
           if ($LASTEXITCODE -ne 0 -or -not (Test-Path $visHtml) -or -not (Test-Path $visPng)) {
             throw "agentsight vis browser smoke failed"
           }
+          if (-not (Select-String -Quiet -SimpleMatch "agentpprof/src/main.rs" $visHtml)) {
+            throw "agentsight vis did not render the Windows session fixture"
+          }
+
+          $fakeBin = Join-Path $env:RUNNER_TEMP "agentsight-fake-provider"
+          New-Item -ItemType Directory -Force -Path $fakeBin | Out-Null
+          @'
+          @echo off
+          node "%~dp0\codex.js" %*
+          '@ | Set-Content -Encoding ascii (Join-Path $fakeBin "codex.cmd")
+          @'
+          const readline = require("readline");
+          const lines = readline.createInterface({ input: process.stdin });
+          lines.on("line", (line) => {
+            const request = JSON.parse(line);
+            if (request.id === 1 || request.id === 2) {
+              console.log(JSON.stringify({ id: request.id, result: {} }));
+            } else if (request.method === "turn/start") {
+              console.log(JSON.stringify({ id: request.id, result: { turn: { id: "fake-turn" } } }));
+              setTimeout(() => process.exit(0), 100);
+            }
+          });
+          '@ | Set-Content -Encoding utf8NoBOM (Join-Path $fakeBin "codex.js")
+          $env:PATH = "$fakeBin;$env:PATH"
 
           $listener = [System.Net.Sockets.TcpListener]::new(
             [System.Net.IPAddress]::Loopback,
@@ -113,14 +147,14 @@ jobs:
               throw "agentsight bind returned incomplete Node capabilities"
             }
             $messageProbe = Invoke-WebRequest `
-              -Uri "$bindBase/api/v1/sessions/missing-session/messages" `
+              -Uri "$bindBase/api/v1/sessions/agentpprof-public-fixture-session/messages" `
               -Method Post `
               -Headers $headers `
               -ContentType "application/json" `
               -Body '{"message":"windows bind smoke"}' `
               -SkipHttpErrorCheck
-            if ([int]$messageProbe.StatusCode -ne 404) {
-              throw "agentsight bind message route was not reachable"
+            if ([int]$messageProbe.StatusCode -ne 202) {
+              throw "agentsight bind did not submit through the Windows codex.cmd shim"
             }
           } finally {
             if (-not $bindProcess.HasExited) {

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -85,10 +85,8 @@ jobs:
               }
               if (Test-Path $tokenPath) {
                 try {
-                  $probe = Invoke-WebRequest `
-                    -Uri "$bindBase/api/v1/info" `
-                    -SkipHttpErrorCheck
-                  if ([int]$probe.StatusCode -eq 401) {
+                  $publicInfo = Invoke-RestMethod -Uri "$bindBase/api/v1/info"
+                  if ($publicInfo.authorization_required -and -not $publicInfo.node) {
                     $ready = $true
                     break
                   }
@@ -102,10 +100,16 @@ jobs:
               throw "agentsight bind did not expose its authenticated API"
             }
 
+            $snapshotProbe = Invoke-WebRequest `
+              -Uri "$bindBase/api/v1/snapshot" `
+              -SkipHttpErrorCheck
+            if ([int]$snapshotProbe.StatusCode -ne 401) {
+              throw "agentsight bind exposed session data without a token"
+            }
             $token = (Get-Content -Raw $tokenPath).Trim()
             $headers = @{ Authorization = "Bearer $token" }
             $info = Invoke-RestMethod -Uri "$bindBase/api/v1/info" -Headers $headers
-            if (-not $info.authorization_required -or -not $info.capabilities.session_messages) {
+            if (-not $info.node -or -not $info.capabilities.session_messages) {
               throw "agentsight bind returned incomplete Node capabilities"
             }
             $messageProbe = Invoke-WebRequest `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,7 +32,20 @@ jobs:
           cargo build --manifest-path collector/Cargo.toml
           $agentsight = "collector/target/debug/agentsight.exe"
           & $agentsight --version
-          & $agentsight report --local
+
+          $fixtureDir = Join-Path $HOME ".codex/sessions/2026/06/18"
+          New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
+          Copy-Item `
+            "agentpprof/examples/codex/sessions/2026/06/18/public-agentpprof-fixture.jsonl" `
+            (Join-Path $fixtureDir "public-agentpprof-fixture.jsonl")
+          $report = (& $agentsight report --local 2>&1 | Out-String)
+          if ($LASTEXITCODE -ne 0) {
+            throw "agentsight report --local failed"
+          }
+          if ($report -notmatch "codex") {
+            throw "agentsight report --local did not discover the Windows Codex fixture"
+          }
+
           & $agentsight top --plain --once
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,25 @@
+name: Windows native
+
+on:
+  pull_request:
+    branches: ["master", "main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Test portable session parser
+        run: cargo test --manifest-path agent-session/Cargo.toml
+
+      - name: Check native AgentSight CLI
+        run: cargo check --manifest-path collector/Cargo.toml

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -21,5 +21,21 @@ jobs:
       - name: Test portable session parser
         run: cargo test --manifest-path agent-session/Cargo.toml
 
-      - name: Check native AgentSight CLI
-        run: cargo check --manifest-path collector/Cargo.toml
+      - name: Test portable capture and native CLI
+        run: |
+          cargo test --manifest-path agentsight-capture/Cargo.toml
+          cargo test --manifest-path collector/Cargo.toml
+
+      - name: Build and smoke test agentsight.exe
+        shell: pwsh
+        run: |
+          cargo build --manifest-path collector/Cargo.toml
+          $agentsight = "collector/target/debug/agentsight.exe"
+          & $agentsight --version
+          & $agentsight report --local
+          & $agentsight top --plain --once
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agentsight-windows-x86_64
+          path: collector/target/debug/agentsight.exe

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -39,12 +39,14 @@ jobs:
           Copy-Item `
             "agentpprof/examples/codex/sessions/2026/06/18/public-agentpprof-fixture.jsonl" `
             (Join-Path $fixtureDir "public-agentpprof-fixture.jsonl")
-          $report = (& $agentsight report --local 2>&1 | Out-String)
+          $snapshotPath = Join-Path $env:RUNNER_TEMP "agentsight-snapshot.json"
+          & $agentsight report --local export --output $snapshotPath
           if ($LASTEXITCODE -ne 0) {
-            throw "agentsight report --local failed"
+            throw "agentsight report --local export failed"
           }
-          if ($report -notmatch "codex") {
-            throw "agentsight report --local did not discover the Windows Codex fixture"
+          $snapshot = Get-Content -Raw $snapshotPath | ConvertFrom-Json
+          if (-not ($snapshot.sessions | Where-Object agent_type -eq "codex")) {
+            throw "agentsight report export did not discover the Windows Codex fixture"
           }
 
           & $agentsight top --plain --once

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,6 +48,10 @@ jobs:
           }
 
           & $agentsight top --plain --once
+          & $agentsight vis . --output "$env:RUNNER_TEMP/agent-nebula.html"
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path "$env:RUNNER_TEMP/agent-nebula.html")) {
+            throw "agentsight vis HTML smoke failed"
+          }
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -33,6 +33,7 @@ jobs:
           $agentsight = "collector/target/debug/agentsight.exe"
           & $agentsight --version
 
+          $env:HOME = Join-Path $env:RUNNER_TEMP "agentsight-home"
           $fixtureDir = Join-Path $HOME ".codex/sessions/2026/06/18"
           New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
           Copy-Item `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,7 +34,7 @@ jobs:
           & $agentsight --version
 
           $env:HOME = Join-Path $env:RUNNER_TEMP "agentsight-home"
-          $fixtureDir = Join-Path $HOME ".codex/sessions/2026/06/18"
+          $fixtureDir = Join-Path $env:HOME ".codex/sessions/2026/06/18"
           New-Item -ItemType Directory -Force -Path $fixtureDir | Out-Null
           Copy-Item `
             "agentpprof/examples/codex/sessions/2026/06/18/public-agentpprof-fixture.jsonl" `

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,9 +50,78 @@ jobs:
           }
 
           & $agentsight top --plain --once
-          & $agentsight vis . --output "$env:RUNNER_TEMP/agent-nebula.html"
-          if ($LASTEXITCODE -ne 0 -or -not (Test-Path "$env:RUNNER_TEMP/agent-nebula.html")) {
-            throw "agentsight vis HTML smoke failed"
+          $visHtml = Join-Path $env:RUNNER_TEMP "agent-nebula.html"
+          $visPng = Join-Path $env:RUNNER_TEMP "agent-nebula.png"
+          & $agentsight vis . --output $visHtml --output $visPng
+          if ($LASTEXITCODE -ne 0 -or -not (Test-Path $visHtml) -or -not (Test-Path $visPng)) {
+            throw "agentsight vis browser smoke failed"
+          }
+
+          $listener = [System.Net.Sockets.TcpListener]::new(
+            [System.Net.IPAddress]::Loopback,
+            0
+          )
+          $listener.Start()
+          $bindPort = $listener.LocalEndpoint.Port
+          $listener.Stop()
+          $bindOut = Join-Path $env:RUNNER_TEMP "agentsight-bind.out"
+          $bindErr = Join-Path $env:RUNNER_TEMP "agentsight-bind.err"
+          $bindProcess = Start-Process `
+            -FilePath $agentsight `
+            -ArgumentList @(
+              "--listen", "127.0.0.1", "bind", "--no-open",
+              "--server-port", "$bindPort", "--app-url", "http://127.0.0.1:17400/"
+            ) `
+            -RedirectStandardOutput $bindOut `
+            -RedirectStandardError $bindErr `
+            -PassThru
+          try {
+            $bindBase = "http://127.0.0.1:$bindPort"
+            $tokenPath = Join-Path $env:APPDATA "agentsight/access-token"
+            $ready = $false
+            for ($attempt = 0; $attempt -lt 80; $attempt++) {
+              if ($bindProcess.HasExited) {
+                throw "agentsight bind exited during startup"
+              }
+              if (Test-Path $tokenPath) {
+                try {
+                  $probe = Invoke-WebRequest `
+                    -Uri "$bindBase/api/v1/info" `
+                    -SkipHttpErrorCheck
+                  if ([int]$probe.StatusCode -eq 401) {
+                    $ready = $true
+                    break
+                  }
+                } catch {
+                  # The listener may not have started yet.
+                }
+              }
+              Start-Sleep -Milliseconds 250
+            }
+            if (-not $ready) {
+              throw "agentsight bind did not expose its authenticated API"
+            }
+
+            $token = (Get-Content -Raw $tokenPath).Trim()
+            $headers = @{ Authorization = "Bearer $token" }
+            $info = Invoke-RestMethod -Uri "$bindBase/api/v1/info" -Headers $headers
+            if (-not $info.authorization_required -or -not $info.capabilities.session_messages) {
+              throw "agentsight bind returned incomplete Node capabilities"
+            }
+            $messageProbe = Invoke-WebRequest `
+              -Uri "$bindBase/api/v1/sessions/missing-session/messages" `
+              -Method Post `
+              -Headers $headers `
+              -ContentType "application/json" `
+              -Body '{"message":"windows bind smoke"}' `
+              -SkipHttpErrorCheck
+            if ([int]$messageProbe.StatusCode -ne 404) {
+              throw "agentsight bind message route was not reachable"
+            }
+          } finally {
+            if (-not $bindProcess.HasExited) {
+              Stop-Process -Id $bindProcess.Id -Force
+            }
           }
 
       - uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -79,8 +79,12 @@ AgentSight captures critical interactions that application-level tools miss:
 
 ### Prerequisites
 
-- **Linux kernel**: 4.1+ with eBPF support (5.0+ recommended)
-- **sudo access**: optional for `top`; eBPF is enabled automatically when sudo is already available
+- **Windows, macOS, or Linux**: `top`, `bind`, `vis`, and `report` can use
+  agent-native session files without eBPF
+- **Linux kernel**: 4.1+ with eBPF support (5.0+ recommended) for `record` and
+  the eBPF-backed debug commands
+- **sudo access on Linux**: optional for `top`; eBPF is enabled automatically
+  when sudo is already available
 
 For source builds, see [docs/build.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/build.md).
 
@@ -102,6 +106,9 @@ you want to record a specific command or inspect saved sessions.
 
 GitHub releases provide `agentsight-x86_64` and `agentsight-aarch64` for Linux.
 The unsuffixed `agentsight` asset remains an x86_64 compatibility alias.
+Native Windows builds are exercised by the Windows CI workflow; until a Windows
+release asset is published, download its `agentsight-windows-x86_64` artifact or
+build the collector crate from source.
 
 #### Docker
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,10 +69,14 @@ AgentSight 能捕获应用级工具遗漏的关键交互：
 
 ### 前置要求
 
-- **Linux 内核**：4.1+ 且支持 eBPF（推荐 5.0+）
-- **sudo 权限**：`top` 可选；当 sudo 已可用时会自动启用 eBPF probes
+- **Windows、macOS 或 Linux**：`top`、`bind`、`vis` 和 `report` 可以直接读取
+  Agent 原生会话文件，不依赖 eBPF
+- **Linux 内核**：`record` 和基于 eBPF 的调试命令需要 4.1+ 且支持 eBPF
+  （推荐 5.0+）
+- **Linux sudo 权限**：`top` 可选；当 sudo 已可用时会自动启用 eBPF probes
 
-从源码构建时还需要 Rust 1.88.0+、Node.js 18+、clang、llvm 和 libelf-dev。
+从源码构建请参阅 `docs/build.md`；Linux 的完整 eBPF 构建还需要 Node.js 18+、
+clang、llvm 和 libelf-dev。
 
 ### Rust 库
 
@@ -93,6 +97,8 @@ Rust 应用可以依赖
 
 GitHub Release 为 Linux 提供 `agentsight-x86_64` 和 `agentsight-aarch64`；
 无后缀的 `agentsight` 继续作为 x86_64 兼容文件保留。
+Windows 原生构建由 Windows CI 验证；正式发布 Windows Release 资产前，可以下载
+该工作流的 `agentsight-windows-x86_64` artifact，或从源码构建 collector crate。
 
 #### Docker
 

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1481,17 +1481,20 @@ fn common_parent_dir(paths: &[String]) -> Option<String> {
         .filter(|path| is_absolute_path_text(path))
         .map(|path| normalize_path_text(path))
         .map(|path| {
-            let rooted = path.starts_with('/');
-            let mut parts = path
+            let (root, remainder) = path_root(&path);
+            let mut parts = remainder
                 .split('/')
                 .filter(|part| !part.is_empty())
                 .map(str::to_string)
                 .collect::<Vec<_>>();
             parts.pop();
-            (rooted, parts)
+            (root.to_string(), parts)
         });
-    let (rooted, mut shared) = dirs.next()?;
-    for (_, candidate) in dirs {
+    let (root, mut shared) = dirs.next()?;
+    for (candidate_root, candidate) in dirs {
+        if candidate_root != root {
+            return None;
+        }
         let keep = shared
             .iter()
             .zip(candidate.iter())
@@ -1499,10 +1502,25 @@ fn common_parent_dir(paths: &[String]) -> Option<String> {
             .count();
         shared.truncate(keep);
     }
-    (!shared.is_empty()).then(|| {
-        let joined = shared.join("/");
-        if rooted { format!("/{joined}") } else { joined }
-    })
+    if root == "//" && shared.len() < 2 {
+        return None;
+    }
+    if shared.is_empty() {
+        return (root != "/").then_some(root);
+    }
+    Some(format!("{root}{}", shared.join("/")))
+}
+
+fn path_root(path: &str) -> (&str, &str) {
+    if let Some(remainder) = path.strip_prefix("//") {
+        ("//", remainder)
+    } else if path.as_bytes().get(1) == Some(&b':') && path.as_bytes().get(2) == Some(&b'/') {
+        (&path[..3], &path[3..])
+    } else if let Some(remainder) = path.strip_prefix('/') {
+        ("/", remainder)
+    } else {
+        ("", path)
+    }
 }
 
 fn cursor_delegating_prompt_index(
@@ -3854,6 +3872,33 @@ mod tests {
         )
         .expect("session");
         assert_eq!(session.cwd, None);
+    }
+
+    #[test]
+    fn cursor_cwd_preserves_windows_drive_and_unc_roots() {
+        assert_eq!(
+            common_parent_dir(&[r"C:\file.rs".to_string()]).as_deref(),
+            Some("C:/")
+        );
+        assert_eq!(
+            common_parent_dir(&[r"\\server\share\file.rs".to_string()]).as_deref(),
+            Some("//server/share")
+        );
+        assert_eq!(
+            common_parent_dir(&[
+                r"C:\repo\src\main.rs".to_string(),
+                r"C:\repo\README.md".to_string(),
+            ])
+            .as_deref(),
+            Some("C:/repo")
+        );
+        assert_eq!(
+            common_parent_dir(&[
+                r"\\server\share-a\file.rs".to_string(),
+                r"\\server\share-b\file.rs".to_string(),
+            ]),
+            None
+        );
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -226,7 +226,7 @@ pub fn session_log_path_from_str(raw: &str) -> Option<PathBuf> {
         return None;
     }
     let path = Path::new(trimmed);
-    if !path.is_absolute() || !is_agent_session_file(path) {
+    if !is_absolute_path_text(trimmed) || !is_agent_session_file(path) {
         return None;
     }
     agent_source_for_path(path).map(|_| normalize_session_log_path(path))
@@ -239,7 +239,7 @@ pub fn normalize_session_log_path(path: &Path) -> PathBuf {
 
 /// Detect which agent a session file belongs to based on its path.
 pub fn agent_source_for_path(path: &Path) -> Option<&'static str> {
-    let value = path.to_string_lossy();
+    let value = normalize_path_text(&path.to_string_lossy());
     if value.contains("/.claude/") && path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
     {
         Some(AGENT_CLAUDE)
@@ -260,7 +260,7 @@ pub fn agent_source_for_path(path: &Path) -> Option<&'static str> {
 
 fn is_cursor_transcript(path: &Path) -> bool {
     path.extension().and_then(|ext| ext.to_str()) == Some("jsonl")
-        && path.to_string_lossy().contains("/agent-transcripts/")
+        && normalize_path_text(&path.to_string_lossy()).contains("/agent-transcripts/")
 }
 
 fn is_cursor_parent_transcript(path: &Path) -> bool {
@@ -273,7 +273,7 @@ fn is_cursor_parent_transcript(path: &Path) -> bool {
 }
 
 fn loose_agent_source_for_path(path: &Path) -> Option<&'static str> {
-    let value = path.to_string_lossy();
+    let value = normalize_path_text(&path.to_string_lossy());
     if value.contains("/codex/") && value.contains("sessions") {
         Some(AGENT_CODEX)
     } else if value.contains("/claude/") && value.contains("projects") {
@@ -1445,7 +1445,7 @@ fn cursor_absorb_transcript(
 }
 
 fn cursor_session_cwd(content: &str, children: &[(PathBuf, String)]) -> Option<String> {
-    let mut absolute: Vec<PathBuf> = Vec::new();
+    let mut absolute = Vec::new();
     for transcript in std::iter::once(content).chain(children.iter().map(|(_, body)| body.as_str()))
     {
         for line in transcript.lines() {
@@ -1457,15 +1457,15 @@ fn cursor_session_cwd(content: &str, children: &[(PathBuf, String)]) -> Option<S
                     continue;
                 };
                 if let Some(dir) = input.get("working_directory").and_then(Value::as_str)
-                    && Path::new(dir).is_absolute()
+                    && is_absolute_path_text(dir)
                 {
-                    return Some(dir.to_string());
+                    return Some(normalize_path_text(dir));
                 }
                 for key in ["path", "paths"] {
                     match input.get(key) {
-                        Some(Value::String(value)) => absolute.push(PathBuf::from(value)),
+                        Some(Value::String(value)) => absolute.push(value.clone()),
                         Some(Value::Array(values)) => absolute
-                            .extend(values.iter().filter_map(Value::as_str).map(PathBuf::from)),
+                            .extend(values.iter().filter_map(Value::as_str).map(str::to_string)),
                         _ => {}
                     }
                 }
@@ -1475,18 +1475,23 @@ fn cursor_session_cwd(content: &str, children: &[(PathBuf, String)]) -> Option<S
     common_parent_dir(&absolute)
 }
 
-fn common_parent_dir(paths: &[PathBuf]) -> Option<String> {
+fn common_parent_dir(paths: &[String]) -> Option<String> {
     let mut dirs = paths
         .iter()
-        .filter(|path| path.is_absolute())
-        .filter_map(|path| path.parent())
-        .map(|dir| {
-            dir.components()
-                .map(|part| part.as_os_str().to_string_lossy().into_owned())
-                .collect::<Vec<_>>()
+        .filter(|path| is_absolute_path_text(path))
+        .map(|path| normalize_path_text(path))
+        .map(|path| {
+            let rooted = path.starts_with('/');
+            let mut parts = path
+                .split('/')
+                .filter(|part| !part.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            parts.pop();
+            (rooted, parts)
         });
-    let mut shared = dirs.next()?;
-    for candidate in dirs {
+    let (rooted, mut shared) = dirs.next()?;
+    for (_, candidate) in dirs {
         let keep = shared
             .iter()
             .zip(candidate.iter())
@@ -1494,13 +1499,9 @@ fn common_parent_dir(paths: &[PathBuf]) -> Option<String> {
             .count();
         shared.truncate(keep);
     }
-    // A single leading "/" component means the paths share nothing useful.
-    (shared.len() > 1).then(|| {
-        let mut out = PathBuf::new();
-        for part in shared {
-            out.push(part);
-        }
-        out.to_string_lossy().into_owned()
+    (!shared.is_empty()).then(|| {
+        let joined = shared.join("/");
+        if rooted { format!("/{joined}") } else { joined }
     })
 }
 
@@ -2087,7 +2088,7 @@ fn shell_file_actions(
     let mut cwd = ["workdir", "cwd", "working_directory"]
         .iter()
         .find_map(|key| input.get(*key).and_then(Value::as_str))
-        .map(PathBuf::from);
+        .map(normalize_path_text);
     let mut rows = Vec::new();
     for parts in shell_segments(command) {
         let Some(command_index) = shell_command_index(&parts) else {
@@ -2097,11 +2098,10 @@ fn shell_file_actions(
         let operands = &parts[command_index + 1..];
         if name == "cd" {
             if let Some(path) = operands.iter().find(|value| !value.starts_with('-')) {
-                let path = PathBuf::from(path);
-                cwd = Some(if path.is_absolute() {
-                    path
+                cwd = Some(if is_absolute_path_text(path) {
+                    normalize_path_text(path)
                 } else {
-                    cwd.take().unwrap_or_default().join(path)
+                    join_path_text(cwd.as_deref().unwrap_or_default(), path)
                 });
             }
             continue;
@@ -2109,18 +2109,18 @@ fn shell_file_actions(
         let mut actions = shell_segment_actions(&name, operands, input, depth);
         for (path, _, previous_path) in &mut actions {
             if !path.starts_with(['~', '$'])
-                && !Path::new(path).is_absolute()
+                && !is_absolute_path_text(path)
                 && let Some(base) = &cwd
             {
-                *path = base.join(&*path).to_string_lossy().into_owned();
+                *path = join_path_text(base, path);
             }
             *path = clean_path_token(path);
             if let Some(previous) = previous_path {
                 if !previous.starts_with(['~', '$'])
-                    && !Path::new(previous).is_absolute()
+                    && !is_absolute_path_text(previous)
                     && let Some(base) = &cwd
                 {
-                    *previous = base.join(&*previous).to_string_lossy().into_owned();
+                    *previous = join_path_text(base, previous);
                 }
                 *previous = clean_path_token(previous);
             }
@@ -2265,14 +2265,39 @@ fn shell_segment_actions(
 }
 
 fn destination_path(target: &str, source: &str, multiple: bool) -> String {
-    if multiple || target.ends_with('/') {
-        Path::new(target)
-            .join(Path::new(source).file_name().unwrap_or_default())
-            .to_string_lossy()
-            .into_owned()
+    if multiple || target.ends_with(['/', '\\']) {
+        join_path_text(target, path_basename(source))
     } else {
-        target.to_string()
+        normalize_path_text(target)
     }
+}
+
+fn normalize_path_text(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+fn is_absolute_path_text(path: &str) -> bool {
+    let path = normalize_path_text(path);
+    path.starts_with('/')
+        || path.as_bytes().get(1) == Some(&b':') && path.as_bytes().get(2) == Some(&b'/')
+}
+
+fn join_path_text(base: &str, child: &str) -> String {
+    let base = normalize_path_text(base);
+    let child = normalize_path_text(child);
+    if base.is_empty() || is_absolute_path_text(&child) {
+        child
+    } else {
+        format!(
+            "{}/{}",
+            base.trim_end_matches('/'),
+            child.trim_start_matches('/')
+        )
+    }
+}
+
+fn path_basename(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
 }
 
 fn collect_path_fields(
@@ -4030,6 +4055,28 @@ mod tests {
 
         let fixture = fixture_session_path(AGENT_CURSOR, &home).expect("fixture");
         assert!(is_agent_file_for(AGENT_CURSOR, &fixture));
+    }
+
+    #[test]
+    fn native_windows_session_paths_classify() {
+        assert_eq!(
+            agent_source_for_path(Path::new(
+                r"C:\Users\dev\.codex\sessions\2026\08\12\session.jsonl"
+            )),
+            Some(AGENT_CODEX)
+        );
+        assert_eq!(
+            agent_source_for_path(Path::new(
+                r"C:\Users\dev\.claude\projects\repo\session.jsonl"
+            )),
+            Some(AGENT_CLAUDE)
+        );
+        assert_eq!(
+            agent_source_for_path(Path::new(
+                r"C:\Users\dev\.cursor\projects\repo\agent-transcripts\id\id.jsonl"
+            )),
+            Some(AGENT_CURSOR)
+        );
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1805,7 +1805,7 @@ fn is_agent_file_for(agent: &str, path: &Path) -> bool {
                     .file_name()
                     .and_then(|name| name.to_str())
                     .is_some_and(|name| name.starts_with("session-"))
-                && path.to_string_lossy().contains("/chats/")
+                && normalize_path_text(&path.to_string_lossy()).contains("/chats/")
         }
         AGENT_CURSOR => is_cursor_parent_transcript(path),
         _ => false,
@@ -1821,13 +1821,13 @@ pub(crate) fn user_home_dir() -> Option<PathBuf> {
                     .lines()
                     .find(|line| line.starts_with(&format!("{user}:")))
                     .and_then(|line| line.split(':').nth(5))
-                .map(PathBuf::from)
+                    .map(PathBuf::from)
             })
         })
         .or_else(|| {
             std::env::var_os("HOME")
-                .filter(|home| !home.is_empty())
                 .map(PathBuf::from)
+                .filter(|home| home.is_absolute())
         })
         .or_else(dirs::home_dir)
 }
@@ -4082,6 +4082,10 @@ mod tests {
             )),
             Some(AGENT_CURSOR)
         );
+        let gemini =
+            Path::new(r"C:\Users\dev\.gemini\tmp\repo\chats\session-2026-08-12T00-00-id.json");
+        assert_eq!(agent_source_for_path(gemini), Some(AGENT_GEMINI));
+        assert!(is_agent_file_for(AGENT_GEMINI, gemini));
     }
 
     #[test]

--- a/agent-session/src/parser.rs
+++ b/agent-session/src/parser.rs
@@ -1821,8 +1821,13 @@ pub(crate) fn user_home_dir() -> Option<PathBuf> {
                     .lines()
                     .find(|line| line.starts_with(&format!("{user}:")))
                     .and_then(|line| line.split(':').nth(5))
-                    .map(PathBuf::from)
+                .map(PathBuf::from)
             })
+        })
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|home| !home.is_empty())
+                .map(PathBuf::from)
         })
         .or_else(dirs::home_dir)
 }

--- a/agentsight-capture/src/binary_extractor.rs
+++ b/agentsight-capture/src/binary_extractor.rs
@@ -3,6 +3,7 @@
 
 use std::fs;
 use std::io::Write;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
@@ -22,6 +23,7 @@ pub struct BinaryExtractor {
 }
 
 impl BinaryExtractor {
+    #[cfg(target_os = "linux")]
     pub async fn new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let temp_dir = TempDir::new()?;
         let temp_path = temp_dir.path();
@@ -48,6 +50,12 @@ impl BinaryExtractor {
         })
     }
 
+    #[cfg(not(target_os = "linux"))]
+    pub async fn new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Err("eBPF capture is available on Linux only; use top, bind, vis, or report on this platform"
+            .into())
+    }
+
     async fn extract_binary(
         path: &Path,
         binary_data: &[u8],
@@ -60,9 +68,7 @@ impl BinaryExtractor {
         } // File is closed here
 
         // Make the binary executable
-        let mut perms = fs::metadata(path)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(path, perms)?;
+        set_executable(path)?;
 
         log::debug!("Extracted {} binary to: {}", name, path.display());
 
@@ -98,9 +104,7 @@ impl BinaryExtractor {
             file.flush()?;
         }
 
-        let mut perms = fs::metadata(&stdiocap_path)?.permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&stdiocap_path, perms)?;
+        set_executable(&stdiocap_path)?;
         log::debug!("Extracted stdiocap binary to: {}", stdiocap_path.display());
 
         self.stdiocap_path
@@ -113,4 +117,16 @@ impl BinaryExtractor {
             .expect("stdiocap path should be initialized")
             .as_path())
     }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> std::io::Result<()> {
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms)
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }

--- a/agentsight-capture/src/binary_extractor.rs
+++ b/agentsight-capture/src/binary_extractor.rs
@@ -15,7 +15,10 @@ use tokio::time::{Duration, sleep};
 const PROCESS_BINARY: &[u8] = include_bytes!("../vendor/bpf/process");
 #[cfg(target_os = "linux")]
 const SSLSNIFF_BINARY: &[u8] = include_bytes!("../vendor/bpf/sslsniff");
+#[cfg(target_os = "linux")]
 const STDIOCAP_BINARY: &[u8] = include_bytes!("../vendor/bpf/stdiocap");
+#[cfg(not(target_os = "linux"))]
+const STDIOCAP_BINARY: &[u8] = &[];
 
 pub struct BinaryExtractor {
     _temp_dir: TempDir, // Keep alive to prevent cleanup

--- a/agentsight-capture/src/binary_extractor.rs
+++ b/agentsight-capture/src/binary_extractor.rs
@@ -8,9 +8,12 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use tempfile::TempDir;
+#[cfg(target_os = "linux")]
 use tokio::time::{Duration, sleep};
 
+#[cfg(target_os = "linux")]
 const PROCESS_BINARY: &[u8] = include_bytes!("../vendor/bpf/process");
+#[cfg(target_os = "linux")]
 const SSLSNIFF_BINARY: &[u8] = include_bytes!("../vendor/bpf/sslsniff");
 const STDIOCAP_BINARY: &[u8] = include_bytes!("../vendor/bpf/stdiocap");
 
@@ -56,6 +59,7 @@ impl BinaryExtractor {
             .into())
     }
 
+    #[cfg(target_os = "linux")]
     async fn extract_binary(
         path: &Path,
         binary_data: &[u8],

--- a/agentsight-capture/src/runners/common.rs
+++ b/agentsight-capture/src/runners/common.rs
@@ -79,14 +79,14 @@ pub fn runner_error_from_event(event: &Event) -> Option<RunnerError> {
 }
 
 struct ProbeProcessGuard {
-    pgid: Option<libc::pid_t>,
+    pgid: Option<u32>,
     needs_sudo: bool,
 }
 
 impl ProbeProcessGuard {
     fn new(pid: Option<u32>, needs_sudo: bool) -> Self {
         Self {
-            pgid: pid.map(|pid| pid as libc::pid_t),
+            pgid: pid,
             needs_sudo,
         }
     }
@@ -104,11 +104,29 @@ impl ProbeProcessGuard {
                 .args(["-n", "kill", "-TERM", "--", &format!("-{pgid}")])
                 .status();
         } else {
-            unsafe {
-                libc::killpg(pgid, libc::SIGTERM);
-            }
+            terminate_process_group(pgid);
         }
     }
+}
+
+#[cfg(unix)]
+fn terminate_process_group(pgid: u32) {
+    unsafe {
+        libc::killpg(pgid as libc::pid_t, libc::SIGTERM);
+    }
+}
+
+#[cfg(not(unix))]
+fn terminate_process_group(_pgid: u32) {}
+
+#[cfg(unix)]
+fn needs_sudo() -> bool {
+    unsafe { libc::geteuid() != 0 }
+}
+
+#[cfg(not(unix))]
+fn needs_sudo() -> bool {
+    false
 }
 
 impl Drop for ProbeProcessGuard {
@@ -217,7 +235,7 @@ impl BinaryExecutor {
     /// eBPF programs get the privileges they need while the parent process
     /// (and the user's agent) stay unprivileged.
     pub async fn get_json_stream(&self) -> Result<JsonStream, RunnerError> {
-        let needs_sudo = unsafe { libc::geteuid() } != 0;
+        let needs_sudo = needs_sudo();
 
         if needs_sudo {
             log::info!(
@@ -244,6 +262,7 @@ impl BinaryExecutor {
         };
         cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
         cmd.kill_on_drop(true);
+        #[cfg(unix)]
         cmd.process_group(0);
 
         // Add additional arguments if any

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -412,6 +412,11 @@ fn user_home_dir() -> Option<PathBuf> {
                         .map(PathBuf::from)
                 })
         })
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .filter(|home| !home.is_empty())
+                .map(PathBuf::from)
+        })
         .or_else(dirs::home_dir)
 }
 

--- a/agentsight-capture/src/sources/agent_native.rs
+++ b/agentsight-capture/src/sources/agent_native.rs
@@ -414,8 +414,8 @@ fn user_home_dir() -> Option<PathBuf> {
         })
         .or_else(|| {
             std::env::var_os("HOME")
-                .filter(|home| !home.is_empty())
                 .map(PathBuf::from)
+                .filter(|home| home.is_absolute())
         })
         .or_else(dirs::home_dir)
 }

--- a/agentsight-capture/src/sources/proc.rs
+++ b/agentsight-capture/src/sources/proc.rs
@@ -431,10 +431,18 @@ pub fn process_cpu_ms_delta(proc_info: &ProcInfo, previous: Option<&ProcSnapshot
 
 fn ticks_per_second() -> f64 {
     static TICKS_PER_SECOND: OnceLock<f64> = OnceLock::new();
-    *TICKS_PER_SECOND.get_or_init(|| {
-        let value = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
-        if value > 0 { value as f64 } else { 100.0 }
-    })
+    *TICKS_PER_SECOND.get_or_init(platform_ticks_per_second)
+}
+
+#[cfg(unix)]
+fn platform_ticks_per_second() -> f64 {
+    let value = unsafe { libc::sysconf(libc::_SC_CLK_TCK) };
+    if value > 0 { value as f64 } else { 100.0 }
+}
+
+#[cfg(not(unix))]
+fn platform_ticks_per_second() -> f64 {
+    100.0
 }
 
 #[cfg(test)]

--- a/agentsight-capture/src/sources/proc.rs
+++ b/agentsight-capture/src/sources/proc.rs
@@ -448,6 +448,7 @@ fn platform_ticks_per_second() -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
     use std::process::Command;
 
     #[test]

--- a/agentsight-capture/src/view/process_select.rs
+++ b/agentsight-capture/src/view/process_select.rs
@@ -3,7 +3,6 @@
 
 use crate::sources::proc::{PidSeed, ProcInfo, ProcSnapshot};
 use std::collections::HashSet;
-use std::path::Path;
 
 pub fn live_root_pids(snapshot: &ProcSnapshot, pid: Option<u32>, comm: Option<&str>) -> Vec<u32> {
     if let Some(pid) = pid {
@@ -178,7 +177,7 @@ fn executable_tokens(command: &str) -> impl Iterator<Item = &str> {
 
 fn looks_like_exec_path(token: &str) -> bool {
     let token = token.trim_matches(|ch| matches!(ch, '"' | '\''));
-    token.contains('/')
+    token.contains(['/', '\\'])
 }
 
 fn executable_token_matches(token: &str, wanted: &str) -> bool {
@@ -191,10 +190,7 @@ fn executable_token_matches(token: &str, wanted: &str) -> bool {
     if label_from_exec_token(&lower).is_some_and(|label| label.contains(wanted)) {
         return true;
     }
-    let basename = Path::new(&lower)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(lower.as_str());
+    let basename = exec_basename(&lower);
     !basename.contains('.') && basename.contains(wanted)
 }
 
@@ -205,12 +201,18 @@ fn label_from_exec_token(token: &str) -> Option<&'static str> {
     }
 
     let lower = token.to_ascii_lowercase();
-    let basename = Path::new(&lower)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(lower.as_str());
+    let basename = exec_basename(&lower);
+    let executable = basename
+        .strip_suffix(".exe")
+        .or_else(|| basename.strip_suffix(".cmd"))
+        .or_else(|| basename.strip_suffix(".bat"))
+        .unwrap_or(basename);
 
-    label_from_exec_name(basename).or_else(|| label_from_known_package_path(&lower))
+    label_from_exec_name(executable).or_else(|| label_from_known_package_path(&lower))
+}
+
+fn exec_basename(token: &str) -> &str {
+    token.rsplit(['/', '\\']).next().unwrap_or(token)
 }
 
 fn label_from_exec_name(name: &str) -> Option<&'static str> {
@@ -228,6 +230,7 @@ fn label_from_exec_name(name: &str) -> Option<&'static str> {
 }
 
 fn label_from_known_package_path(path: &str) -> Option<&'static str> {
+    let path = path.replace('\\', "/");
     if path.contains("@anthropic-ai/claude-code") || path.contains("/claude-code/") {
         Some("claude")
     } else if path.contains("@openai/codex") || path.contains("/codex-linux-") {
@@ -261,11 +264,10 @@ fn is_codex_executable_token(token: &str) -> bool {
         return false;
     }
     let lower = token.to_ascii_lowercase();
-    let basename = Path::new(&lower)
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or(lower.as_str());
-    matches!(basename, "codex" | "codex-cli")
+    matches!(
+        exec_basename(&lower),
+        "codex" | "codex.exe" | "codex-cli" | "codex-cli.exe"
+    )
 }
 
 #[cfg(test)]
@@ -304,7 +306,35 @@ mod tests {
             Some("claude")
         );
         assert_eq!(known_agent_label("claude", "claude"), Some("claude"));
+        assert_eq!(
+            known_agent_label("claude.exe", r#"C:\Users\dev\bin\claude.exe"#),
+            Some("claude")
+        );
+        assert_eq!(
+            known_agent_label(
+                "codex.exe",
+                r#"C:\Program Files\WindowsApps\OpenAI.Codex\codex.exe app-server"#
+            ),
+            Some("codex")
+        );
+        assert_eq!(
+            known_agent_label(
+                "node.exe",
+                r#"node.exe C:\Users\dev\npm\node_modules\@openai\codex\bin\codex.js"#
+            ),
+            Some("codex")
+        );
         assert_eq!(known_agent_label("openclaw-gatewa", ""), Some("openclaw"));
+    }
+
+    #[test]
+    fn codex_exec_detection_accepts_windows_executable_names() {
+        let proc_info = ProcInfo {
+            comm: "codex.exe".to_string(),
+            command: r#"C:\Users\dev\bin\codex.exe exec --skip-git-repo-check"#.to_string(),
+            ..Default::default()
+        };
+        assert!(is_codex_exec_invocation(&proc_info));
     }
 
     #[test]

--- a/agentvis/src/export.rs
+++ b/agentvis/src/export.rs
@@ -393,24 +393,13 @@ fn browser_binary() -> Result<PathBuf, String> {
     }
     if let Some(home) = dirs::home_dir() {
         let cache = home.join(".cache/ms-playwright");
-        let mut versions = fs::read_dir(cache)
-            .into_iter()
-            .flatten()
-            .filter_map(Result::ok)
-            .map(|entry| entry.path())
-            .collect::<Vec<_>>();
-        versions.sort();
-        for version in versions.into_iter().rev() {
-            for suffix in [
-                "chrome-linux64/chrome",
-                "chrome-linux/chrome",
-                "chrome-headless-shell-linux64/headless_shell",
-            ] {
-                let path = version.join(suffix);
-                if path.is_file() {
-                    return Ok(path);
-                }
-            }
+        if let Some(path) = browser_from_playwright_cache(&cache) {
+            return Ok(path);
+        }
+    }
+    for path in system_browser_candidates() {
+        if path.is_file() {
+            return Ok(path);
         }
     }
     for name in [
@@ -427,7 +416,51 @@ fn browser_binary() -> Result<PathBuf, String> {
             return Ok(name.into());
         }
     }
-    Err("PNG/SVG/GIF/MP4 export needs Chromium; HTML has no browser dependency".into())
+    Err(
+        "PNG/SVG/GIF/MP4 export needs Chrome, Edge, or Chromium; HTML has no browser dependency"
+            .into(),
+    )
+}
+
+fn browser_from_playwright_cache(cache: &Path) -> Option<PathBuf> {
+    let mut versions = fs::read_dir(cache)
+        .into_iter()
+        .flatten()
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .collect::<Vec<_>>();
+    versions.sort();
+    for version in versions.into_iter().rev() {
+        for suffix in [
+            "chrome-linux64/chrome",
+            "chrome-linux/chrome",
+            "chrome-headless-shell-linux64/headless_shell",
+            "chrome-win64/chrome.exe",
+            "chrome-win/chrome.exe",
+            "chrome-headless-shell-win64/headless_shell.exe",
+        ] {
+            let path = version.join(suffix);
+            if path.is_file() {
+                return Some(path);
+            }
+        }
+    }
+    None
+}
+
+fn system_browser_candidates() -> Vec<PathBuf> {
+    ["PROGRAMFILES", "PROGRAMFILES(X86)", "LOCALAPPDATA"]
+        .into_iter()
+        .filter_map(env::var_os)
+        .flat_map(|root| {
+            let root = PathBuf::from(root);
+            [
+                root.join("Google/Chrome/Application/chrome.exe"),
+                root.join("Microsoft/Edge/Application/msedge.exe"),
+                root.join("Chromium/Application/chrome.exe"),
+            ]
+        })
+        .collect()
 }
 
 fn html_document(payload: &serde_json::Value) -> Result<String, serde_json::Error> {
@@ -460,6 +493,16 @@ mod tests {
         assert_eq!("2m".parse(), Ok(CompactRate::DurationSeconds(120.0)));
         assert_eq!("full".parse(), Ok(CompactRate::Full));
         assert!("0s".parse::<CompactRate>().is_err());
+    }
+
+    #[test]
+    fn playwright_cache_accepts_windows_chrome_layout() {
+        let temp = tempfile::tempdir().unwrap();
+        let browser = temp.path().join("chromium-1200/chrome-win64/chrome.exe");
+        fs::create_dir_all(browser.parent().unwrap()).unwrap();
+        fs::write(&browser, b"fixture").unwrap();
+
+        assert_eq!(browser_from_playwright_cache(temp.path()), Some(browser));
     }
 
     #[test]

--- a/collector/src/cmd_bind.rs
+++ b/collector/src/cmd_bind.rs
@@ -7,7 +7,9 @@ use crate::view::MaterializedView;
 use qrcode::QrCode;
 use qrcode::render::unicode;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+#[cfg(unix)]
 use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 use url::{Url, form_urlencoded};
@@ -70,7 +72,9 @@ pub(crate) async fn run_bind(
         "The access key is stored locally, survives Node restarts, and is removed from the browser URL after opening."
     );
     if relay_handle.is_some() {
-        println!("Controller relay is enabled for signed-in remote browsers; Direct access remains preferred.");
+        println!(
+            "Controller relay is enabled for signed-in remote browsers; Direct access remains preferred."
+        );
     }
     if let Some(db_path) = db_path {
         println!("Serving saved AgentSight data from {db_path}.");
@@ -140,11 +144,7 @@ fn local_access_token() -> Result<String, Box<dyn std::error::Error + Send + Syn
         Ok(_) => Err(format!("invalid AgentSight access token at {}", path.display()).into()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             let token = random_token();
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(path)?;
+            let mut file = create_private_file(&path)?;
             use std::io::Write;
             writeln!(file, "{token}")?;
             Ok(token)
@@ -172,11 +172,7 @@ fn local_node_metadata()
         }
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
             let id = format!("node_{}", uuid::Uuid::new_v4().simple());
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .mode(0o600)
-                .open(&id_path)?;
+            let mut file = create_private_file(&id_path)?;
             use std::io::Write;
             writeln!(file, "{id}")?;
             id
@@ -187,12 +183,21 @@ fn local_node_metadata()
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var("COMPUTERNAME").ok())
         .unwrap_or_else(|| "AgentSight Node".to_string());
     Ok(crate::server::NodeMetadata {
         id,
         name,
         version: env!("CARGO_PKG_VERSION").to_string(),
     })
+}
+
+fn create_private_file(path: &Path) -> std::io::Result<std::fs::File> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    options.open(path)
 }
 
 fn valid_node_id(value: &str) -> bool {

--- a/collector/src/cmd_bind.rs
+++ b/collector/src/cmd_bind.rs
@@ -303,8 +303,26 @@ fn print_qr(value: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
 }
 
 fn open_browser(url: &str) -> bool {
-    Command::new("xdg-open")
-        .arg(url)
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = Command::new("explorer.exe");
+        command.arg(url);
+        command
+    };
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = Command::new("open");
+        command.arg(url);
+        command
+    };
+    #[cfg(all(unix, not(target_os = "macos")))]
+    let mut command = {
+        let mut command = Command::new("xdg-open");
+        command.arg(url);
+        command
+    };
+
+    command
         .spawn()
         .map(|mut child| {
             std::thread::spawn(move || {

--- a/collector/src/cmd_exec.rs
+++ b/collector/src/cmd_exec.rs
@@ -29,13 +29,23 @@ use crate::view::MaterializedView;
 /// from the command name, starts SSL + process + system monitoring in the
 /// background (quiet, so the child owns the terminal), then spawns the child.
 /// Monitoring stops automatically when the child exits.
-pub(crate) fn target_user_ids() -> Option<(libc::uid_t, libc::gid_t)> {
-    if unsafe { libc::geteuid() } != 0 {
+pub(crate) fn target_user_ids() -> Option<(u32, u32)> {
+    if !running_as_root() {
         return None;
     }
     let uid = std::env::var("SUDO_UID").ok()?.parse().ok()?;
     let gid = std::env::var("SUDO_GID").ok()?.parse().ok()?;
     Some((uid, gid))
+}
+
+#[cfg(unix)]
+fn running_as_root() -> bool {
+    unsafe { libc::geteuid() == 0 }
+}
+
+#[cfg(not(unix))]
+fn running_as_root() -> bool {
+    false
 }
 
 pub(crate) fn sudo_cached() -> bool {
@@ -130,7 +140,7 @@ pub(crate) async fn run_exec(
     // When not running as root, warm the sudo credential cache so the
     // user is prompted once (with a visible terminal) before eBPF binaries
     // are spawned with piped stdio.  Skip if passwordless sudo already works.
-    if unsafe { libc::geteuid() } != 0 && !sudo_cached() {
+    if !running_as_root() && !sudo_cached() {
         print_record_sudo_prompt();
         let ok = std::process::Command::new("sudo")
             .arg("true")
@@ -156,13 +166,14 @@ pub(crate) async fn run_exec(
     if let Some((uid, gid)) = target_ids {
         print_record_drop_user(uid, gid);
     }
+    #[cfg(unix)]
     unsafe {
         command_builder.pre_exec(move || {
             if let Some((uid, gid)) = target_ids {
-                if libc::setgid(gid) != 0 {
+                if libc::setgid(gid as libc::gid_t) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
-                if libc::setuid(uid) != 0 {
+                if libc::setuid(uid as libc::uid_t) != 0 {
                     return Err(std::io::Error::last_os_error());
                 }
             }
@@ -271,6 +282,7 @@ pub(crate) async fn run_exec(
     Ok(db_path_for_summary)
 }
 
+#[cfg(unix)]
 fn continue_child(pid: u32) -> Result<(), RunnerError> {
     let result = unsafe { libc::kill(pid as libc::pid_t, libc::SIGCONT) };
     if result == 0 {
@@ -282,6 +294,11 @@ fn continue_child(pid: u32) -> Result<(), RunnerError> {
             std::io::Error::last_os_error()
         )))
     }
+}
+
+#[cfg(not(unix))]
+fn continue_child(_pid: u32) -> Result<(), RunnerError> {
+    Err(RunnerError::from("record is available on Linux only"))
 }
 
 pub(crate) async fn stop_child(child: &mut tokio::process::Child) {

--- a/collector/src/cmd_monitor.rs
+++ b/collector/src/cmd_monitor.rs
@@ -595,12 +595,18 @@ fn write_monitor_pid_file(pid_file: &MonitorPidFile) -> io::Result<()> {
     std::fs::write(path, json)
 }
 
+#[cfg(unix)]
 fn pid_is_alive(pid: u32) -> bool {
     if pid == 0 {
         return false;
     }
     let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
     result == 0 || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn pid_is_alive(pid: u32) -> bool {
+    pid != 0 && ProcSnapshot::collect().is_ok_and(|snapshot| snapshot.procs.contains_key(&pid))
 }
 
 struct MonitorPidGuard {

--- a/collector/src/main.rs
+++ b/collector/src/main.rs
@@ -9,7 +9,7 @@
 
 use clap::{Parser, Subcommand};
 use std::collections::VecDeque;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::sync::{
     Arc, Mutex, OnceLock,
@@ -120,7 +120,7 @@ pub(crate) fn shutdown_requested() -> bool {
 }
 
 fn interactive_terminal_available() -> bool {
-    unsafe { libc::isatty(libc::STDIN_FILENO) == 1 && libc::isatty(libc::STDOUT_FILENO) == 1 }
+    std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
 }
 
 fn top_uses_tui(plain: bool, interactive: bool) -> bool {
@@ -150,6 +150,7 @@ fn init_logging(suppress_terminal_output: bool) {
     let _ = builder.try_init();
 }
 
+#[cfg(unix)]
 async fn setup_signal_handler(suppress_terminal_output: bool) {
     let mut sigint = signal::unix::signal(signal::unix::SignalKind::interrupt())
         .expect("Failed to install SIGINT handler");
@@ -161,19 +162,27 @@ async fn setup_signal_handler(suppress_terminal_output: bool) {
             _ = sigint.recv() => {}
             _ = sigterm.recv() => {}
         }
-        if !suppress_terminal_output {
-            println!("\n\nReceived shutdown signal, shutting down...");
-
-            // Print HTTP filter metrics using the global function
-            print_global_http_filter_metrics();
-
-            // Print SSL filter metrics using the global function
-            print_global_ssl_filter_metrics();
-        }
-
-        SHUTDOWN_REQUESTED.store(true, Ordering::Relaxed);
-        shutdown_notify().notify_waiters();
+        notify_shutdown(suppress_terminal_output);
     });
+}
+
+#[cfg(not(unix))]
+async fn setup_signal_handler(suppress_terminal_output: bool) {
+    tokio::spawn(async move {
+        if signal::ctrl_c().await.is_ok() {
+            notify_shutdown(suppress_terminal_output);
+        }
+    });
+}
+
+fn notify_shutdown(suppress_terminal_output: bool) {
+    if !suppress_terminal_output {
+        println!("\n\nReceived shutdown signal, shutting down...");
+        print_global_http_filter_metrics();
+        print_global_ssl_filter_metrics();
+    }
+    SHUTDOWN_REQUESTED.store(true, Ordering::Relaxed);
+    shutdown_notify().notify_waiters();
 }
 
 #[derive(Parser)]

--- a/collector/src/output/format.rs
+++ b/collector/src/output/format.rs
@@ -394,7 +394,7 @@ pub(crate) fn print_record_sudo_prompt() {
     println!("🔑 eBPF probes require root. Requesting sudo access...");
 }
 
-pub(crate) fn print_record_drop_user(uid: libc::uid_t, gid: libc::gid_t) {
+pub(crate) fn print_record_drop_user(uid: u32, gid: u32) {
     println!("✓ Dropping child to uid={uid} gid={gid}");
 }
 

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -443,13 +443,12 @@ mod tests {
         std::fs::write(&shim, "@echo off\r\n").unwrap();
         let path = std::env::join_paths([temp.path()]).unwrap();
 
-        assert_eq!(
-            resolve_windows_program(
-                Path::new("codex"),
-                Some(&path),
-                Some(OsStr::new(".EXE;.CMD")),
-            ),
-            Some(shim)
-        );
+        let resolved = resolve_windows_program(
+            Path::new("codex"),
+            Some(&path),
+            Some(OsStr::new(".EXE;.CMD")),
+        )
+        .unwrap();
+        assert_eq!(resolved.canonicalize().unwrap(), shim.canonicalize().unwrap());
     }
 }

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -4,6 +4,10 @@
 use agent_session::AgentSession;
 use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
+#[cfg(target_os = "windows")]
+use std::ffi::OsStr;
+#[cfg(target_os = "windows")]
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Arc, Mutex as StdMutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -149,7 +153,7 @@ pub async fn submit_message(
 }
 
 fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
-    let mut command = Command::new("claude");
+    let mut command = provider_command("claude");
     command.args([
         "-p",
         "--resume",
@@ -170,7 +174,7 @@ fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
 }
 
 async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
-    let mut command = Command::new("codex");
+    let mut command = provider_command("codex");
     command.args(["app-server", "--listen", "stdio://"]);
     configure(&mut command, session, true);
     let mut child = command
@@ -330,7 +334,7 @@ fn session_is_running(session: &AgentSession) -> bool {
 }
 
 fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
-    let mut command = Command::new("gemini");
+    let mut command = provider_command("gemini");
     command.args(["--resume", &session.session_id, message]);
     configure(&mut command, session, false);
     let child = command
@@ -338,6 +342,46 @@ fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitErro
         .map_err(|error| failed(format!("failed to resume Gemini session: {error}")))?;
     reap(child, "gemini", session.session_id.clone());
     Ok(())
+}
+
+fn provider_command(name: &str) -> Command {
+    #[cfg(target_os = "windows")]
+    let program = resolve_windows_program(
+        Path::new(name),
+        std::env::var_os("PATH").as_deref(),
+        std::env::var_os("PATHEXT").as_deref(),
+    )
+    .unwrap_or_else(|| PathBuf::from(name));
+    #[cfg(not(target_os = "windows"))]
+    let program = name;
+    Command::new(program)
+}
+
+#[cfg(target_os = "windows")]
+fn resolve_windows_program(
+    program: &Path,
+    search_path: Option<&OsStr>,
+    path_ext: Option<&OsStr>,
+) -> Option<PathBuf> {
+    if program.components().count() > 1 || program.extension().is_some() {
+        return program.is_file().then(|| program.to_path_buf());
+    }
+    let extensions = path_ext
+        .and_then(OsStr::to_str)
+        .unwrap_or(".COM;.EXE;.BAT;.CMD")
+        .split(';')
+        .filter(|extension| !extension.is_empty());
+    for directory in search_path.into_iter().flat_map(std::env::split_paths) {
+        for extension in extensions.clone() {
+            let mut candidate = directory.join(program).into_os_string();
+            candidate.push(extension);
+            let candidate = PathBuf::from(candidate);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 fn configure(command: &mut Command, session: &AgentSession, piped: bool) {
@@ -386,4 +430,26 @@ fn now_ms() -> u64 {
 
 fn failed(message: impl Into<String>) -> SubmitError {
     SubmitError::Failed(message.into())
+}
+
+#[cfg(all(test, target_os = "windows"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_resolution_accepts_cmd_shims() {
+        let temp = tempfile::tempdir().unwrap();
+        let shim = temp.path().join("codex.cmd");
+        std::fs::write(&shim, "@echo off\r\n").unwrap();
+        let path = std::env::join_paths([temp.path()]).unwrap();
+
+        assert_eq!(
+            resolve_windows_program(
+                Path::new("codex"),
+                Some(&path),
+                Some(OsStr::new(".EXE;.CMD")),
+            ),
+            Some(shim)
+        );
+    }
 }

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -814,10 +814,12 @@ mod tests {
     fn snapshot_uses_agent_native_indexed_codex_sessions() {
         let _guard = ENV_LOCK.lock().unwrap();
         let old_home = std::env::var_os("HOME");
+        let old_userprofile = std::env::var_os("USERPROFILE");
         let old_sudo_user = std::env::var_os("SUDO_USER");
         let temp = tempfile::tempdir().unwrap();
         unsafe {
             std::env::set_var("HOME", temp.path());
+            std::env::set_var("USERPROFILE", temp.path());
             std::env::remove_var("SUDO_USER");
         }
 
@@ -839,6 +841,10 @@ mod tests {
             match old_home {
                 Some(value) => std::env::set_var("HOME", value),
                 None => std::env::remove_var("HOME"),
+            }
+            match old_userprofile {
+                Some(value) => std::env::set_var("USERPROFILE", value),
+                None => std::env::remove_var("USERPROFILE"),
             }
             match old_sudo_user {
                 Some(value) => std::env::set_var("SUDO_USER", value),

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -814,12 +814,10 @@ mod tests {
     fn snapshot_uses_agent_native_indexed_codex_sessions() {
         let _guard = ENV_LOCK.lock().unwrap();
         let old_home = std::env::var_os("HOME");
-        let old_userprofile = std::env::var_os("USERPROFILE");
         let old_sudo_user = std::env::var_os("SUDO_USER");
         let temp = tempfile::tempdir().unwrap();
         unsafe {
             std::env::set_var("HOME", temp.path());
-            std::env::set_var("USERPROFILE", temp.path());
             std::env::remove_var("SUDO_USER");
         }
 
@@ -841,10 +839,6 @@ mod tests {
             match old_home {
                 Some(value) => std::env::set_var("HOME", value),
                 None => std::env::remove_var("HOME"),
-            }
-            match old_userprofile {
-                Some(value) => std::env::set_var("USERPROFILE", value),
-                None => std::env::remove_var("USERPROFILE"),
             }
             match old_sudo_user {
                 Some(value) => std::env::set_var("SUDO_USER", value),

--- a/collector/tests/system_runner_test.rs
+++ b/collector/tests/system_runner_test.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
+#![cfg(target_os = "linux")]
+
 // Standalone test for system runner functionality
 // This can be run independently to verify the system monitoring logic
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -4,8 +4,17 @@ Use this guide when developing AgentSight or building a local binary from the re
 
 ## Requirements
 
-- Linux with eBPF support
 - Rust toolchain 1.88.0+
+
+The portable agent-native commands (`top`, `bind`, `vis`, and `report`) build on
+Windows, macOS, and Linux. A Windows source build needs the MSVC Rust host
+toolchain and linker; the repository's Windows GitHub Actions workflow provides
+that environment and uploads `agentsight.exe`, so Windows users do not need a
+local compiler when using its artifact.
+
+Building the eBPF capture path additionally requires:
+
+- Linux with eBPF support
 - Node.js 18+
 - clang and LLVM
 - libelf development headers
@@ -38,6 +47,18 @@ Build all components:
 ```bash
 make build
 ```
+
+For a native Windows build of the portable CLI, build the collector crate from
+a Developer PowerShell, or run the Windows workflow and download its artifact:
+
+```powershell
+cargo build --release --manifest-path collector/Cargo.toml
+```
+
+The resulting binary is `collector/target/release/agentsight.exe`. Commands that
+load eBPF (`record` and eBPF-backed debug commands) return a platform-specific
+error on Windows; session discovery, reporting, visualization, binding, and the
+process-backed `top` view remain available.
 
 `make build` rebuilds the frontend and eBPF loaders, then refreshes the
 vendored assets embedded by the Rust binary. The frontend build id is stable for


### PR DESCRIPTION
## Summary

- build, test, and upload a native `agentsight.exe` on `windows-latest`
- reuse AgentSight's existing session parser, Node API, Controller relay, and session UI for portable Windows `report`, `top`, `vis`, and `bind` workflows
- support authenticated Claude/Codex/Gemini session continuation through Windows provider shims
- keep eBPF capture and `record` / tracing commands Linux-only

## Scope

This does not add an ETW/eBPF Windows capture backend, publish a release asset, or claim Linux tracing parity. The uploaded Windows artifact is the CI debug binary.

## Validation

- Windows native: [run 31583011829](https://github.com/eunomia-bpf/agentsight/actions/runs/31583011829) — Rust tests, native build, fixture-backed `report`, `top`, nonempty Chrome/Edge HTML+PNG `vis`, authenticated `bind`, real fake-`codex.cmd` continuation, artifact upload
- macOS regression: [run 31583011866](https://github.com/eunomia-bpf/agentsight/actions/runs/31583011866) — passed
- Linux regression: [run 31583011902](https://github.com/eunomia-bpf/agentsight/actions/runs/31583011902) — build, frontend/control plane, eBPF C tests, Rust tests, Clippy, agentpprof, CLI canary, ASAN, and aarch64 release build passed
- Downloaded the exact Windows artifact and ran it locally without a local MSVC build: `agentsight 1.0.14`; fixture-backed `report`, `top`, HTML `vis`, and PNG `vis` all passed
- Final internal independent review: APPROVE
- Final external Kimi Code review: APPROVE
- Copilot: no reviews, inline comments, or unresolved review threads on the final head