### PR TITLE
Add organization pricing and capability authorization

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -30,11 +30,13 @@ agentsight-capture = { version = "1.0.14", path = "../agentsight-capture" }
 agentsight-protocol = { version = "1.0.14", path = "../agentsight-protocol" }
 agent-session = { version = "0.4.35", path = "../agent-session" }
 agentvis = { version = "1.0.14", path = "../agentvis" }
+base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.41", features = ["derive"] }
 futures = "0.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+sha2 = "0.10"
 tempfile = "3.10"
 tokio = { version = "1.0", features = ["full"] }
 tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }

--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -30,13 +30,11 @@ agentsight-capture = { version = "1.0.14", path = "../agentsight-capture" }
 agentsight-protocol = { version = "1.0.14", path = "../agentsight-protocol" }
 agent-session = { version = "0.4.35", path = "../agent-session" }
 agentvis = { version = "1.0.14", path = "../agentvis" }
-base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5.41", features = ["derive"] }
 futures = "0.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
-sha2 = "0.10"
 tempfile = "3.10"
 tokio = { version = "1.0", features = ["full"] }
 tokio-tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }

--- a/collector/src/server/capability.rs
+++ b/collector/src/server/capability.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use serde::Deserialize;
+use std::collections::HashMap;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const NODE_INFO: &str = "node.info";
@@ -11,19 +10,14 @@ pub const EVIDENCE_READ: &str = "evidence.read";
 pub const SESSION_READ: &str = "session.read";
 pub const SESSION_MESSAGE: &str = "session.message";
 
-const TOKEN_PREFIX: &str = "as1";
-const HMAC_BLOCK_BYTES: usize = 64;
-const MAX_TOKEN_BYTES: usize = 4096;
 const MAX_TTL_SECONDS: u64 = 600;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct CapabilityClaims {
-    pub v: u8,
-    pub node: String,
-    pub actions: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    pub exp: u64,
+#[derive(Debug, Clone)]
+struct Grant {
+    node_id: String,
+    actions: Vec<String>,
+    session_id: Option<String>,
+    expires_at: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -53,99 +47,62 @@ impl CapabilityMintRequest {
     }
 }
 
-pub fn mint(
-    secret: &str,
-    node_id: &str,
-    request: &CapabilityMintRequest,
-) -> Result<String, &'static str> {
-    request.validate()?;
-    mint_at(secret, node_id, request, now_seconds())
+#[derive(Debug, Default)]
+pub struct CapabilityStore {
+    grants: HashMap<String, Grant>,
 }
 
-fn mint_at(
-    secret: &str,
-    node_id: &str,
-    request: &CapabilityMintRequest,
-    now: u64,
-) -> Result<String, &'static str> {
-    if secret.is_empty() || node_id.is_empty() {
-        return Err("capability issuer is not configured");
+impl CapabilityStore {
+    pub fn mint(
+        &mut self,
+        node_id: &str,
+        request: &CapabilityMintRequest,
+    ) -> Result<(String, u64), &'static str> {
+        request.validate()?;
+        let now = now_seconds();
+        self.remove_expired(now);
+        let token = format!(
+            "cap_{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        );
+        let expires_at = now.saturating_add(request.ttl_seconds);
+        self.grants.insert(
+            token.clone(),
+            Grant {
+                node_id: node_id.to_string(),
+                actions: request.actions.clone(),
+                session_id: request.session_id.clone(),
+                expires_at,
+            },
+        );
+        Ok((token, expires_at))
     }
-    let claims = CapabilityClaims {
-        v: 1,
-        node: node_id.to_string(),
-        actions: request.actions.clone(),
-        session_id: request.session_id.clone(),
-        exp: now.saturating_add(request.ttl_seconds),
-    };
-    let payload = serde_json::to_vec(&claims).map_err(|_| "could not encode capability")?;
-    let payload = URL_SAFE_NO_PAD.encode(payload);
-    let signed = format!("{TOKEN_PREFIX}.{payload}");
-    let signature = URL_SAFE_NO_PAD.encode(hmac_sha256(secret.as_bytes(), signed.as_bytes()));
-    Ok(format!("{signed}.{signature}"))
-}
 
-pub fn authorizes(
-    secret: &str,
-    node_id: &str,
-    token: &str,
-    action: &str,
-    session_id: Option<&str>,
-) -> bool {
-    authorizes_at(secret, node_id, token, action, session_id, now_seconds())
-}
+    pub fn authorizes(
+        &mut self,
+        node_id: &str,
+        token: &str,
+        action: &str,
+        session_id: Option<&str>,
+    ) -> bool {
+        let now = now_seconds();
+        self.remove_expired(now);
+        let Some(grant) = self.grants.get(token) else {
+            return false;
+        };
+        if grant.node_id != node_id || !grant.actions.iter().any(|candidate| candidate == action) {
+            return false;
+        }
+        match grant.session_id.as_deref() {
+            Some(expected) => session_id == Some(expected),
+            None => true,
+        }
+    }
 
-fn authorizes_at(
-    secret: &str,
-    node_id: &str,
-    token: &str,
-    action: &str,
-    session_id: Option<&str>,
-    now: u64,
-) -> bool {
-    let Some(claims) = verify_at(secret, token, now) else {
-        return false;
-    };
-    if claims.node != node_id || !claims.actions.iter().any(|candidate| candidate == action) {
-        return false;
+    fn remove_expired(&mut self, now: u64) {
+        self.grants.retain(|_, grant| grant.expires_at >= now);
     }
-    match claims.session_id.as_deref() {
-        Some(expected) => session_id == Some(expected),
-        None => true,
-    }
-}
-
-pub fn verify(secret: &str, token: &str) -> Option<CapabilityClaims> {
-    verify_at(secret, token, now_seconds())
-}
-
-fn verify_at(secret: &str, token: &str, now: u64) -> Option<CapabilityClaims> {
-    if token.len() > MAX_TOKEN_BYTES {
-        return None;
-    }
-    let mut parts = token.split('.');
-    if parts.next()? != TOKEN_PREFIX {
-        return None;
-    }
-    let payload = parts.next()?;
-    let signature = parts.next()?;
-    if parts.next().is_some() {
-        return None;
-    }
-    let signed = format!("{TOKEN_PREFIX}.{payload}");
-    let expected = hmac_sha256(secret.as_bytes(), signed.as_bytes());
-    let supplied = URL_SAFE_NO_PAD.decode(signature).ok()?;
-    if !constant_time_eq(&expected, &supplied) {
-        return None;
-    }
-    let claims: CapabilityClaims = serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).ok()?).ok()?;
-    if claims.v != 1 || claims.exp < now || claims.actions.is_empty()
-        || claims.actions.iter().any(|action| !known_action(action))
-        || claims.session_id.as_deref().is_some_and(|value| !valid_session_id(value))
-    {
-        return None;
-    }
-    Some(claims)
 }
 
 pub fn action_for_request(method: &str, path: &str) -> Option<(&'static str, Option<String>)> {
@@ -195,112 +152,48 @@ fn now_seconds() -> u64 {
         .as_secs()
 }
 
-fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
-    let mut normalized = [0u8; HMAC_BLOCK_BYTES];
-    if key.len() > HMAC_BLOCK_BYTES {
-        let digest = Sha256::digest(key);
-        normalized[..digest.len()].copy_from_slice(&digest);
-    } else {
-        normalized[..key.len()].copy_from_slice(key);
-    }
-
-    let mut inner_pad = [0x36u8; HMAC_BLOCK_BYTES];
-    let mut outer_pad = [0x5cu8; HMAC_BLOCK_BYTES];
-    for index in 0..HMAC_BLOCK_BYTES {
-        inner_pad[index] ^= normalized[index];
-        outer_pad[index] ^= normalized[index];
-    }
-
-    let mut inner = Sha256::new();
-    inner.update(inner_pad);
-    inner.update(data);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(outer_pad);
-    outer.update(inner_digest);
-    outer.finalize().into()
-}
-
-fn constant_time_eq(expected: &[u8], supplied: &[u8]) -> bool {
-    if expected.len() != supplied.len() {
-        return false;
-    }
-    expected
-        .iter()
-        .zip(supplied)
-        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
-        == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn request(actions: &[&str], session_id: Option<&str>, ttl_seconds: u64) -> CapabilityMintRequest {
+    fn request(actions: &[&str], session_id: Option<&str>) -> CapabilityMintRequest {
         CapabilityMintRequest {
             actions: actions.iter().map(|value| value.to_string()).collect(),
             session_id: session_id.map(str::to_string),
-            ttl_seconds,
+            ttl_seconds: 60,
         }
     }
 
     #[test]
     fn scoped_capability_authorizes_only_requested_action_and_session() {
-        let token = mint_at(
-            "root-secret",
-            "node_test",
-            &request(&[SESSION_READ], Some("session-1"), 60),
-            1_000,
-        )
-        .unwrap();
-        assert!(authorizes_at(
-            "root-secret",
+        let mut store = CapabilityStore::default();
+        let (token, _) = store
+            .mint("node_test", &request(&[SESSION_READ], Some("session-1")))
+            .unwrap();
+        assert!(store.authorizes(
             "node_test",
             &token,
             SESSION_READ,
             Some("session-1"),
-            1_001,
         ));
-        assert!(!authorizes_at(
-            "root-secret",
+        assert!(!store.authorizes(
             "node_test",
             &token,
             SESSION_MESSAGE,
             Some("session-1"),
-            1_001,
         ));
-        assert!(!authorizes_at(
-            "root-secret",
+        assert!(!store.authorizes(
             "node_test",
             &token,
             SESSION_READ,
             Some("session-2"),
-            1_001,
         ));
-    }
-
-    #[test]
-    fn capability_rejects_tampering_expiry_and_wrong_node() {
-        let token = mint_at(
-            "root-secret",
-            "node_test",
-            &request(&[EVIDENCE_READ], None, 60),
-            1_000,
-        )
-        .unwrap();
-        assert!(verify_at("root-secret", &token, 1_060).is_some());
-        assert!(verify_at("root-secret", &token, 1_061).is_none());
-        assert!(!authorizes_at(
-            "root-secret",
+        assert!(!store.authorizes(
             "node_other",
             &token,
-            EVIDENCE_READ,
-            None,
-            1_001,
+            SESSION_READ,
+            Some("session-1"),
         ));
-        let tampered = token.replacen("as1.", "as1.A", 1);
-        assert!(verify_at("root-secret", &tampered, 1_001).is_none());
     }
 
     #[test]
@@ -315,5 +208,15 @@ mod tests {
             Some((SESSION_MESSAGE, Some("s-1".to_string())))
         );
         assert_eq!(action_for_request("GET", "/etc/passwd"), None);
+    }
+
+    #[test]
+    fn mint_rejects_unknown_actions_and_excessive_ttl() {
+        let mut store = CapabilityStore::default();
+        let mut invalid = request(&["root"], None);
+        assert!(store.mint("node_test", &invalid).is_err());
+        invalid.actions = vec![NODE_INFO.to_string()];
+        invalid.ttl_seconds = 601;
+        assert!(store.mint("node_test", &invalid).is_err());
     }
 }

--- a/collector/src/server/capability.rs
+++ b/collector/src/server/capability.rs
@@ -10,7 +10,7 @@ pub const EVIDENCE_READ: &str = "evidence.read";
 pub const SESSION_READ: &str = "session.read";
 pub const SESSION_MESSAGE: &str = "session.message";
 
-const MAX_TTL_SECONDS: u64 = 600;
+const MAX_TTL_SECONDS: u64 = 12 * 60 * 60;
 
 #[derive(Debug, Clone)]
 struct Grant {
@@ -38,7 +38,7 @@ impl CapabilityMintRequest {
             return Err("capability contains an unknown action");
         }
         if !(30..=MAX_TTL_SECONDS).contains(&self.ttl_seconds) {
-            return Err("capability ttl must be between 30 and 600 seconds");
+            return Err("capability ttl must be between 30 seconds and 12 hours");
         }
         if self.session_id.as_deref().is_some_and(|value| !valid_session_id(value)) {
             return Err("invalid capability session scope");
@@ -216,7 +216,7 @@ mod tests {
         let mut invalid = request(&["root"], None);
         assert!(store.mint("node_test", &invalid).is_err());
         invalid.actions = vec![NODE_INFO.to_string()];
-        invalid.ttl_seconds = 601;
+        invalid.ttl_seconds = MAX_TTL_SECONDS + 1;
         assert!(store.mint("node_test", &invalid).is_err());
     }
 }

--- a/collector/src/server/capability.rs
+++ b/collector/src/server/capability.rs
@@ -1,0 +1,319 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const NODE_INFO: &str = "node.info";
+pub const EVIDENCE_READ: &str = "evidence.read";
+pub const SESSION_READ: &str = "session.read";
+pub const SESSION_MESSAGE: &str = "session.message";
+
+const TOKEN_PREFIX: &str = "as1";
+const HMAC_BLOCK_BYTES: usize = 64;
+const MAX_TOKEN_BYTES: usize = 4096;
+const MAX_TTL_SECONDS: u64 = 600;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CapabilityClaims {
+    pub v: u8,
+    pub node: String,
+    pub actions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub exp: u64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct CapabilityMintRequest {
+    pub actions: Vec<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default = "default_ttl_seconds")]
+    pub ttl_seconds: u64,
+}
+
+impl CapabilityMintRequest {
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if self.actions.is_empty() || self.actions.len() > 8 {
+            return Err("capability must contain between 1 and 8 actions");
+        }
+        if self.actions.iter().any(|action| !known_action(action)) {
+            return Err("capability contains an unknown action");
+        }
+        if !(30..=MAX_TTL_SECONDS).contains(&self.ttl_seconds) {
+            return Err("capability ttl must be between 30 and 600 seconds");
+        }
+        if self.session_id.as_deref().is_some_and(|value| !valid_session_id(value)) {
+            return Err("invalid capability session scope");
+        }
+        Ok(())
+    }
+}
+
+pub fn mint(
+    secret: &str,
+    node_id: &str,
+    request: &CapabilityMintRequest,
+) -> Result<String, &'static str> {
+    request.validate()?;
+    mint_at(secret, node_id, request, now_seconds())
+}
+
+fn mint_at(
+    secret: &str,
+    node_id: &str,
+    request: &CapabilityMintRequest,
+    now: u64,
+) -> Result<String, &'static str> {
+    if secret.is_empty() || node_id.is_empty() {
+        return Err("capability issuer is not configured");
+    }
+    let claims = CapabilityClaims {
+        v: 1,
+        node: node_id.to_string(),
+        actions: request.actions.clone(),
+        session_id: request.session_id.clone(),
+        exp: now.saturating_add(request.ttl_seconds),
+    };
+    let payload = serde_json::to_vec(&claims).map_err(|_| "could not encode capability")?;
+    let payload = URL_SAFE_NO_PAD.encode(payload);
+    let signed = format!("{TOKEN_PREFIX}.{payload}");
+    let signature = URL_SAFE_NO_PAD.encode(hmac_sha256(secret.as_bytes(), signed.as_bytes()));
+    Ok(format!("{signed}.{signature}"))
+}
+
+pub fn authorizes(
+    secret: &str,
+    node_id: &str,
+    token: &str,
+    action: &str,
+    session_id: Option<&str>,
+) -> bool {
+    authorizes_at(secret, node_id, token, action, session_id, now_seconds())
+}
+
+fn authorizes_at(
+    secret: &str,
+    node_id: &str,
+    token: &str,
+    action: &str,
+    session_id: Option<&str>,
+    now: u64,
+) -> bool {
+    let Some(claims) = verify_at(secret, token, now) else {
+        return false;
+    };
+    if claims.node != node_id || !claims.actions.iter().any(|candidate| candidate == action) {
+        return false;
+    }
+    match claims.session_id.as_deref() {
+        Some(expected) => session_id == Some(expected),
+        None => true,
+    }
+}
+
+pub fn verify(secret: &str, token: &str) -> Option<CapabilityClaims> {
+    verify_at(secret, token, now_seconds())
+}
+
+fn verify_at(secret: &str, token: &str, now: u64) -> Option<CapabilityClaims> {
+    if token.len() > MAX_TOKEN_BYTES {
+        return None;
+    }
+    let mut parts = token.split('.');
+    if parts.next()? != TOKEN_PREFIX {
+        return None;
+    }
+    let payload = parts.next()?;
+    let signature = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+    let signed = format!("{TOKEN_PREFIX}.{payload}");
+    let expected = hmac_sha256(secret.as_bytes(), signed.as_bytes());
+    let supplied = URL_SAFE_NO_PAD.decode(signature).ok()?;
+    if !constant_time_eq(&expected, &supplied) {
+        return None;
+    }
+    let claims: CapabilityClaims = serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload).ok()?).ok()?;
+    if claims.v != 1 || claims.exp < now || claims.actions.is_empty()
+        || claims.actions.iter().any(|action| !known_action(action))
+        || claims.session_id.as_deref().is_some_and(|value| !valid_session_id(value))
+    {
+        return None;
+    }
+    Some(claims)
+}
+
+pub fn action_for_request(method: &str, path: &str) -> Option<(&'static str, Option<String>)> {
+    let path = path.split_once('?').map_or(path, |(path, _)| path);
+    if method == "GET" && path == "/api/v1/info" {
+        return Some((NODE_INFO, None));
+    }
+    if method == "GET" && path == "/api/v1/snapshot" {
+        return Some((EVIDENCE_READ, None));
+    }
+    let session = path.strip_prefix("/api/v1/sessions/")?;
+    let (session_id, messages) = session
+        .strip_suffix("/messages")
+        .map_or((session, false), |id| (id, true));
+    if !valid_session_id(session_id) {
+        return None;
+    }
+    if method == "GET" && !messages {
+        return Some((SESSION_READ, Some(session_id.to_string())));
+    }
+    if method == "POST" && messages {
+        return Some((SESSION_MESSAGE, Some(session_id.to_string())));
+    }
+    None
+}
+
+pub fn known_action(action: &str) -> bool {
+    matches!(action, NODE_INFO | EVIDENCE_READ | SESSION_READ | SESSION_MESSAGE)
+}
+
+fn valid_session_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 768
+        && !value.contains('/')
+        && !value.contains('\\')
+        && !value.contains("..")
+}
+
+fn default_ttl_seconds() -> u64 {
+    300
+}
+
+fn now_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; 32] {
+    let mut normalized = [0u8; HMAC_BLOCK_BYTES];
+    if key.len() > HMAC_BLOCK_BYTES {
+        let digest = Sha256::digest(key);
+        normalized[..digest.len()].copy_from_slice(&digest);
+    } else {
+        normalized[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; HMAC_BLOCK_BYTES];
+    let mut outer_pad = [0x5cu8; HMAC_BLOCK_BYTES];
+    for index in 0..HMAC_BLOCK_BYTES {
+        inner_pad[index] ^= normalized[index];
+        outer_pad[index] ^= normalized[index];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().into()
+}
+
+fn constant_time_eq(expected: &[u8], supplied: &[u8]) -> bool {
+    if expected.len() != supplied.len() {
+        return false;
+    }
+    expected
+        .iter()
+        .zip(supplied)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(actions: &[&str], session_id: Option<&str>, ttl_seconds: u64) -> CapabilityMintRequest {
+        CapabilityMintRequest {
+            actions: actions.iter().map(|value| value.to_string()).collect(),
+            session_id: session_id.map(str::to_string),
+            ttl_seconds,
+        }
+    }
+
+    #[test]
+    fn scoped_capability_authorizes_only_requested_action_and_session() {
+        let token = mint_at(
+            "root-secret",
+            "node_test",
+            &request(&[SESSION_READ], Some("session-1"), 60),
+            1_000,
+        )
+        .unwrap();
+        assert!(authorizes_at(
+            "root-secret",
+            "node_test",
+            &token,
+            SESSION_READ,
+            Some("session-1"),
+            1_001,
+        ));
+        assert!(!authorizes_at(
+            "root-secret",
+            "node_test",
+            &token,
+            SESSION_MESSAGE,
+            Some("session-1"),
+            1_001,
+        ));
+        assert!(!authorizes_at(
+            "root-secret",
+            "node_test",
+            &token,
+            SESSION_READ,
+            Some("session-2"),
+            1_001,
+        ));
+    }
+
+    #[test]
+    fn capability_rejects_tampering_expiry_and_wrong_node() {
+        let token = mint_at(
+            "root-secret",
+            "node_test",
+            &request(&[EVIDENCE_READ], None, 60),
+            1_000,
+        )
+        .unwrap();
+        assert!(verify_at("root-secret", &token, 1_060).is_some());
+        assert!(verify_at("root-secret", &token, 1_061).is_none());
+        assert!(!authorizes_at(
+            "root-secret",
+            "node_other",
+            &token,
+            EVIDENCE_READ,
+            None,
+            1_001,
+        ));
+        let tampered = token.replacen("as1.", "as1.A", 1);
+        assert!(verify_at("root-secret", &tampered, 1_001).is_none());
+    }
+
+    #[test]
+    fn protocol_paths_map_to_semantic_actions() {
+        assert_eq!(action_for_request("GET", "/api/v1/info"), Some((NODE_INFO, None)));
+        assert_eq!(
+            action_for_request("GET", "/api/v1/sessions/s-1"),
+            Some((SESSION_READ, Some("s-1".to_string())))
+        );
+        assert_eq!(
+            action_for_request("POST", "/api/v1/sessions/s-1/messages"),
+            Some((SESSION_MESSAGE, Some("s-1".to_string())))
+        );
+        assert_eq!(action_for_request("GET", "/etc/passwd"), None);
+    }
+}

--- a/collector/src/server/capability.rs
+++ b/collector/src/server/capability.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use serde::Deserialize;
-use std::collections::HashMap;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const NODE_INFO: &str = "node.info";
@@ -10,14 +11,21 @@ pub const EVIDENCE_READ: &str = "evidence.read";
 pub const SESSION_READ: &str = "session.read";
 pub const SESSION_MESSAGE: &str = "session.message";
 
+const TOKEN_PREFIX: &str = "cap_";
+const DOMAIN: &[u8] = b"AgentSight.NodeCapability.v1\0";
+const SIGNATURE_BYTES: usize = 32;
+const MAX_TOKEN_BYTES: usize = 4096;
 const MAX_TTL_SECONDS: u64 = 12 * 60 * 60;
+const HMAC_BLOCK_BYTES: usize = 64;
 
-#[derive(Debug, Clone)]
-struct Grant {
-    node_id: String,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct Claims {
+    v: u8,
+    node: String,
     actions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
-    expires_at: u64,
+    exp: u64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -47,62 +55,80 @@ impl CapabilityMintRequest {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct CapabilityStore {
-    grants: HashMap<String, Grant>,
+pub fn mint(
+    bootstrap_secret: &str,
+    node_id: &str,
+    request: &CapabilityMintRequest,
+) -> Result<(String, u64), &'static str> {
+    request.validate()?;
+    if bootstrap_secret.is_empty() || node_id.is_empty() {
+        return Err("capability issuer is not configured");
+    }
+    let expires_at = now_seconds().saturating_add(request.ttl_seconds);
+    let claims = Claims {
+        v: 1,
+        node: node_id.to_string(),
+        actions: request.actions.clone(),
+        session_id: request.session_id.clone(),
+        exp: expires_at,
+    };
+    let payload = serde_json::to_vec(&claims).map_err(|_| "could not encode capability")?;
+    let signature = capability_signature(bootstrap_secret.as_bytes(), &payload);
+    let mut token_bytes = Vec::with_capacity(payload.len() + SIGNATURE_BYTES);
+    token_bytes.extend_from_slice(&payload);
+    token_bytes.extend_from_slice(&signature);
+    let token = format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode(token_bytes));
+    if token.len() > MAX_TOKEN_BYTES {
+        return Err("capability is too large");
+    }
+    Ok((token, expires_at))
 }
 
-impl CapabilityStore {
-    pub fn mint(
-        &mut self,
-        node_id: &str,
-        request: &CapabilityMintRequest,
-    ) -> Result<(String, u64), &'static str> {
-        request.validate()?;
-        let now = now_seconds();
-        self.remove_expired(now);
-        let token = format!(
-            "cap_{}{}",
-            uuid::Uuid::new_v4().simple(),
-            uuid::Uuid::new_v4().simple()
-        );
-        let expires_at = now.saturating_add(request.ttl_seconds);
-        self.grants.insert(
-            token.clone(),
-            Grant {
-                node_id: node_id.to_string(),
-                actions: request.actions.clone(),
-                session_id: request.session_id.clone(),
-                expires_at,
-            },
-        );
-        Ok((token, expires_at))
+pub fn authorizes(
+    bootstrap_secret: &str,
+    node_id: &str,
+    token: &str,
+    action: &str,
+    session_id: Option<&str>,
+) -> bool {
+    let Some(claims) = verify(bootstrap_secret, token) else {
+        return false;
+    };
+    if claims.node != node_id || !claims.actions.iter().any(|candidate| candidate == action) {
+        return false;
     }
+    match claims.session_id.as_deref() {
+        Some(expected) => session_id == Some(expected),
+        None => true,
+    }
+}
 
-    pub fn authorizes(
-        &mut self,
-        node_id: &str,
-        token: &str,
-        action: &str,
-        session_id: Option<&str>,
-    ) -> bool {
-        let now = now_seconds();
-        self.remove_expired(now);
-        let Some(grant) = self.grants.get(token) else {
-            return false;
-        };
-        if grant.node_id != node_id || !grant.actions.iter().any(|candidate| candidate == action) {
-            return false;
-        }
-        match grant.session_id.as_deref() {
-            Some(expected) => session_id == Some(expected),
-            None => true,
-        }
+fn verify(bootstrap_secret: &str, token: &str) -> Option<Claims> {
+    if token.len() > MAX_TOKEN_BYTES || bootstrap_secret.is_empty() {
+        return None;
     }
-
-    fn remove_expired(&mut self, now: u64) {
-        self.grants.retain(|_, grant| grant.expires_at >= now);
+    let encoded = token.strip_prefix(TOKEN_PREFIX)?;
+    let decoded = URL_SAFE_NO_PAD.decode(encoded).ok()?;
+    if decoded.len() <= SIGNATURE_BYTES {
+        return None;
     }
+    let split = decoded.len() - SIGNATURE_BYTES;
+    let (payload, supplied_signature) = decoded.split_at(split);
+    let expected_signature = capability_signature(bootstrap_secret.as_bytes(), payload);
+    if !constant_time_eq(&expected_signature, supplied_signature) {
+        return None;
+    }
+    let claims: Claims = serde_json::from_slice(payload).ok()?;
+    if claims.v != 1
+        || claims.exp < now_seconds()
+        || claims.actions.is_empty()
+        || claims.actions.len() > 8
+        || claims.actions.iter().any(|action| !known_action(action))
+        || claims.session_id.as_deref().is_some_and(|value| !valid_session_id(value))
+    {
+        return None;
+    }
+    Some(claims)
 }
 
 pub fn action_for_request(method: &str, path: &str) -> Option<(&'static str, Option<String>)> {
@@ -141,6 +167,51 @@ fn valid_session_id(value: &str) -> bool {
         && !value.contains("..")
 }
 
+fn capability_signature(key: &[u8], payload: &[u8]) -> [u8; SIGNATURE_BYTES] {
+    let mut message = Vec::with_capacity(DOMAIN.len() + payload.len());
+    message.extend_from_slice(DOMAIN);
+    message.extend_from_slice(payload);
+    hmac_sha256(key, &message)
+}
+
+fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; SIGNATURE_BYTES] {
+    let mut normalized = [0u8; HMAC_BLOCK_BYTES];
+    if key.len() > HMAC_BLOCK_BYTES {
+        let digest = Sha256::digest(key);
+        normalized[..digest.len()].copy_from_slice(&digest);
+    } else {
+        normalized[..key.len()].copy_from_slice(key);
+    }
+
+    let mut inner_pad = [0x36u8; HMAC_BLOCK_BYTES];
+    let mut outer_pad = [0x5cu8; HMAC_BLOCK_BYTES];
+    for index in 0..HMAC_BLOCK_BYTES {
+        inner_pad[index] ^= normalized[index];
+        outer_pad[index] ^= normalized[index];
+    }
+
+    let mut inner = Sha256::new();
+    inner.update(inner_pad);
+    inner.update(data);
+    let inner_digest = inner.finalize();
+
+    let mut outer = Sha256::new();
+    outer.update(outer_pad);
+    outer.update(inner_digest);
+    outer.finalize().into()
+}
+
+fn constant_time_eq(expected: &[u8], supplied: &[u8]) -> bool {
+    if expected.len() != supplied.len() {
+        return false;
+    }
+    expected
+        .iter()
+        .zip(supplied)
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
 fn default_ttl_seconds() -> u64 {
     300
 }
@@ -166,33 +237,76 @@ mod tests {
 
     #[test]
     fn scoped_capability_authorizes_only_requested_action_and_session() {
-        let mut store = CapabilityStore::default();
-        let (token, _) = store
-            .mint("node_test", &request(&[SESSION_READ], Some("session-1")))
-            .unwrap();
-        assert!(store.authorizes(
+        let (token, _) = mint(
+            "persistent-root",
+            "node_test",
+            &request(&[SESSION_READ], Some("session-1")),
+        )
+        .unwrap();
+        assert!(authorizes(
+            "persistent-root",
             "node_test",
             &token,
             SESSION_READ,
             Some("session-1"),
         ));
-        assert!(!store.authorizes(
+        assert!(!authorizes(
+            "persistent-root",
             "node_test",
             &token,
             SESSION_MESSAGE,
             Some("session-1"),
         ));
-        assert!(!store.authorizes(
+        assert!(!authorizes(
+            "persistent-root",
             "node_test",
             &token,
             SESSION_READ,
             Some("session-2"),
         ));
-        assert!(!store.authorizes(
+        assert!(!authorizes(
+            "persistent-root",
             "node_other",
             &token,
             SESSION_READ,
             Some("session-1"),
+        ));
+    }
+
+    #[test]
+    fn capability_is_stateless_and_bound_to_the_persistent_root() {
+        let (token, expires_at) = mint(
+            "persistent-root",
+            "node_test",
+            &request(&[NODE_INFO, EVIDENCE_READ], None),
+        )
+        .unwrap();
+        assert!(expires_at > now_seconds());
+        assert!(token.starts_with(TOKEN_PREFIX));
+        assert!(authorizes(
+            "persistent-root",
+            "node_test",
+            &token,
+            EVIDENCE_READ,
+            None,
+        ));
+        assert!(!authorizes(
+            "rotated-root",
+            "node_test",
+            &token,
+            EVIDENCE_READ,
+            None,
+        ));
+
+        let mut tampered = token.into_bytes();
+        let last = tampered.last_mut().unwrap();
+        *last = if *last == b'A' { b'B' } else { b'A' };
+        assert!(!authorizes(
+            "persistent-root",
+            "node_test",
+            std::str::from_utf8(&tampered).unwrap(),
+            EVIDENCE_READ,
+            None,
         ));
     }
 
@@ -212,11 +326,10 @@ mod tests {
 
     #[test]
     fn mint_rejects_unknown_actions_and_excessive_ttl() {
-        let mut store = CapabilityStore::default();
         let mut invalid = request(&["root"], None);
-        assert!(store.mint("node_test", &invalid).is_err());
+        assert!(mint("persistent-root", "node_test", &invalid).is_err());
         invalid.actions = vec![NODE_INFO.to_string()];
         invalid.ttl_seconds = MAX_TTL_SECONDS + 1;
-        assert!(store.mint("node_test", &invalid).is_err());
+        assert!(mint("persistent-root", "node_test", &invalid).is_err());
     }
 }

--- a/collector/src/server/capability.rs
+++ b/collector/src/server/capability.rs
@@ -56,48 +56,32 @@ impl CapabilityMintRequest {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct CapabilityStore {
     node_id: Option<String>,
     persist_path: Option<PathBuf>,
     grants: HashMap<String, Grant>,
 }
 
-impl CapabilityStore {
-    pub fn for_node(node_id: &str) -> Self {
-        let persist_path = capability_path();
-        let now = now_seconds();
-        let grants = persist_path
-            .as_ref()
-            .and_then(|path| std::fs::read(path).ok())
-            .and_then(|bytes| serde_json::from_slice::<PersistedCapabilities>(&bytes).ok())
-            .filter(|saved| saved.node_id == node_id)
-            .map(|saved| {
-                saved
-                    .grants
-                    .into_iter()
-                    .filter(|(_, grant)| grant.persistent && grant.expires_at >= now)
-                    .collect()
-            })
-            .unwrap_or_default();
+impl Default for CapabilityStore {
+    fn default() -> Self {
         Self {
-            node_id: Some(node_id.to_string()),
-            persist_path,
-            grants,
+            node_id: None,
+            persist_path: capability_path(),
+            grants: HashMap::new(),
         }
     }
+}
 
+impl CapabilityStore {
     pub fn mint(
         &mut self,
         node_id: &str,
         request: &CapabilityMintRequest,
     ) -> Result<(String, u64), &'static str> {
         request.validate()?;
-        if self.node_id.as_deref().is_some_and(|configured| configured != node_id) {
+        if !self.ensure_node(node_id) {
             return Err("capability store belongs to another Node");
-        }
-        if self.node_id.is_none() {
-            self.node_id = Some(node_id.to_string());
         }
         let now = now_seconds();
         self.remove_expired(now);
@@ -131,6 +115,9 @@ impl CapabilityStore {
         action: &str,
         session_id: Option<&str>,
     ) -> bool {
+        if !self.ensure_node(node_id) {
+            return false;
+        }
         let now = now_seconds();
         self.remove_expired(now);
         let Some(grant) = self.grants.get(token) else {
@@ -143,6 +130,31 @@ impl CapabilityStore {
             Some(expected) => session_id == Some(expected),
             None => true,
         }
+    }
+
+    fn ensure_node(&mut self, node_id: &str) -> bool {
+        match self.node_id.as_deref() {
+            Some(configured) => return configured == node_id,
+            None => self.node_id = Some(node_id.to_string()),
+        }
+        let now = now_seconds();
+        let Some(path) = self.persist_path.as_ref() else {
+            return true;
+        };
+        let Some(saved) = std::fs::read(path)
+            .ok()
+            .and_then(|bytes| serde_json::from_slice::<PersistedCapabilities>(&bytes).ok())
+            .filter(|saved| saved.node_id == node_id)
+        else {
+            return true;
+        };
+        self.grants.extend(
+            saved
+                .grants
+                .into_iter()
+                .filter(|(_, grant)| grant.persistent && grant.expires_at >= now),
+        );
+        true
     }
 
     fn remove_expired(&mut self, now: u64) {
@@ -251,7 +263,10 @@ mod tests {
 
     #[test]
     fn scoped_capability_authorizes_only_requested_action_and_session() {
-        let mut store = CapabilityStore::default();
+        let mut store = CapabilityStore {
+            persist_path: None,
+            ..CapabilityStore::default()
+        };
         let (token, _) = store
             .mint("node_test", &request(&[SESSION_READ], Some("session-1")))
             .unwrap();
@@ -286,7 +301,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("capabilities.json");
         let mut store = CapabilityStore {
-            node_id: Some("node_test".to_string()),
+            node_id: None,
             persist_path: Some(path.clone()),
             grants: HashMap::new(),
         };
@@ -296,11 +311,11 @@ mod tests {
             ttl_seconds: 3600,
         };
         let (token, _) = store.mint("node_test", &request).unwrap();
-        let saved: PersistedCapabilities = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+
         let mut restarted = CapabilityStore {
-            node_id: Some(saved.node_id),
-            persist_path: None,
-            grants: saved.grants,
+            node_id: None,
+            persist_path: Some(path),
+            grants: HashMap::new(),
         };
         assert!(restarted.authorizes("node_test", &token, EVIDENCE_READ, None));
         assert!(!restarted.authorizes("node_test", &token, SESSION_MESSAGE, None));
@@ -311,7 +326,7 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let path = temp.path().join("capabilities.json");
         let mut store = CapabilityStore {
-            node_id: Some("node_test".to_string()),
+            node_id: None,
             persist_path: Some(path.clone()),
             grants: HashMap::new(),
         };
@@ -335,7 +350,10 @@ mod tests {
 
     #[test]
     fn mint_rejects_unknown_actions_and_excessive_ttl() {
-        let mut store = CapabilityStore::default();
+        let mut store = CapabilityStore {
+            persist_path: None,
+            ..CapabilityStore::default()
+        };
         let mut invalid = request(&["root"], None);
         assert!(store.mint("node_test", &invalid).is_err());
         invalid.actions = vec![NODE_INFO.to_string()];

--- a/collector/src/server/capability.rs
+++ b/collector/src/server/capability.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub const NODE_INFO: &str = "node.info";
@@ -11,21 +11,22 @@ pub const EVIDENCE_READ: &str = "evidence.read";
 pub const SESSION_READ: &str = "session.read";
 pub const SESSION_MESSAGE: &str = "session.message";
 
-const TOKEN_PREFIX: &str = "cap_";
-const DOMAIN: &[u8] = b"AgentSight.NodeCapability.v1\0";
-const SIGNATURE_BYTES: usize = 32;
-const MAX_TOKEN_BYTES: usize = 4096;
 const MAX_TTL_SECONDS: u64 = 12 * 60 * 60;
-const HMAC_BLOCK_BYTES: usize = 64;
+const PERSIST_THRESHOLD_SECONDS: u64 = 10 * 60;
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-struct Claims {
-    v: u8,
-    node: String,
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Grant {
+    node_id: String,
     actions: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     session_id: Option<String>,
-    exp: u64,
+    expires_at: u64,
+    persistent: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PersistedCapabilities {
+    node_id: String,
+    grants: HashMap<String, Grant>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -55,80 +56,134 @@ impl CapabilityMintRequest {
     }
 }
 
-pub fn mint(
-    bootstrap_secret: &str,
-    node_id: &str,
-    request: &CapabilityMintRequest,
-) -> Result<(String, u64), &'static str> {
-    request.validate()?;
-    if bootstrap_secret.is_empty() || node_id.is_empty() {
-        return Err("capability issuer is not configured");
-    }
-    let expires_at = now_seconds().saturating_add(request.ttl_seconds);
-    let claims = Claims {
-        v: 1,
-        node: node_id.to_string(),
-        actions: request.actions.clone(),
-        session_id: request.session_id.clone(),
-        exp: expires_at,
-    };
-    let payload = serde_json::to_vec(&claims).map_err(|_| "could not encode capability")?;
-    let signature = capability_signature(bootstrap_secret.as_bytes(), &payload);
-    let mut token_bytes = Vec::with_capacity(payload.len() + SIGNATURE_BYTES);
-    token_bytes.extend_from_slice(&payload);
-    token_bytes.extend_from_slice(&signature);
-    let token = format!("{TOKEN_PREFIX}{}", URL_SAFE_NO_PAD.encode(token_bytes));
-    if token.len() > MAX_TOKEN_BYTES {
-        return Err("capability is too large");
-    }
-    Ok((token, expires_at))
+#[derive(Debug, Default)]
+pub struct CapabilityStore {
+    node_id: Option<String>,
+    persist_path: Option<PathBuf>,
+    grants: HashMap<String, Grant>,
 }
 
-pub fn authorizes(
-    bootstrap_secret: &str,
-    node_id: &str,
-    token: &str,
-    action: &str,
-    session_id: Option<&str>,
-) -> bool {
-    let Some(claims) = verify(bootstrap_secret, token) else {
-        return false;
-    };
-    if claims.node != node_id || !claims.actions.iter().any(|candidate| candidate == action) {
-        return false;
+impl CapabilityStore {
+    pub fn for_node(node_id: &str) -> Self {
+        let persist_path = capability_path();
+        let now = now_seconds();
+        let grants = persist_path
+            .as_ref()
+            .and_then(|path| std::fs::read(path).ok())
+            .and_then(|bytes| serde_json::from_slice::<PersistedCapabilities>(&bytes).ok())
+            .filter(|saved| saved.node_id == node_id)
+            .map(|saved| {
+                saved
+                    .grants
+                    .into_iter()
+                    .filter(|(_, grant)| grant.persistent && grant.expires_at >= now)
+                    .collect()
+            })
+            .unwrap_or_default();
+        Self {
+            node_id: Some(node_id.to_string()),
+            persist_path,
+            grants,
+        }
     }
-    match claims.session_id.as_deref() {
-        Some(expected) => session_id == Some(expected),
-        None => true,
-    }
-}
 
-fn verify(bootstrap_secret: &str, token: &str) -> Option<Claims> {
-    if token.len() > MAX_TOKEN_BYTES || bootstrap_secret.is_empty() {
-        return None;
+    pub fn mint(
+        &mut self,
+        node_id: &str,
+        request: &CapabilityMintRequest,
+    ) -> Result<(String, u64), &'static str> {
+        request.validate()?;
+        if self.node_id.as_deref().is_some_and(|configured| configured != node_id) {
+            return Err("capability store belongs to another Node");
+        }
+        if self.node_id.is_none() {
+            self.node_id = Some(node_id.to_string());
+        }
+        let now = now_seconds();
+        self.remove_expired(now);
+        let token = format!(
+            "cap_{}{}",
+            uuid::Uuid::new_v4().simple(),
+            uuid::Uuid::new_v4().simple()
+        );
+        let expires_at = now.saturating_add(request.ttl_seconds);
+        let persistent = request.ttl_seconds > PERSIST_THRESHOLD_SECONDS;
+        self.grants.insert(
+            token.clone(),
+            Grant {
+                node_id: node_id.to_string(),
+                actions: request.actions.clone(),
+                session_id: request.session_id.clone(),
+                expires_at,
+                persistent,
+            },
+        );
+        if persistent {
+            self.persist().map_err(|_| "could not persist capability")?;
+        }
+        Ok((token, expires_at))
     }
-    let encoded = token.strip_prefix(TOKEN_PREFIX)?;
-    let decoded = URL_SAFE_NO_PAD.decode(encoded).ok()?;
-    if decoded.len() <= SIGNATURE_BYTES {
-        return None;
+
+    pub fn authorizes(
+        &mut self,
+        node_id: &str,
+        token: &str,
+        action: &str,
+        session_id: Option<&str>,
+    ) -> bool {
+        let now = now_seconds();
+        self.remove_expired(now);
+        let Some(grant) = self.grants.get(token) else {
+            return false;
+        };
+        if grant.node_id != node_id || !grant.actions.iter().any(|candidate| candidate == action) {
+            return false;
+        }
+        match grant.session_id.as_deref() {
+            Some(expected) => session_id == Some(expected),
+            None => true,
+        }
     }
-    let split = decoded.len() - SIGNATURE_BYTES;
-    let (payload, supplied_signature) = decoded.split_at(split);
-    let expected_signature = capability_signature(bootstrap_secret.as_bytes(), payload);
-    if !constant_time_eq(&expected_signature, supplied_signature) {
-        return None;
+
+    fn remove_expired(&mut self, now: u64) {
+        self.grants.retain(|_, grant| grant.expires_at >= now);
     }
-    let claims: Claims = serde_json::from_slice(payload).ok()?;
-    if claims.v != 1
-        || claims.exp < now_seconds()
-        || claims.actions.is_empty()
-        || claims.actions.len() > 8
-        || claims.actions.iter().any(|action| !known_action(action))
-        || claims.session_id.as_deref().is_some_and(|value| !valid_session_id(value))
-    {
-        return None;
+
+    fn persist(&self) -> std::io::Result<()> {
+        let (Some(node_id), Some(path)) = (self.node_id.as_deref(), self.persist_path.as_ref()) else {
+            return Ok(());
+        };
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let saved = PersistedCapabilities {
+            node_id: node_id.to_string(),
+            grants: self
+                .grants
+                .iter()
+                .filter(|(_, grant)| grant.persistent)
+                .map(|(token, grant)| (token.clone(), grant.clone()))
+                .collect(),
+        };
+        let bytes = serde_json::to_vec(&saved).map_err(std::io::Error::other)?;
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        use std::io::Write;
+        let mut file = options.open(path)?;
+        file.write_all(&bytes)?;
+        file.sync_all()?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(())
     }
-    Some(claims)
 }
 
 pub fn action_for_request(method: &str, path: &str) -> Option<(&'static str, Option<String>)> {
@@ -167,49 +222,8 @@ fn valid_session_id(value: &str) -> bool {
         && !value.contains("..")
 }
 
-fn capability_signature(key: &[u8], payload: &[u8]) -> [u8; SIGNATURE_BYTES] {
-    let mut message = Vec::with_capacity(DOMAIN.len() + payload.len());
-    message.extend_from_slice(DOMAIN);
-    message.extend_from_slice(payload);
-    hmac_sha256(key, &message)
-}
-
-fn hmac_sha256(key: &[u8], data: &[u8]) -> [u8; SIGNATURE_BYTES] {
-    let mut normalized = [0u8; HMAC_BLOCK_BYTES];
-    if key.len() > HMAC_BLOCK_BYTES {
-        let digest = Sha256::digest(key);
-        normalized[..digest.len()].copy_from_slice(&digest);
-    } else {
-        normalized[..key.len()].copy_from_slice(key);
-    }
-
-    let mut inner_pad = [0x36u8; HMAC_BLOCK_BYTES];
-    let mut outer_pad = [0x5cu8; HMAC_BLOCK_BYTES];
-    for index in 0..HMAC_BLOCK_BYTES {
-        inner_pad[index] ^= normalized[index];
-        outer_pad[index] ^= normalized[index];
-    }
-
-    let mut inner = Sha256::new();
-    inner.update(inner_pad);
-    inner.update(data);
-    let inner_digest = inner.finalize();
-
-    let mut outer = Sha256::new();
-    outer.update(outer_pad);
-    outer.update(inner_digest);
-    outer.finalize().into()
-}
-
-fn constant_time_eq(expected: &[u8], supplied: &[u8]) -> bool {
-    if expected.len() != supplied.len() {
-        return false;
-    }
-    expected
-        .iter()
-        .zip(supplied)
-        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
-        == 0
+fn capability_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|dir| dir.join("agentsight").join("capabilities.json"))
 }
 
 fn default_ttl_seconds() -> u64 {
@@ -237,35 +251,29 @@ mod tests {
 
     #[test]
     fn scoped_capability_authorizes_only_requested_action_and_session() {
-        let (token, _) = mint(
-            "persistent-root",
-            "node_test",
-            &request(&[SESSION_READ], Some("session-1")),
-        )
-        .unwrap();
-        assert!(authorizes(
-            "persistent-root",
+        let mut store = CapabilityStore::default();
+        let (token, _) = store
+            .mint("node_test", &request(&[SESSION_READ], Some("session-1")))
+            .unwrap();
+        assert!(store.authorizes(
             "node_test",
             &token,
             SESSION_READ,
             Some("session-1"),
         ));
-        assert!(!authorizes(
-            "persistent-root",
+        assert!(!store.authorizes(
             "node_test",
             &token,
             SESSION_MESSAGE,
             Some("session-1"),
         ));
-        assert!(!authorizes(
-            "persistent-root",
+        assert!(!store.authorizes(
             "node_test",
             &token,
             SESSION_READ,
             Some("session-2"),
         ));
-        assert!(!authorizes(
-            "persistent-root",
+        assert!(!store.authorizes(
             "node_other",
             &token,
             SESSION_READ,
@@ -274,40 +282,41 @@ mod tests {
     }
 
     #[test]
-    fn capability_is_stateless_and_bound_to_the_persistent_root() {
-        let (token, expires_at) = mint(
-            "persistent-root",
-            "node_test",
-            &request(&[NODE_INFO, EVIDENCE_READ], None),
-        )
-        .unwrap();
-        assert!(expires_at > now_seconds());
-        assert!(token.starts_with(TOKEN_PREFIX));
-        assert!(authorizes(
-            "persistent-root",
-            "node_test",
-            &token,
-            EVIDENCE_READ,
-            None,
-        ));
-        assert!(!authorizes(
-            "rotated-root",
-            "node_test",
-            &token,
-            EVIDENCE_READ,
-            None,
-        ));
+    fn long_lived_capability_round_trips_through_persistent_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("capabilities.json");
+        let mut store = CapabilityStore {
+            node_id: Some("node_test".to_string()),
+            persist_path: Some(path.clone()),
+            grants: HashMap::new(),
+        };
+        let request = CapabilityMintRequest {
+            actions: vec![NODE_INFO.to_string(), EVIDENCE_READ.to_string()],
+            session_id: None,
+            ttl_seconds: 3600,
+        };
+        let (token, _) = store.mint("node_test", &request).unwrap();
+        let saved: PersistedCapabilities = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+        let mut restarted = CapabilityStore {
+            node_id: Some(saved.node_id),
+            persist_path: None,
+            grants: saved.grants,
+        };
+        assert!(restarted.authorizes("node_test", &token, EVIDENCE_READ, None));
+        assert!(!restarted.authorizes("node_test", &token, SESSION_MESSAGE, None));
+    }
 
-        let mut tampered = token.into_bytes();
-        let last = tampered.last_mut().unwrap();
-        *last = if *last == b'A' { b'B' } else { b'A' };
-        assert!(!authorizes(
-            "persistent-root",
-            "node_test",
-            std::str::from_utf8(&tampered).unwrap(),
-            EVIDENCE_READ,
-            None,
-        ));
+    #[test]
+    fn short_relay_capability_is_not_persisted() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("capabilities.json");
+        let mut store = CapabilityStore {
+            node_id: Some("node_test".to_string()),
+            persist_path: Some(path.clone()),
+            grants: HashMap::new(),
+        };
+        store.mint("node_test", &request(&[SESSION_READ], None)).unwrap();
+        assert!(!path.exists());
     }
 
     #[test]
@@ -326,10 +335,11 @@ mod tests {
 
     #[test]
     fn mint_rejects_unknown_actions_and_excessive_ttl() {
+        let mut store = CapabilityStore::default();
         let mut invalid = request(&["root"], None);
-        assert!(mint("persistent-root", "node_test", &invalid).is_err());
+        assert!(store.mint("node_test", &invalid).is_err());
         invalid.actions = vec![NODE_INFO.to_string()];
         invalid.ttl_seconds = MAX_TTL_SECONDS + 1;
-        assert!(mint("persistent-root", "node_test", &invalid).is_err());
+        assert!(store.mint("node_test", &invalid).is_err());
     }
 }

--- a/collector/src/server/mod.rs
+++ b/collector/src/server/mod.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 eunomia-bpf org.
 
 pub mod assets;
+pub(crate) mod capability;
 pub(crate) mod relay_client;
 pub(crate) mod session_runtime;
 pub mod web;

--- a/collector/src/server/relay_client.rs
+++ b/collector/src/server/relay_client.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
+use crate::server::capability;
 use futures::{SinkExt, StreamExt};
 use http_body_util::{BodyExt, Full};
 use hyper::body::Bytes;
@@ -21,6 +22,7 @@ use url::Url;
 const MAX_RELAY_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const RECONNECT_DELAY_SECS: u64 = 2;
 const HEARTBEAT_INTERVAL_SECS: u64 = 20;
+const RELAY_CAPABILITY_TTL_SECONDS: u64 = 60;
 
 #[derive(Debug, Deserialize)]
 struct RelayRequestEnvelope {
@@ -37,6 +39,11 @@ struct RelayResponseEnvelope {
     id: String,
     status: u16,
     body: String,
+}
+
+#[derive(Deserialize)]
+struct MintResponse {
+    access_token: String,
 }
 
 pub(crate) async fn run(
@@ -63,13 +70,13 @@ pub(crate) async fn run(
 
 async fn connect_once(
     relay_url: &str,
-    access_token: &str,
+    bootstrap_token: &str,
     local_endpoint: &str,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
     let mut request = relay_url.into_client_request()?;
     request.headers_mut().insert(
         "Authorization",
-        HeaderValue::from_str(&format!("Bearer {access_token}"))?,
+        HeaderValue::from_str(&format!("Bearer {bootstrap_token}"))?,
     );
     request.headers_mut().insert(
         "User-Agent",
@@ -95,7 +102,7 @@ async fn connect_once(
                 match message? {
                     Message::Text(text) if text.as_str() == "pong" => {}
                     Message::Text(text) => {
-                        let response = handle_request(text.as_str(), local_endpoint, access_token).await;
+                        let response = handle_request(text.as_str(), local_endpoint, bootstrap_token).await;
                         socket.send(Message::Text(serde_json::to_string(&response)?.into())).await?;
                     }
                     Message::Ping(payload) => {
@@ -113,7 +120,7 @@ async fn connect_once(
 async fn handle_request(
     raw: &str,
     local_endpoint: &str,
-    access_token: &str,
+    bootstrap_token: &str,
 ) -> RelayResponseEnvelope {
     let request = match serde_json::from_str::<RelayRequestEnvelope>(raw) {
         Ok(request) if request.r#type == "request" && !request.id.is_empty() => request,
@@ -136,9 +143,48 @@ async fn handle_request(
         };
     }
 
+    // Capability minting is the only relay operation that uses the Node's
+    // persistent bootstrap credential directly. All normal data/control
+    // operations are translated into a short-lived local capability first.
+    let credential = if request.method == "POST" && request.path == "/api/v1/capabilities" {
+        bootstrap_token.to_string()
+    } else {
+        let Some((action, session_id)) = capability::action_for_request(&request.method, &request.path)
+        else {
+            return RelayResponseEnvelope {
+                r#type: "response",
+                id: request.id,
+                status: 403,
+                body: json_error("relay_path_not_allowed"),
+            };
+        };
+        match mint_local_capability(
+            local_endpoint,
+            bootstrap_token,
+            action,
+            session_id.as_deref(),
+        )
+        .await
+        {
+            Ok(token) => token,
+            Err(error) => {
+                return RelayResponseEnvelope {
+                    r#type: "response",
+                    id: request.id,
+                    status: 502,
+                    body: serde_json::json!({
+                        "error": "node_capability_failed",
+                        "detail": error.to_string()
+                    })
+                    .to_string(),
+                };
+            }
+        }
+    };
+
     match forward_local(
         local_endpoint,
-        access_token,
+        &credential,
         &request.method,
         &request.path,
         request.body.as_deref(),
@@ -161,9 +207,39 @@ async fn handle_request(
     }
 }
 
+async fn mint_local_capability(
+    endpoint: &str,
+    bootstrap_token: &str,
+    action: &str,
+    session_id: Option<&str>,
+) -> Result<String, Box<dyn Error + Send + Sync>> {
+    let body = serde_json::json!({
+        "actions": [action],
+        "session_id": session_id,
+        "ttl_seconds": RELAY_CAPABILITY_TTL_SECONDS,
+    })
+    .to_string();
+    let (status, body) = forward_local(
+        endpoint,
+        bootstrap_token,
+        "POST",
+        "/api/v1/capabilities",
+        Some(&body),
+    )
+    .await?;
+    if status != 201 {
+        return Err(format!("Node capability mint failed with HTTP {status}").into());
+    }
+    let response: MintResponse = serde_json::from_str(&body)?;
+    if !response.access_token.starts_with("cap_") {
+        return Err("Node returned an invalid capability".into());
+    }
+    Ok(response.access_token)
+}
+
 async fn forward_local(
     endpoint: &str,
-    access_token: &str,
+    credential: &str,
     method: &str,
     path: &str,
     body: Option<&str>,
@@ -178,7 +254,7 @@ async fn forward_local(
     let mut builder = Request::builder()
         .method(method)
         .uri(format!("{endpoint}{path}"))
-        .header("Authorization", format!("Bearer {access_token}"));
+        .header("Authorization", format!("Bearer {credential}"));
     if body.is_some() {
         builder = builder.header("Content-Type", "application/json");
     }
@@ -211,6 +287,9 @@ fn allowed_relay_path(method: &str, value: &str) -> bool {
     let (path, query) = value.split_once('?').map_or((value, None), |(path, query)| {
         (path, Some(query))
     });
+    if method == "POST" && path == "/api/v1/capabilities" && query.is_none() {
+        return true;
+    }
     if method == "GET" && path == "/api/v1/snapshot" {
         return query.is_none_or(|query| {
             query.strip_prefix("audit_limit=")
@@ -254,7 +333,8 @@ mod tests {
     }
 
     #[test]
-    fn relay_only_accepts_the_node_protocol_surface() {
+    fn relay_only_accepts_the_node_protocol_and_internal_mint_surface() {
+        assert!(allowed_relay_path("POST", "/api/v1/capabilities"));
         assert!(allowed_relay_path("GET", "/api/v1/snapshot?audit_limit=50000"));
         assert!(allowed_relay_path("GET", "/api/v1/sessions/session-123"));
         assert!(allowed_relay_path("POST", "/api/v1/sessions/session-123/messages"));

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -4,7 +4,7 @@
 use crate::model::{Snapshot, SnapshotOptions};
 use crate::server::assets::FrontendAssets;
 use crate::server::capability::{
-    self, CapabilityMintRequest, CapabilityStore, EVIDENCE_READ, NODE_INFO, SESSION_MESSAGE,
+    CapabilityMintRequest, CapabilityStore, EVIDENCE_READ, NODE_INFO, SESSION_MESSAGE,
     SESSION_READ,
 };
 use crate::sources::agent_native::{self as agent_native_sessions, SessionCache};
@@ -824,11 +824,11 @@ mod tests {
     #[test]
     fn semantic_protocol_mapping_matches_web_routes() {
         assert_eq!(
-            capability::action_for_request("GET", "/api/v1/snapshot?audit_limit=42"),
+            crate::server::capability::action_for_request("GET", "/api/v1/snapshot?audit_limit=42"),
             Some((EVIDENCE_READ, None))
         );
         assert_eq!(
-            capability::action_for_request("POST", "/api/v1/sessions/s-1/messages"),
+            crate::server::capability::action_for_request("POST", "/api/v1/sessions/s-1/messages"),
             Some((SESSION_MESSAGE, Some("s-1".to_string())))
         );
     }

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -3,6 +3,10 @@
 
 use crate::model::{Snapshot, SnapshotOptions};
 use crate::server::assets::FrontendAssets;
+use crate::server::capability::{
+    self, CapabilityMintRequest, CapabilityStore, EVIDENCE_READ, NODE_INFO, SESSION_MESSAGE,
+    SESSION_READ,
+};
 use crate::sources::agent_native::{self as agent_native_sessions, SessionCache};
 use crate::sources::sqlite as sqlite_source;
 use crate::view::SharedMaterializedView;
@@ -25,7 +29,7 @@ use tokio::net::TcpListener;
 
 #[derive(Clone)]
 struct DirectAuth {
-    access_token: String,
+    bootstrap_token: String,
     node: NodeMetadata,
     allowed_origin: String,
 }
@@ -38,22 +42,41 @@ pub struct NodeMetadata {
 }
 
 impl DirectAuth {
-    fn new(access_token: String, node: NodeMetadata, allowed_origin: String) -> Self {
+    fn new(bootstrap_token: String, node: NodeMetadata, allowed_origin: String) -> Self {
         Self {
-            access_token,
+            bootstrap_token,
             node,
             allowed_origin,
         }
     }
 
-    fn authorizes(&self, value: Option<&HeaderValue>) -> bool {
-        let Some(token) = value
+    fn bearer<'a>(&self, value: Option<&'a HeaderValue>) -> Option<&'a str> {
+        value
             .and_then(|value| value.to_str().ok())
             .and_then(|value| value.strip_prefix("Bearer "))
-        else {
+    }
+
+    fn is_root(&self, value: Option<&HeaderValue>) -> bool {
+        self.bearer(value) == Some(self.bootstrap_token.as_str())
+    }
+
+    fn authorizes(
+        &self,
+        capabilities: &Arc<Mutex<CapabilityStore>>,
+        value: Option<&HeaderValue>,
+        action: &str,
+        session_id: Option<&str>,
+    ) -> bool {
+        if self.is_root(value) {
+            return true;
+        }
+        let Some(token) = self.bearer(value) else {
             return false;
         };
-        token == self.access_token
+        capabilities
+            .lock()
+            .ok()
+            .is_some_and(|mut store| store.authorizes(&self.node.id, token, action, session_id))
     }
 
     fn allows_origin(&self, origin: &str) -> bool {
@@ -65,6 +88,7 @@ pub struct WebServer {
     assets: Arc<FrontendAssets>,
     view: SharedMaterializedView,
     agent_native_sessions: Arc<Mutex<SessionCache>>,
+    capabilities: Arc<Mutex<CapabilityStore>>,
     db_path: Option<String>,
     direct_auth: Option<DirectAuth>,
 }
@@ -79,6 +103,7 @@ impl WebServer {
             assets: Arc::new(assets),
             view,
             agent_native_sessions: Arc::new(Mutex::new(SessionCache::new())),
+            capabilities: Arc::new(Mutex::new(CapabilityStore::default())),
             db_path,
             direct_auth: None,
         })
@@ -123,6 +148,7 @@ impl WebServer {
             let assets = Arc::clone(&self.assets);
             let view = Arc::clone(&self.view);
             let agent_native_sessions = Arc::clone(&self.agent_native_sessions);
+            let capabilities = Arc::clone(&self.capabilities);
             let db_path = self.db_path.clone();
             let direct_auth = self.direct_auth.clone();
 
@@ -134,6 +160,7 @@ impl WebServer {
                         assets.clone(),
                         view.clone(),
                         agent_native_sessions.clone(),
+                        capabilities.clone(),
                         db_path.clone(),
                         direct_auth.clone(),
                     )
@@ -152,6 +179,7 @@ async fn handle_request(
     assets: Arc<FrontendAssets>,
     view: SharedMaterializedView,
     agent_native_sessions: Arc<Mutex<SessionCache>>,
+    capabilities: Arc<Mutex<CapabilityStore>>,
     db_path: Option<String>,
     direct_auth: Option<DirectAuth>,
 ) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
@@ -190,10 +218,18 @@ async fn handle_request(
     let session_detail_id = session_detail_id(&path).map(str::to_string);
     let response = match (method, path.as_str()) {
         (Method::GET, "/api/v1/info") => {
-            if !info_access_allowed(direct_auth.as_ref(), authorization.as_ref()) {
-                json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
+            if !info_access_allowed(
+                direct_auth.as_ref(),
+                &capabilities,
+                authorization.as_ref(),
+            ) {
+                json_error(StatusCode::UNAUTHORIZED, "valid Node capability required")
             } else {
-                let node = info_node(direct_auth.as_ref(), authorization.as_ref());
+                let node = info_node(
+                    direct_auth.as_ref(),
+                    &capabilities,
+                    authorization.as_ref(),
+                );
                 json_response(
                     StatusCode::OK,
                     &serde_json::json!({
@@ -201,6 +237,7 @@ async fn handle_request(
                         "product": PRODUCT,
                         "authorization_required": direct_auth.is_some(),
                         "capabilities": {
+                            "scoped_authorization": direct_auth.is_some(),
                             "session_detail": true,
                             "session_messages": direct_auth.is_some() && db_path.is_none(),
                         },
@@ -209,49 +246,64 @@ async fn handle_request(
                 )
             }
         }
-        (Method::GET, "/api/v1/snapshot") => {
-            if !snapshot_access_allowed(
+        (Method::POST, "/api/v1/capabilities") => {
+            serve_capability_mint_api(
+                req,
                 direct_auth.as_ref(),
+                &capabilities,
                 authorization.as_ref(),
+            )
+            .await?
+        }
+        (Method::GET, "/api/v1/snapshot") => {
+            if !protocol_access_allowed(
+                direct_auth.as_ref(),
+                &capabilities,
+                authorization.as_ref(),
+                EVIDENCE_READ,
+                None,
                 origin.as_deref(),
             ) {
-                json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
+                json_error(StatusCode::UNAUTHORIZED, "evidence.read capability required")
             } else {
                 serve_snapshot_api(view, agent_native_sessions, db_path, query.as_deref()).await?
             }
         }
         (Method::GET, _) if session_detail_id.is_some() => {
-            if !snapshot_access_allowed(
+            let session_id = session_detail_id.as_deref().unwrap_or_default();
+            if !protocol_access_allowed(
                 direct_auth.as_ref(),
+                &capabilities,
                 authorization.as_ref(),
+                SESSION_READ,
+                Some(session_id),
                 origin.as_deref(),
             ) {
-                json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
+                json_error(StatusCode::UNAUTHORIZED, "session.read capability required")
             } else if db_path.is_some() {
                 json_error(
                     StatusCode::CONFLICT,
                     "saved captures do not expose native session messages",
                 )
             } else {
-                serve_session_api(
-                    agent_native_sessions,
-                    session_detail_id.as_deref().unwrap_or_default(),
-                )
-                .await?
+                serve_session_api(agent_native_sessions, session_id).await?
             }
         }
         (Method::POST, _) if session_message_id.is_some() => {
-            if !session_control_access_allowed(direct_auth.as_ref(), authorization.as_ref()) {
-                json_error(StatusCode::UNAUTHORIZED, "valid binding token required")
+            let session_id = session_message_id.as_deref().unwrap_or_default();
+            if !protocol_access_allowed(
+                direct_auth.as_ref(),
+                &capabilities,
+                authorization.as_ref(),
+                SESSION_MESSAGE,
+                Some(session_id),
+                origin.as_deref(),
+            ) {
+                json_error(StatusCode::UNAUTHORIZED, "session.message capability required")
             } else if db_path.is_some() {
                 json_error(StatusCode::CONFLICT, "saved captures are read-only")
             } else {
-                serve_session_message_api(
-                    req,
-                    agent_native_sessions,
-                    session_message_id.as_deref().unwrap_or_default(),
-                )
-                .await?
+                serve_session_message_api(req, agent_native_sessions, session_id).await?
             }
         }
         (Method::GET, _) => serve_asset(assets, &path).await?,
@@ -265,6 +317,68 @@ async fn handle_request(
         response,
         origin.as_deref(),
         direct_auth.as_ref(),
+    ))
+}
+
+async fn serve_capability_mint_api(
+    req: Request<hyper::body::Incoming>,
+    direct_auth: Option<&DirectAuth>,
+    capabilities: &Arc<Mutex<CapabilityStore>>,
+    authorization: Option<&HeaderValue>,
+) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
+    let Some(auth) = direct_auth else {
+        return Ok(json_error(StatusCode::NOT_FOUND, "capability issuer unavailable"));
+    };
+    if !auth.is_root(authorization) {
+        return Ok(json_error(
+            StatusCode::UNAUTHORIZED,
+            "Node bootstrap credential required",
+        ));
+    }
+    let body = match req.into_body().collect().await {
+        Ok(body) => body.to_bytes(),
+        Err(error) => {
+            return Ok(json_error(
+                StatusCode::BAD_REQUEST,
+                &format!("failed to read request body: {error}"),
+            ));
+        }
+    };
+    if body.len() > 16 * 1024 {
+        return Ok(json_error(StatusCode::PAYLOAD_TOO_LARGE, "request too large"));
+    }
+    let request: CapabilityMintRequest = match serde_json::from_slice(&body) {
+        Ok(request) => request,
+        Err(error) => {
+            return Ok(json_error(
+                StatusCode::BAD_REQUEST,
+                &format!("invalid capability request: {error}"),
+            ));
+        }
+    };
+    if let Err(error) = request.validate() {
+        return Ok(json_error(StatusCode::BAD_REQUEST, error));
+    }
+    let minted = capabilities
+        .lock()
+        .map_err(|_| ())
+        .and_then(|mut store| store.mint(&auth.node.id, &request).map_err(|_| ()));
+    let Ok((access_token, expires_at)) = minted else {
+        return Ok(json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "could not mint capability",
+        ));
+    };
+    Ok(json_response(
+        StatusCode::CREATED,
+        &serde_json::json!({
+            "access_token": access_token,
+            "token_type": "Bearer",
+            "expires_at": expires_at,
+            "expires_in": request.ttl_seconds,
+            "actions": request.actions,
+            "session_id": request.session_id,
+        }),
     ))
 }
 
@@ -514,39 +628,40 @@ fn allowed_origin(origin: &str, direct_auth: Option<&DirectAuth>) -> bool {
         || option_env!("AGENTSIGHT_DEV_APP_ORIGIN").is_some_and(|allowed| origin == allowed)
 }
 
-fn snapshot_access_allowed(
+fn protocol_access_allowed(
     direct_auth: Option<&DirectAuth>,
+    capabilities: &Arc<Mutex<CapabilityStore>>,
     authorization: Option<&HeaderValue>,
+    action: &str,
+    session_id: Option<&str>,
     origin: Option<&str>,
 ) -> bool {
     match direct_auth {
-        Some(auth) => auth.authorizes(authorization),
+        Some(auth) => auth.authorizes(capabilities, authorization, action, session_id),
         None => origin.is_none(),
     }
 }
 
-fn session_control_access_allowed(
-    direct_auth: Option<&DirectAuth>,
-    authorization: Option<&HeaderValue>,
-) -> bool {
-    direct_auth.is_some_and(|auth| auth.authorizes(authorization))
-}
-
 fn info_access_allowed(
     direct_auth: Option<&DirectAuth>,
+    capabilities: &Arc<Mutex<CapabilityStore>>,
     authorization: Option<&HeaderValue>,
 ) -> bool {
     match (direct_auth, authorization) {
-        (Some(auth), Some(value)) => auth.authorizes(Some(value)),
+        (Some(auth), Some(value)) => auth.authorizes(capabilities, Some(value), NODE_INFO, None),
         _ => true,
     }
 }
 
 fn info_node(
     direct_auth: Option<&DirectAuth>,
+    capabilities: &Arc<Mutex<CapabilityStore>>,
     authorization: Option<&HeaderValue>,
 ) -> Option<NodeMetadata> {
-    direct_auth.and_then(|auth| auth.authorizes(authorization).then(|| auth.node.clone()))
+    direct_auth.and_then(|auth| {
+        auth.authorizes(capabilities, authorization, NODE_INFO, None)
+            .then(|| auth.node.clone())
+    })
 }
 
 fn cors_response(
@@ -637,9 +752,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn direct_access_key_authorizes() {
-        let auth = DirectAuth::new(
+    fn test_auth() -> DirectAuth {
+        DirectAuth::new(
             "process-lifetime-key".to_string(),
             NodeMetadata {
                 id: "node_test".to_string(),
@@ -647,35 +761,40 @@ mod tests {
                 version: "1".to_string(),
             },
             "https://console.example".to_string(),
-        );
-        let header = HeaderValue::from_static("Bearer process-lifetime-key");
-        assert!(auth.authorizes(Some(&header)));
-        assert!(!auth.authorizes(Some(&HeaderValue::from_static("Bearer wrong"))));
-        assert!(!auth.authorizes(None));
-        assert!(info_access_allowed(Some(&auth), None));
-        assert!(info_access_allowed(Some(&auth), Some(&header)));
-        assert!(!info_access_allowed(
-            Some(&auth),
-            Some(&HeaderValue::from_static("Bearer wrong"))
-        ));
-        assert!(info_node(Some(&auth), None).is_none());
+        )
+    }
+
+    #[test]
+    fn bootstrap_key_is_root_and_scoped_capability_is_narrow() {
+        let auth = test_auth();
+        let root = HeaderValue::from_static("Bearer process-lifetime-key");
+        let store = Arc::new(Mutex::new(CapabilityStore::default()));
+        assert!(auth.is_root(Some(&root)));
+        assert!(!auth.is_root(Some(&HeaderValue::from_static("Bearer wrong"))));
+        assert!(auth.authorizes(&store, Some(&root), SESSION_MESSAGE, Some("session-1")));
+
+        let request = CapabilityMintRequest {
+            actions: vec![SESSION_READ.to_string()],
+            session_id: Some("session-1".to_string()),
+            ttl_seconds: 60,
+        };
+        let (token, _) = store.lock().unwrap().mint("node_test", &request).unwrap();
+        let scoped = HeaderValue::from_str(&format!("Bearer {token}")).unwrap();
+        assert!(auth.authorizes(&store, Some(&scoped), SESSION_READ, Some("session-1")));
+        assert!(!auth.authorizes(&store, Some(&scoped), SESSION_MESSAGE, Some("session-1")));
+        assert!(!auth.authorizes(&store, Some(&scoped), SESSION_READ, Some("session-2")));
+        assert!(info_access_allowed(Some(&auth), &store, None));
+        assert!(info_access_allowed(Some(&auth), &store, Some(&root)));
+        assert!(info_node(Some(&auth), &store, None).is_none());
         assert_eq!(
-            info_node(Some(&auth), Some(&header)).unwrap().id,
+            info_node(Some(&auth), &store, Some(&root)).unwrap().id,
             "node_test"
         );
     }
 
     #[test]
     fn cors_uses_the_configured_app_origin() {
-        let auth = DirectAuth::new(
-            "key".to_string(),
-            NodeMetadata {
-                id: "node_test".to_string(),
-                name: "test".to_string(),
-                version: "1".to_string(),
-            },
-            "https://console.example".to_string(),
-        );
+        let auth = test_auth();
         assert!(allowed_origin("https://console.example", Some(&auth)));
         assert!(!allowed_origin("https://app.agentsight.us", Some(&auth)));
         assert!(!allowed_origin("https://evil.example", Some(&auth)));
@@ -683,12 +802,35 @@ mod tests {
 
     #[test]
     fn hosted_origin_cannot_reuse_token_against_an_unpaired_server() {
-        assert!(snapshot_access_allowed(None, None, None));
-        assert!(!snapshot_access_allowed(
+        let store = Arc::new(Mutex::new(CapabilityStore::default()));
+        assert!(protocol_access_allowed(
             None,
+            &store,
+            None,
+            EVIDENCE_READ,
+            None,
+            None
+        ));
+        assert!(!protocol_access_allowed(
+            None,
+            &store,
+            None,
+            EVIDENCE_READ,
             None,
             Some("https://console.example")
         ));
+    }
+
+    #[test]
+    fn semantic_protocol_mapping_matches_web_routes() {
+        assert_eq!(
+            capability::action_for_request("GET", "/api/v1/snapshot?audit_limit=42"),
+            Some((EVIDENCE_READ, None))
+        );
+        assert_eq!(
+            capability::action_for_request("POST", "/api/v1/sessions/s-1/messages"),
+            Some((SESSION_MESSAGE, Some("s-1".to_string())))
+        );
     }
 
     fn llm_call(id: &str, pid: u32, comm: &str, timestamp_ms: u64, text: &str) -> LlmCallRow {

--- a/controller/README.md
+++ b/controller/README.md
@@ -1,8 +1,73 @@
 # AgentSight Controller
 
-Controller is the fully open-source coordination service for AgentSight. It provides OAuth identity, Node ownership/discovery, and an online relay for Nodes that cannot be reached directly from the browser. The community/self-hosted build has the same Controller and relay capabilities as the hosted service; there is no code-level feature gate here.
+Controller is the fully open-source coordination service for AgentSight. It is deliberately not AgentSight's telemetry data plane.
 
-Node telemetry remains authoritative on the Node. Controller does not persist snapshots, session transcripts, prompts, process data, or relay response bodies. Relay traffic passes through Controller runtime memory only while a request is active.
+Controller stores and coordinates:
+
+- GitHub/Google OAuth identity;
+- organizations and user memberships;
+- built-in roles and organization configuration;
+- plan, billing-provider metadata, and entitlements;
+- Node registration, relay credentials, and presence;
+- the authorization decision used before Controller relays a Node operation.
+
+Detailed runtime evidence remains authoritative on the Node. Controller does not persist snapshots, session transcripts, prompts, process data, or relay response bodies. Relay traffic passes through Controller runtime memory only while a request is active.
+
+## Authorization model
+
+Human login and Node authorization are separate concerns.
+
+```text
+OAuth user
+  -> organization membership
+  -> viewer / operator / admin / owner
+  -> semantic action
+  -> Direct or Controller relay
+  -> Node capability enforcement
+```
+
+A Node never needs a user, owner, membership, role, or billing record. Its persistent local credential is a bootstrap/relay identity. Normal Node Protocol operations use Node-local scoped capabilities such as `evidence.read`, `session.read`, and `session.message`.
+
+Controller's Node registry is organization-scoped rather than user-owned. A user may belong to multiple organizations. Every account has a personal organization; team organizations use the same data model.
+
+Built-in roles intentionally remain small:
+
+- `viewer`: inspect organization metadata, Nodes, evidence, sessions, config, and billing state;
+- `operator`: viewer plus `session.message`;
+- `admin`: operator plus Node/member/config management;
+- `owner`: admin plus organization and billing management.
+
+## Plans
+
+The Controller exposes the canonical catalog at `GET /v1/pricing`:
+
+- Free: $0; local/direct open-source use;
+- Pro: $5/month or $49/year; managed connectivity for a personal organization;
+- Team: $10/user/month; shared organization/fleet and team roles;
+- Enterprise: custom.
+
+A `pro_lifetime` entitlement gives a contributor's personal organization effective Pro access without changing Team or Enterprise billing. The admin adapter can record provider-neutral billing state and contributor entitlements; payment-provider checkout/webhook code is intentionally kept outside the authorization model.
+
+Plan enforcement happens at the Controller boundary: Free remains usable locally/directly, Pro enables managed registration/relay for a personal organization, and Team/Enterprise enable multi-member organization operations.
+
+## Organization API
+
+The main coordination surfaces are:
+
+```text
+GET/POST          /v1/organizations
+PATCH/DELETE      /v1/organizations/{organization_id}
+GET/POST          /v1/organizations/{organization_id}/members
+PATCH/DELETE      /v1/organizations/{organization_id}/members/{user_id}
+GET/PUT           /v1/organizations/{organization_id}/config/{key}
+GET               /v1/organizations/{organization_id}/billing
+POST              /v1/invitations/accept
+GET/POST          /v1/nodes?organization_id=...
+DELETE            /v1/nodes/{node_id}
+POST              /v1/nodes/{node_id}/capabilities
+```
+
+Privileged deployment automation may use `ADMIN_API_TOKEN` for provider-neutral billing state and contributor entitlement updates. Do not expose that token to browsers.
 
 ## Development
 

--- a/controller/migrations/0005_organizations_pricing_capabilities.sql
+++ b/controller/migrations/0005_organizations_pricing_capabilities.sql
@@ -1,0 +1,117 @@
+CREATE TABLE IF NOT EXISTS organizations (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('personal', 'team')),
+    plan TEXT NOT NULL DEFAULT 'free' CHECK (plan IN ('free', 'pro', 'team', 'enterprise')),
+    billing_interval TEXT CHECK (billing_interval IS NULL OR billing_interval IN ('monthly', 'annual')),
+    billing_status TEXT NOT NULL DEFAULT 'inactive' CHECK (billing_status IN ('inactive', 'trialing', 'active', 'past_due', 'canceled')),
+    external_customer_id TEXT,
+    external_subscription_id TEXT,
+    current_period_end INTEGER,
+    created_by_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memberships (
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('viewer', 'operator', 'admin', 'owner')),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (organization_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS organization_configs (
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    updated_by TEXT NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (organization_id, key)
+);
+
+CREATE TABLE IF NOT EXISTS entitlements (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+    organization_id TEXT REFERENCES organizations(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    source TEXT NOT NULL,
+    source_ref TEXT,
+    expires_at INTEGER,
+    revoked_at INTEGER,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS organization_invites (
+    token_hash TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('viewer', 'operator', 'admin')),
+    invited_by_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at INTEGER NOT NULL,
+    consumed_at INTEGER,
+    created_at INTEGER NOT NULL
+);
+
+INSERT OR IGNORE INTO organizations (
+    id, name, kind, plan, billing_status, created_by_user_id, created_at, updated_at
+)
+SELECT
+    'org_personal_' || replace(id, '-', ''),
+    'Personal',
+    'personal',
+    'free',
+    'inactive',
+    id,
+    created_at,
+    updated_at
+FROM users;
+
+INSERT OR IGNORE INTO memberships (organization_id, user_id, role, created_at, updated_at)
+SELECT
+    'org_personal_' || replace(id, '-', ''),
+    id,
+    'owner',
+    created_at,
+    updated_at
+FROM users;
+
+CREATE TABLE nodes_v2 (
+    id TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    version TEXT,
+    public_key TEXT,
+    relay_token_hash TEXT,
+    connection_mode TEXT NOT NULL DEFAULT 'direct',
+    last_seen_at INTEGER NOT NULL,
+    created_at INTEGER NOT NULL
+);
+
+INSERT INTO nodes_v2 (
+    id, organization_id, name, version, public_key, relay_token_hash,
+    connection_mode, last_seen_at, created_at
+)
+SELECT
+    id,
+    'org_personal_' || replace(owner_user_id, '-', ''),
+    name,
+    version,
+    public_key,
+    relay_token_hash,
+    connection_mode,
+    last_seen_at,
+    created_at
+FROM nodes;
+
+DROP TABLE nodes;
+ALTER TABLE nodes_v2 RENAME TO nodes;
+
+CREATE INDEX IF NOT EXISTS idx_memberships_user ON memberships(user_id, organization_id);
+CREATE INDEX IF NOT EXISTS idx_memberships_org ON memberships(organization_id, role);
+CREATE INDEX IF NOT EXISTS idx_nodes_org ON nodes(organization_id, last_seen_at DESC);
+CREATE INDEX IF NOT EXISTS idx_entitlements_user ON entitlements(user_id, kind, revoked_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_entitlements_org ON entitlements(organization_id, kind, revoked_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_invites_org ON organization_invites(organization_id, expires_at);
+CREATE INDEX IF NOT EXISTS idx_invites_email ON organization_invites(email, expires_at);

--- a/controller/schema.sql
+++ b/controller/schema.sql
@@ -39,9 +39,33 @@ CREATE TABLE IF NOT EXISTS sessions (
     last_seen_at INTEGER NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS organizations (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL CHECK (kind IN ('personal', 'team')),
+    plan TEXT NOT NULL DEFAULT 'free' CHECK (plan IN ('free', 'pro', 'team', 'enterprise')),
+    billing_interval TEXT CHECK (billing_interval IS NULL OR billing_interval IN ('monthly', 'annual')),
+    billing_status TEXT NOT NULL DEFAULT 'inactive' CHECK (billing_status IN ('inactive', 'trialing', 'active', 'past_due', 'canceled')),
+    external_customer_id TEXT,
+    external_subscription_id TEXT,
+    current_period_end INTEGER,
+    created_by_user_id TEXT REFERENCES users(id) ON DELETE SET NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memberships (
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role TEXT NOT NULL CHECK (role IN ('viewer', 'operator', 'admin', 'owner')),
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (organization_id, user_id)
+);
+
 CREATE TABLE IF NOT EXISTS nodes (
     id TEXT PRIMARY KEY,
-    owner_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
     version TEXT,
     public_key TEXT,
@@ -51,9 +75,47 @@ CREATE TABLE IF NOT EXISTS nodes (
     created_at INTEGER NOT NULL
 );
 
-CREATE INDEX IF NOT EXISTS idx_nodes_owner ON nodes(owner_user_id, last_seen_at DESC);
+CREATE TABLE IF NOT EXISTS organization_configs (
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    key TEXT NOT NULL,
+    value_json TEXT NOT NULL,
+    updated_by TEXT NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (organization_id, key)
+);
+
+CREATE TABLE IF NOT EXISTS entitlements (
+    id TEXT PRIMARY KEY,
+    user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+    organization_id TEXT REFERENCES organizations(id) ON DELETE CASCADE,
+    kind TEXT NOT NULL,
+    source TEXT NOT NULL,
+    source_ref TEXT,
+    expires_at INTEGER,
+    revoked_at INTEGER,
+    created_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS organization_invites (
+    token_hash TEXT PRIMARY KEY,
+    organization_id TEXT NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    email TEXT NOT NULL,
+    role TEXT NOT NULL CHECK (role IN ('viewer', 'operator', 'admin')),
+    invited_by_user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at INTEGER NOT NULL,
+    consumed_at INTEGER,
+    created_at INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_nodes_org ON nodes(organization_id, last_seen_at DESC);
 CREATE INDEX IF NOT EXISTS idx_sessions_user ON sessions(user_id, expires_at);
 CREATE INDEX IF NOT EXISTS idx_oauth_states_expiry ON oauth_states(expires_at);
 CREATE INDEX IF NOT EXISTS idx_auth_codes_expiry ON auth_codes(expires_at);
 CREATE INDEX IF NOT EXISTS idx_auth_codes_consumed ON auth_codes(consumed_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_expiry ON sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_memberships_user ON memberships(user_id, organization_id);
+CREATE INDEX IF NOT EXISTS idx_memberships_org ON memberships(organization_id, role);
+CREATE INDEX IF NOT EXISTS idx_entitlements_user ON entitlements(user_id, kind, revoked_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_entitlements_org ON entitlements(organization_id, kind, revoked_at, expires_at);
+CREATE INDEX IF NOT EXISTS idx_invites_org ON organization_invites(organization_id, expires_at);
+CREATE INDEX IF NOT EXISTS idx_invites_email ON organization_invites(email, expires_at);

--- a/controller/src/access.ts
+++ b/controller/src/access.ts
@@ -1,0 +1,652 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 eunomia-bpf org.
+
+export type Role = 'viewer' | 'operator' | 'admin' | 'owner';
+export type Plan = 'free' | 'pro' | 'team' | 'enterprise';
+export type OrganizationKind = 'personal' | 'team';
+export type BillingStatus = 'inactive' | 'trialing' | 'active' | 'past_due' | 'canceled';
+
+export type Action =
+  | 'organization.read'
+  | 'organization.manage'
+  | 'member.read'
+  | 'member.manage'
+  | 'node.read'
+  | 'node.manage'
+  | 'node.info'
+  | 'evidence.read'
+  | 'session.read'
+  | 'session.message'
+  | 'config.read'
+  | 'config.write'
+  | 'billing.read'
+  | 'billing.manage';
+
+export interface PlanDefinition {
+  id: Plan;
+  name: string;
+  monthly_cents: number | null;
+  annual_cents: number | null;
+  per_seat: boolean;
+  managed_connectivity: boolean;
+  multi_member: boolean;
+  custom: boolean;
+}
+
+export const PLAN_CATALOG: Record<Plan, PlanDefinition> = {
+  free: {
+    id: 'free',
+    name: 'Free',
+    monthly_cents: 0,
+    annual_cents: 0,
+    per_seat: false,
+    managed_connectivity: false,
+    multi_member: false,
+    custom: false,
+  },
+  pro: {
+    id: 'pro',
+    name: 'Pro',
+    monthly_cents: 500,
+    annual_cents: 4900,
+    per_seat: false,
+    managed_connectivity: true,
+    multi_member: false,
+    custom: false,
+  },
+  team: {
+    id: 'team',
+    name: 'Team',
+    monthly_cents: 1000,
+    annual_cents: null,
+    per_seat: true,
+    managed_connectivity: true,
+    multi_member: true,
+    custom: false,
+  },
+  enterprise: {
+    id: 'enterprise',
+    name: 'Enterprise',
+    monthly_cents: null,
+    annual_cents: null,
+    per_seat: false,
+    managed_connectivity: true,
+    multi_member: true,
+    custom: true,
+  },
+};
+
+const ROLE_ACTIONS: Record<Role, ReadonlySet<Action>> = {
+  viewer: new Set<Action>([
+    'organization.read',
+    'member.read',
+    'node.read',
+    'node.info',
+    'evidence.read',
+    'session.read',
+    'config.read',
+    'billing.read',
+  ]),
+  operator: new Set<Action>([
+    'organization.read',
+    'member.read',
+    'node.read',
+    'node.info',
+    'evidence.read',
+    'session.read',
+    'session.message',
+    'config.read',
+    'billing.read',
+  ]),
+  admin: new Set<Action>([
+    'organization.read',
+    'member.read',
+    'member.manage',
+    'node.read',
+    'node.manage',
+    'node.info',
+    'evidence.read',
+    'session.read',
+    'session.message',
+    'config.read',
+    'config.write',
+    'billing.read',
+  ]),
+  owner: new Set<Action>([
+    'organization.read',
+    'organization.manage',
+    'member.read',
+    'member.manage',
+    'node.read',
+    'node.manage',
+    'node.info',
+    'evidence.read',
+    'session.read',
+    'session.message',
+    'config.read',
+    'config.write',
+    'billing.read',
+    'billing.manage',
+  ]),
+};
+
+export interface UserIdentity {
+  id: string;
+  email: string;
+  name: string;
+  avatar_url: string | null;
+}
+
+interface OrganizationRow {
+  id: string;
+  name: string;
+  kind: OrganizationKind;
+  plan: Plan;
+  billing_interval: 'monthly' | 'annual' | null;
+  billing_status: BillingStatus;
+  current_period_end: number | null;
+  role: Role;
+  contributor_pro: number;
+  created_at: number;
+}
+
+export interface OrganizationAccess {
+  id: string;
+  name: string;
+  kind: OrganizationKind;
+  role: Role;
+  plan: Plan;
+  effectivePlan: Plan;
+  billingInterval: 'monthly' | 'annual' | null;
+  billingStatus: BillingStatus;
+  currentPeriodEnd: number | null;
+  contributorPro: boolean;
+  createdAt: number;
+}
+
+export interface NodeAccess {
+  organization: OrganizationAccess;
+  nodeId: string;
+}
+
+export interface NodeRow {
+  id: string;
+  organization_id: string;
+  name: string;
+  version: string | null;
+  connection_mode: string;
+  last_seen_at: number;
+  created_at: number;
+}
+
+const ACTIVE_BILLING = new Set<BillingStatus>(['active', 'trialing']);
+const MANAGED_PLANS = new Set<Plan>(['pro', 'team', 'enterprise']);
+const TEAM_PLANS = new Set<Plan>(['team', 'enterprise']);
+const VALID_CONFIG_KEY = /^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$/;
+
+export function roleAllows(role: Role, action: Action): boolean {
+  return ROLE_ACTIONS[role]?.has(action) === true;
+}
+
+export function planAllowsManagedConnectivity(plan: Plan): boolean {
+  return MANAGED_PLANS.has(plan);
+}
+
+export function planAllowsMultipleMembers(plan: Plan): boolean {
+  return TEAM_PLANS.has(plan);
+}
+
+export function publicPricing() {
+  return {
+    currency: 'USD',
+    plans: [PLAN_CATALOG.free, PLAN_CATALOG.pro, PLAN_CATALOG.team, PLAN_CATALOG.enterprise],
+    contributor_benefit: {
+      entitlement: 'pro_lifetime',
+      description: 'Meaningful AgentSight contributors receive personal Pro for life.',
+      includes_team: false,
+    },
+  };
+}
+
+function effectivePlan(row: Pick<OrganizationRow, 'kind' | 'plan' | 'billing_status' | 'contributor_pro'>): Plan {
+  if (row.kind === 'personal' && Boolean(row.contributor_pro)) return 'pro';
+  if (row.plan === 'free') return 'free';
+  return ACTIVE_BILLING.has(row.billing_status) ? row.plan : 'free';
+}
+
+function organizationFromRow(row: OrganizationRow): OrganizationAccess {
+  return {
+    id: row.id,
+    name: row.name,
+    kind: row.kind,
+    role: row.role,
+    plan: row.plan,
+    effectivePlan: effectivePlan(row),
+    billingInterval: row.billing_interval,
+    billingStatus: row.billing_status,
+    currentPeriodEnd: row.current_period_end,
+    contributorPro: Boolean(row.contributor_pro),
+    createdAt: row.created_at,
+  };
+}
+
+export function personalOrganizationId(userId: string): string {
+  return `org_personal_${userId.replaceAll('-', '')}`;
+}
+
+export async function ensurePersonalOrganization(
+  db: D1Database,
+  user: Pick<UserIdentity, 'id'>,
+): Promise<string> {
+  const id = personalOrganizationId(user.id);
+  const now = nowSeconds();
+  await db.batch([
+    db.prepare(
+      `INSERT OR IGNORE INTO organizations
+       (id, name, kind, plan, billing_status, created_by_user_id, created_at, updated_at)
+       VALUES (?1, 'Personal', 'personal', 'free', 'inactive', ?2, ?3, ?3)`,
+    ).bind(id, user.id, now),
+    db.prepare(
+      `INSERT OR IGNORE INTO memberships
+       (organization_id, user_id, role, created_at, updated_at)
+       VALUES (?1, ?2, 'owner', ?3, ?3)`,
+    ).bind(id, user.id, now),
+  ]);
+  return id;
+}
+
+const ORGANIZATION_SELECT = `
+  SELECT o.id, o.name, o.kind, o.plan, o.billing_interval, o.billing_status,
+         o.current_period_end, o.created_at, m.role,
+         EXISTS(
+           SELECT 1 FROM entitlements e
+           WHERE e.user_id = m.user_id
+             AND e.kind = 'pro_lifetime'
+             AND e.revoked_at IS NULL
+             AND (e.expires_at IS NULL OR e.expires_at >= ?3)
+         ) AS contributor_pro
+  FROM organizations o
+  JOIN memberships m ON m.organization_id = o.id
+  WHERE m.user_id = ?1`;
+
+export async function listOrganizations(db: D1Database, user: UserIdentity): Promise<OrganizationAccess[]> {
+  await ensurePersonalOrganization(db, user);
+  const result = await db.prepare(`${ORGANIZATION_SELECT} ORDER BY o.kind ASC, o.created_at ASC`)
+    .bind(user.id, user.id, nowSeconds()).all<OrganizationRow>();
+  return result.results.map(organizationFromRow);
+}
+
+export async function getOrganizationAccess(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+): Promise<OrganizationAccess | null> {
+  const row = await db.prepare(`${ORGANIZATION_SELECT} AND o.id = ?2 LIMIT 1`)
+    .bind(userId, organizationId, nowSeconds()).first<OrganizationRow>();
+  return row ? organizationFromRow(row) : null;
+}
+
+export async function createOrganization(
+  db: D1Database,
+  userId: string,
+  name: string,
+): Promise<string> {
+  const normalized = name.trim();
+  if (!normalized || normalized.length > 128) throw new AccessError(400, 'invalid_organization_name');
+  const id = `org_${crypto.randomUUID().replaceAll('-', '')}`;
+  const now = nowSeconds();
+  await db.batch([
+    db.prepare(
+      `INSERT INTO organizations
+       (id, name, kind, plan, billing_status, created_by_user_id, created_at, updated_at)
+       VALUES (?1, ?2, 'team', 'free', 'inactive', ?3, ?4, ?4)`,
+    ).bind(id, normalized, userId, now),
+    db.prepare(
+      `INSERT INTO memberships
+       (organization_id, user_id, role, created_at, updated_at)
+       VALUES (?1, ?2, 'owner', ?3, ?3)`,
+    ).bind(id, userId, now),
+  ]);
+  return id;
+}
+
+export async function requireOrganizationAction(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+  action: Action,
+): Promise<OrganizationAccess> {
+  const access = await getOrganizationAccess(db, userId, organizationId);
+  if (!access) throw new AccessError(404, 'organization_not_found');
+  if (!roleAllows(access.role, action)) throw new AccessError(403, 'permission_denied');
+  return access;
+}
+
+export async function getNodeAccess(
+  db: D1Database,
+  userId: string,
+  nodeId: string,
+  action: Action,
+): Promise<NodeAccess> {
+  const row = await db.prepare('SELECT organization_id FROM nodes WHERE id = ?1')
+    .bind(nodeId).first<{ organization_id: string }>();
+  if (!row) throw new AccessError(404, 'node_not_found');
+  const organization = await requireOrganizationAction(db, userId, row.organization_id, action);
+  return { organization, nodeId };
+}
+
+export function requireManagedPlan(access: OrganizationAccess): void {
+  if (!planAllowsManagedConnectivity(access.effectivePlan)) {
+    throw new AccessError(402, 'plan_upgrade_required');
+  }
+}
+
+export function requireTeamPlan(access: OrganizationAccess): void {
+  if (!planAllowsMultipleMembers(access.effectivePlan)) {
+    throw new AccessError(402, 'team_plan_required');
+  }
+}
+
+export async function listNodes(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+): Promise<NodeRow[]> {
+  await requireOrganizationAction(db, userId, organizationId, 'node.read');
+  const result = await db.prepare(
+    `SELECT id, organization_id, name, version, connection_mode, last_seen_at, created_at
+     FROM nodes WHERE organization_id = ?1 ORDER BY last_seen_at DESC LIMIT 500`,
+  ).bind(organizationId).all<NodeRow>();
+  return result.results;
+}
+
+export async function registerNode(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+  node: { id: string; name: string; version?: string | null },
+): Promise<OrganizationAccess> {
+  const access = await requireOrganizationAction(db, userId, organizationId, 'node.manage');
+  requireManagedPlan(access);
+  const existing = await db.prepare('SELECT organization_id FROM nodes WHERE id = ?1')
+    .bind(node.id).first<{ organization_id: string }>();
+  if (existing && existing.organization_id !== organizationId) {
+    throw new AccessError(409, 'node_registered_to_another_organization');
+  }
+  const now = nowSeconds();
+  await db.prepare(
+    `INSERT INTO nodes
+     (id, organization_id, name, version, public_key, relay_token_hash, connection_mode, last_seen_at, created_at)
+     VALUES (?1, ?2, ?3, ?4, NULL, NULL, 'direct', ?5, ?5)
+     ON CONFLICT(id) DO UPDATE SET
+       name = excluded.name,
+       version = excluded.version,
+       last_seen_at = excluded.last_seen_at
+     WHERE nodes.organization_id = excluded.organization_id`,
+  ).bind(node.id, organizationId, node.name, node.version || null, now).run();
+  return access;
+}
+
+export async function deleteNode(
+  db: D1Database,
+  userId: string,
+  nodeId: string,
+): Promise<void> {
+  const access = await getNodeAccess(db, userId, nodeId, 'node.manage');
+  await db.prepare('DELETE FROM nodes WHERE id = ?1 AND organization_id = ?2')
+    .bind(nodeId, access.organization.id).run();
+}
+
+export async function listMembers(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+) {
+  await requireOrganizationAction(db, userId, organizationId, 'member.read');
+  const result = await db.prepare(
+    `SELECT u.id, u.email, u.name, u.avatar_url, m.role, m.created_at
+     FROM memberships m JOIN users u ON u.id = m.user_id
+     WHERE m.organization_id = ?1
+     ORDER BY CASE m.role WHEN 'owner' THEN 0 WHEN 'admin' THEN 1 WHEN 'operator' THEN 2 ELSE 3 END,
+              m.created_at ASC`,
+  ).bind(organizationId).all();
+  return result.results;
+}
+
+export async function createInvite(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+  email: string,
+  role: Role,
+): Promise<string> {
+  const access = await requireOrganizationAction(db, userId, organizationId, 'member.manage');
+  requireTeamPlan(access);
+  if (access.kind !== 'team') throw new AccessError(400, 'personal_organization_cannot_invite');
+  if (!['viewer', 'operator', 'admin'].includes(role)) throw new AccessError(400, 'invalid_role');
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!normalizedEmail || normalizedEmail.length > 320 || !normalizedEmail.includes('@')) {
+    throw new AccessError(400, 'invalid_email');
+  }
+  const token = randomToken();
+  const now = nowSeconds();
+  await db.prepare(
+    `INSERT INTO organization_invites
+     (token_hash, organization_id, email, role, invited_by_user_id, expires_at, consumed_at, created_at)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6, NULL, ?7)`,
+  ).bind(await sha256(token), organizationId, normalizedEmail, role, userId, now + 7 * 24 * 60 * 60, now).run();
+  return token;
+}
+
+export async function acceptInvite(
+  db: D1Database,
+  user: UserIdentity,
+  token: string,
+): Promise<string> {
+  if (!token || token.length > 512) throw new AccessError(400, 'invalid_invite');
+  const now = nowSeconds();
+  const row = await db.prepare(
+    `UPDATE organization_invites SET consumed_at = ?1
+     WHERE token_hash = ?2 AND lower(email) = lower(?3)
+       AND consumed_at IS NULL AND expires_at >= ?1
+     RETURNING organization_id, role`,
+  ).bind(now, await sha256(token), user.email).first<{ organization_id: string; role: Role }>();
+  if (!row) throw new AccessError(400, 'invite_invalid_or_expired');
+  const organization = await db.prepare(
+    `SELECT id, kind, plan, billing_status FROM organizations WHERE id = ?1`,
+  ).bind(row.organization_id).first<{ id: string; kind: OrganizationKind; plan: Plan; billing_status: BillingStatus }>();
+  if (!organization || organization.kind !== 'team') throw new AccessError(400, 'invite_invalid');
+  const paidPlan = organization.plan !== 'free' && ACTIVE_BILLING.has(organization.billing_status)
+    ? organization.plan : 'free';
+  if (!planAllowsMultipleMembers(paidPlan)) throw new AccessError(402, 'team_plan_required');
+  await db.prepare(
+    `INSERT INTO memberships (organization_id, user_id, role, created_at, updated_at)
+     VALUES (?1, ?2, ?3, ?4, ?4)
+     ON CONFLICT(organization_id, user_id) DO UPDATE SET role = excluded.role, updated_at = excluded.updated_at`,
+  ).bind(row.organization_id, user.id, row.role, now).run();
+  return row.organization_id;
+}
+
+export async function updateMemberRole(
+  db: D1Database,
+  actorUserId: string,
+  organizationId: string,
+  memberUserId: string,
+  role: Role,
+): Promise<void> {
+  const access = await requireOrganizationAction(db, actorUserId, organizationId, 'member.manage');
+  requireTeamPlan(access);
+  if (!['viewer', 'operator', 'admin'].includes(role)) throw new AccessError(400, 'invalid_role');
+  const existing = await db.prepare(
+    'SELECT role FROM memberships WHERE organization_id = ?1 AND user_id = ?2',
+  ).bind(organizationId, memberUserId).first<{ role: Role }>();
+  if (!existing) throw new AccessError(404, 'member_not_found');
+  if (existing.role === 'owner') throw new AccessError(409, 'owner_role_is_immutable');
+  await db.prepare(
+    `UPDATE memberships SET role = ?1, updated_at = ?2 WHERE organization_id = ?3 AND user_id = ?4`,
+  ).bind(role, nowSeconds(), organizationId, memberUserId).run();
+}
+
+export async function removeMember(
+  db: D1Database,
+  actorUserId: string,
+  organizationId: string,
+  memberUserId: string,
+): Promise<void> {
+  const access = await requireOrganizationAction(db, actorUserId, organizationId, 'member.manage');
+  requireTeamPlan(access);
+  const existing = await db.prepare(
+    'SELECT role FROM memberships WHERE organization_id = ?1 AND user_id = ?2',
+  ).bind(organizationId, memberUserId).first<{ role: Role }>();
+  if (!existing) return;
+  if (existing.role === 'owner') throw new AccessError(409, 'owner_cannot_be_removed');
+  await db.prepare('DELETE FROM memberships WHERE organization_id = ?1 AND user_id = ?2')
+    .bind(organizationId, memberUserId).run();
+}
+
+export async function getConfig(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+  key: string,
+) {
+  await requireOrganizationAction(db, userId, organizationId, 'config.read');
+  validateConfigKey(key);
+  const row = await db.prepare(
+    'SELECT value_json, updated_by, updated_at FROM organization_configs WHERE organization_id = ?1 AND key = ?2',
+  ).bind(organizationId, key).first<{ value_json: string; updated_by: string; updated_at: number }>();
+  if (!row) throw new AccessError(404, 'config_not_found');
+  return { key, value: JSON.parse(row.value_json), updated_by: row.updated_by, updated_at: row.updated_at };
+}
+
+export async function putConfig(
+  db: D1Database,
+  userId: string,
+  organizationId: string,
+  key: string,
+  value: unknown,
+): Promise<void> {
+  await requireOrganizationAction(db, userId, organizationId, 'config.write');
+  validateConfigKey(key);
+  const encoded = JSON.stringify(value);
+  if (new TextEncoder().encode(encoded).byteLength > 64 * 1024) throw new AccessError(413, 'config_too_large');
+  const now = nowSeconds();
+  await db.prepare(
+    `INSERT INTO organization_configs (organization_id, key, value_json, updated_by, updated_at)
+     VALUES (?1, ?2, ?3, ?4, ?5)
+     ON CONFLICT(organization_id, key) DO UPDATE SET
+       value_json = excluded.value_json, updated_by = excluded.updated_by, updated_at = excluded.updated_at`,
+  ).bind(organizationId, key, encoded, `user:${userId}`, now).run();
+}
+
+export async function setBilling(
+  db: D1Database,
+  organizationId: string,
+  input: {
+    plan: Plan;
+    interval?: 'monthly' | 'annual' | null;
+    status: BillingStatus;
+    externalCustomerId?: string | null;
+    externalSubscriptionId?: string | null;
+    currentPeriodEnd?: number | null;
+  },
+): Promise<void> {
+  if (!Object.hasOwn(PLAN_CATALOG, input.plan)) throw new AccessError(400, 'invalid_plan');
+  await db.prepare(
+    `UPDATE organizations SET
+       plan = ?1, billing_interval = ?2, billing_status = ?3,
+       external_customer_id = ?4, external_subscription_id = ?5,
+       current_period_end = ?6, updated_at = ?7
+     WHERE id = ?8`,
+  ).bind(
+    input.plan,
+    input.interval || null,
+    input.status,
+    input.externalCustomerId || null,
+    input.externalSubscriptionId || null,
+    input.currentPeriodEnd || null,
+    nowSeconds(),
+    organizationId,
+  ).run();
+}
+
+export async function grantLifetimePro(
+  db: D1Database,
+  email: string,
+  source: string,
+  sourceRef?: string | null,
+): Promise<string> {
+  const user = await db.prepare('SELECT id FROM users WHERE lower(email) = lower(?1)')
+    .bind(email.trim()).first<{ id: string }>();
+  if (!user) throw new AccessError(404, 'user_not_found');
+  const existing = await db.prepare(
+    `SELECT id FROM entitlements
+     WHERE user_id = ?1 AND kind = 'pro_lifetime' AND revoked_at IS NULL LIMIT 1`,
+  ).bind(user.id).first<{ id: string }>();
+  if (existing) return existing.id;
+  const id = `ent_${crypto.randomUUID().replaceAll('-', '')}`;
+  await db.prepare(
+    `INSERT INTO entitlements
+     (id, user_id, organization_id, kind, source, source_ref, expires_at, revoked_at, created_at)
+     VALUES (?1, ?2, NULL, 'pro_lifetime', ?3, ?4, NULL, NULL, ?5)`,
+  ).bind(id, user.id, source || 'contributor', sourceRef || null, nowSeconds()).run();
+  return id;
+}
+
+export function relayAction(method: 'GET' | 'POST', nodePath: string | null, statusOnly: boolean): Action {
+  if (statusOnly) return 'node.read';
+  if (method === 'GET' && nodePath?.startsWith('/api/v1/snapshot')) return 'evidence.read';
+  if (method === 'GET' && nodePath?.startsWith('/api/v1/sessions/')) return 'session.read';
+  if (method === 'POST' && nodePath?.endsWith('/messages')) return 'session.message';
+  throw new AccessError(403, 'permission_denied');
+}
+
+export function validNodeId(value: string): boolean {
+  return /^node_[A-Za-z0-9_]{1,123}$/.test(value);
+}
+
+export function nodeIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/v1\/nodes\/([^/]+)$/);
+  if (!match) return null;
+  try {
+    const nodeId = decodeURIComponent(match[1]);
+    return validNodeId(nodeId) ? nodeId : null;
+  } catch {
+    return null;
+  }
+}
+
+export class AccessError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string) {
+    super(code);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function validateConfigKey(key: string): void {
+  if (!VALID_CONFIG_KEY.test(key)) throw new AccessError(400, 'invalid_config_key');
+}
+
+function randomToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return base64Url(bytes);
+}
+
+function base64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+async function sha256(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(value));
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
+}

--- a/controller/src/access.ts
+++ b/controller/src/access.ts
@@ -263,7 +263,7 @@ const ORGANIZATION_SELECT = `
            WHERE e.user_id = m.user_id
              AND e.kind = 'pro_lifetime'
              AND e.revoked_at IS NULL
-             AND (e.expires_at IS NULL OR e.expires_at >= ?3)
+             AND (e.expires_at IS NULL OR e.expires_at >= ?2)
          ) AS contributor_pro
   FROM organizations o
   JOIN memberships m ON m.organization_id = o.id
@@ -272,7 +272,7 @@ const ORGANIZATION_SELECT = `
 export async function listOrganizations(db: D1Database, user: UserIdentity): Promise<OrganizationAccess[]> {
   await ensurePersonalOrganization(db, user);
   const result = await db.prepare(`${ORGANIZATION_SELECT} ORDER BY o.kind ASC, o.created_at ASC`)
-    .bind(user.id, user.id, nowSeconds()).all<OrganizationRow>();
+    .bind(user.id, nowSeconds()).all<OrganizationRow>();
   return result.results.map(organizationFromRow);
 }
 
@@ -281,8 +281,8 @@ export async function getOrganizationAccess(
   userId: string,
   organizationId: string,
 ): Promise<OrganizationAccess | null> {
-  const row = await db.prepare(`${ORGANIZATION_SELECT} AND o.id = ?2 LIMIT 1`)
-    .bind(userId, organizationId, nowSeconds()).first<OrganizationRow>();
+  const row = await db.prepare(`${ORGANIZATION_SELECT} AND o.id = ?3 LIMIT 1`)
+    .bind(userId, nowSeconds(), organizationId).first<OrganizationRow>();
   return row ? organizationFromRow(row) : null;
 }
 
@@ -374,7 +374,7 @@ export async function registerNode(
     throw new AccessError(409, 'node_registered_to_another_organization');
   }
   const now = nowSeconds();
-  await db.prepare(
+  const result = await db.prepare(
     `INSERT INTO nodes
      (id, organization_id, name, version, public_key, relay_token_hash, connection_mode, last_seen_at, created_at)
      VALUES (?1, ?2, ?3, ?4, NULL, NULL, 'direct', ?5, ?5)
@@ -384,6 +384,7 @@ export async function registerNode(
        last_seen_at = excluded.last_seen_at
      WHERE nodes.organization_id = excluded.organization_id`,
   ).bind(node.id, organizationId, node.name, node.version || null, now).run();
+  if (!result.meta.changes) throw new AccessError(409, 'node_registered_to_another_organization');
   return access;
 }
 
@@ -445,26 +446,37 @@ export async function acceptInvite(
 ): Promise<string> {
   if (!token || token.length > 512) throw new AccessError(400, 'invalid_invite');
   const now = nowSeconds();
-  const row = await db.prepare(
-    `UPDATE organization_invites SET consumed_at = ?1
-     WHERE token_hash = ?2 AND lower(email) = lower(?3)
-       AND consumed_at IS NULL AND expires_at >= ?1
-     RETURNING organization_id, role`,
-  ).bind(now, await sha256(token), user.email).first<{ organization_id: string; role: Role }>();
-  if (!row) throw new AccessError(400, 'invite_invalid_or_expired');
+  const tokenHash = await sha256(token);
+  const candidate = await db.prepare(
+    `SELECT organization_id, role FROM organization_invites
+     WHERE token_hash = ?1 AND lower(email) = lower(?2)
+       AND consumed_at IS NULL AND expires_at >= ?3`,
+  ).bind(tokenHash, user.email, now).first<{ organization_id: string; role: Role }>();
+  if (!candidate) throw new AccessError(400, 'invite_invalid_or_expired');
+
   const organization = await db.prepare(
     `SELECT id, kind, plan, billing_status FROM organizations WHERE id = ?1`,
-  ).bind(row.organization_id).first<{ id: string; kind: OrganizationKind; plan: Plan; billing_status: BillingStatus }>();
+  ).bind(candidate.organization_id)
+    .first<{ id: string; kind: OrganizationKind; plan: Plan; billing_status: BillingStatus }>();
   if (!organization || organization.kind !== 'team') throw new AccessError(400, 'invite_invalid');
   const paidPlan = organization.plan !== 'free' && ACTIVE_BILLING.has(organization.billing_status)
     ? organization.plan : 'free';
   if (!planAllowsMultipleMembers(paidPlan)) throw new AccessError(402, 'team_plan_required');
+
+  const consumed = await db.prepare(
+    `UPDATE organization_invites SET consumed_at = ?1
+     WHERE token_hash = ?2 AND lower(email) = lower(?3)
+       AND consumed_at IS NULL AND expires_at >= ?1
+     RETURNING organization_id, role`,
+  ).bind(now, tokenHash, user.email).first<{ organization_id: string; role: Role }>();
+  if (!consumed) throw new AccessError(400, 'invite_invalid_or_expired');
+
   await db.prepare(
     `INSERT INTO memberships (organization_id, user_id, role, created_at, updated_at)
      VALUES (?1, ?2, ?3, ?4, ?4)
      ON CONFLICT(organization_id, user_id) DO UPDATE SET role = excluded.role, updated_at = excluded.updated_at`,
-  ).bind(row.organization_id, user.id, row.role, now).run();
-  return row.organization_id;
+  ).bind(consumed.organization_id, user.id, consumed.role, now).run();
+  return consumed.organization_id;
 }
 
 export async function updateMemberRole(
@@ -529,6 +541,7 @@ export async function putConfig(
   await requireOrganizationAction(db, userId, organizationId, 'config.write');
   validateConfigKey(key);
   const encoded = JSON.stringify(value);
+  if (encoded === undefined) throw new AccessError(400, 'invalid_config_value');
   if (new TextEncoder().encode(encoded).byteLength > 64 * 1024) throw new AccessError(413, 'config_too_large');
   const now = nowSeconds();
   await db.prepare(
@@ -552,7 +565,7 @@ export async function setBilling(
   },
 ): Promise<void> {
   if (!Object.hasOwn(PLAN_CATALOG, input.plan)) throw new AccessError(400, 'invalid_plan');
-  await db.prepare(
+  const result = await db.prepare(
     `UPDATE organizations SET
        plan = ?1, billing_interval = ?2, billing_status = ?3,
        external_customer_id = ?4, external_subscription_id = ?5,
@@ -568,6 +581,7 @@ export async function setBilling(
     nowSeconds(),
     organizationId,
   ).run();
+  if (!result.meta.changes) throw new AccessError(404, 'organization_not_found');
 }
 
 export async function grantLifetimePro(

--- a/controller/src/core.ts
+++ b/controller/src/core.ts
@@ -22,7 +22,7 @@ interface OAuthProfile {
   avatarUrl?: string;
 }
 
-interface UserRow {
+export interface UserRow {
   id: string;
   email: string;
   name: string;
@@ -33,19 +33,12 @@ interface OAuthStartLimiter {
   limit(options: { key: string }): Promise<{ success: boolean }>;
 }
 
-interface NodeDeleteDatabase {
-  prepare(query: string): {
-    bind(...values: unknown[]): { run(): Promise<unknown> };
-  };
-}
-
 const encoder = new TextEncoder();
 const STATE_TTL_SECONDS = 10 * 60;
 const AUTH_CODE_TTL_SECONDS = 2 * 60;
 const SESSION_TTL_SECONDS = 30 * 24 * 60 * 60;
 const PKCE_CHALLENGE_PATTERN = /^[A-Za-z0-9_-]{43}$/;
 const PKCE_VERIFIER_PATTERN = /^[A-Za-z0-9_-]{43,128}$/;
-const NODE_ID_PATTERN = /^node_[A-Za-z0-9_]{1,123}$/;
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -59,7 +52,7 @@ export default {
     try {
       let response: Response;
       if (request.method === 'GET' && url.pathname === '/v1/health') {
-        response = json({ status: 'ok', service: 'agentsight-control' });
+        response = json({ status: 'ok', service: 'agentsight-controller' });
       } else if (request.method === 'GET' && url.pathname.startsWith('/v1/auth/start/')) {
         response = await startOAuth(request, env, providerFromPath(url.pathname));
       } else if (request.method === 'GET' && url.pathname.startsWith('/v1/auth/callback/')) {
@@ -70,14 +63,6 @@ export default {
         response = await logout(request, env);
       } else if (request.method === 'GET' && url.pathname === '/v1/me') {
         response = await currentUser(request, env);
-      } else if (url.pathname === '/v1/nodes' && request.method === 'GET') {
-        response = await listNodes(request, env);
-      } else if (url.pathname === '/v1/nodes' && request.method === 'POST') {
-        response = await registerNode(request, env);
-      } else if (request.method === 'DELETE' && url.pathname.startsWith('/v1/nodes/')) {
-        const nodeId = nodeIdFromPath(url.pathname);
-        if (!nodeId) throw new HttpError(404, 'not_found');
-        response = await deleteNode(request, env, nodeId);
       } else {
         response = json({ error: 'not_found' }, 404);
       }
@@ -193,7 +178,7 @@ async function exchangeAuthCode(request: Request, env: Env): Promise<Response> {
 }
 
 async function currentUser(request: Request, env: Env): Promise<Response> {
-  const user = await requireUser(request, env.DB);
+  const user = await authenticateUser(request, env.DB);
   return json(publicUser(user));
 }
 
@@ -206,55 +191,7 @@ async function logout(request: Request, env: Env): Promise<Response> {
   return new Response(null, { status: 204 });
 }
 
-async function listNodes(request: Request, env: Env): Promise<Response> {
-  const user = await requireUser(request, env.DB);
-  const result = await env.DB.prepare(
-    `SELECT id, name, version, connection_mode, last_seen_at, created_at
-     FROM nodes WHERE owner_user_id = ?1 ORDER BY last_seen_at DESC LIMIT 200`,
-  ).bind(user.id).all();
-  return json({ nodes: result.results });
-}
-
-async function registerNode(request: Request, env: Env): Promise<Response> {
-  const user = await requireUser(request, env.DB);
-  const body = await readJson<{
-    id?: string;
-    name?: string;
-    version?: string;
-  }>(request);
-  if (!body.id || !validNodeId(body.id)
-      || !body.name?.trim() || body.name.length > 128) {
-    return json({ error: 'invalid_node' }, 400);
-  }
-  const now = nowSeconds();
-  const result = await env.DB.prepare(
-    `INSERT INTO nodes (id, owner_user_id, name, version, public_key, connection_mode, last_seen_at, created_at)
-     VALUES (?1, ?2, ?3, ?4, NULL, 'direct', ?5, ?5)
-     ON CONFLICT(id) DO UPDATE SET
-       name = excluded.name, version = excluded.version,
-       connection_mode = 'direct', last_seen_at = excluded.last_seen_at
-     WHERE nodes.owner_user_id = excluded.owner_user_id`,
-  ).bind(body.id, user.id, body.name.trim(), body.version || null, now).run();
-  if (!result.meta.changes) return json({ error: 'node_owned_by_another_user' }, 409);
-  return json({ id: body.id, status: 'registered' }, 201);
-}
-
-async function deleteNode(request: Request, env: Env, nodeId: string): Promise<Response> {
-  const user = await requireUser(request, env.DB);
-  await deleteOwnedNode(env.DB, nodeId, user.id);
-  return new Response(null, { status: 204 });
-}
-
-export async function deleteOwnedNode(
-  db: NodeDeleteDatabase,
-  nodeId: string,
-  ownerUserId: string,
-): Promise<void> {
-  await db.prepare('DELETE FROM nodes WHERE id = ?1 AND owner_user_id = ?2')
-    .bind(nodeId, ownerUserId).run();
-}
-
-async function requireUser(request: Request, db: D1Database): Promise<UserRow> {
+export async function authenticateUser(request: Request, db: D1Database): Promise<UserRow> {
   const token = request.headers.get('Authorization')?.match(/^Bearer (.+)$/)?.[1];
   if (!token) throw new HttpError(401, 'authentication_required');
   const now = nowSeconds();
@@ -264,6 +201,8 @@ async function requireUser(request: Request, db: D1Database): Promise<UserRow> {
      WHERE s.token_hash = ?1 AND s.expires_at >= ?2`,
   ).bind(await sha256(token), now).first<UserRow>();
   if (!user) throw new HttpError(401, 'session_invalid_or_expired');
+  await db.prepare('UPDATE sessions SET last_seen_at = ?1 WHERE token_hash = ?2')
+    .bind(now, await sha256(token)).run();
   return user;
 }
 
@@ -440,21 +379,6 @@ export async function sha256Base64Url(value: string): Promise<string> {
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
 }
 
-export function validNodeId(value: string): boolean {
-  return NODE_ID_PATTERN.test(value);
-}
-
-export function nodeIdFromPath(pathname: string): string | null {
-  const match = pathname.match(/^\/v1\/nodes\/([^/]+)$/);
-  if (!match) return null;
-  try {
-    const nodeId = decodeURIComponent(match[1]);
-    return validNodeId(nodeId) ? nodeId : null;
-  } catch {
-    return null;
-  }
-}
-
 export function githubApiHeaders(accessToken: string): Record<string, string> {
   return {
     Authorization: `Bearer ${accessToken}`,
@@ -480,6 +404,7 @@ async function deleteExpiredRows(db: D1Database): Promise<void> {
     db.prepare('DELETE FROM oauth_states WHERE expires_at < ?1').bind(now),
     db.prepare('DELETE FROM auth_codes WHERE expires_at < ?1 OR consumed_at IS NOT NULL').bind(now),
     db.prepare('DELETE FROM sessions WHERE expires_at < ?1').bind(now),
+    db.prepare('DELETE FROM organization_invites WHERE expires_at < ?1 OR consumed_at IS NOT NULL').bind(now),
   ]);
 }
 
@@ -498,13 +423,13 @@ function cors(response: Response, env: Env): Response {
   const headers = new Headers(response.headers);
   headers.set('Access-Control-Allow-Origin', new URL(env.APP_ORIGIN).origin);
   headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
-  headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
   headers.set('X-Content-Type-Options', 'nosniff');
   headers.set('Vary', 'Origin');
   return new Response(response.body, { status: response.status, statusText: response.statusText, headers });
 }
 
-class HttpError extends Error {
+export class HttpError extends Error {
   readonly status: number;
   readonly code: string;
 

--- a/controller/src/index.test.ts
+++ b/controller/src/index.test.ts
@@ -4,9 +4,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
-  allowedReturnTo, deleteOwnedNode, githubApiHeaders, nodeIdFromPath, oauthStartAllowed,
-  sha256Base64Url, validNodeId,
+  allowedReturnTo, githubApiHeaders, nodeIdFromPath, oauthStartAllowed,
+  publicPricing, roleAllows, sha256Base64Url, validNodeId,
 } from './index.ts';
+import {
+  planAllowsManagedConnectivity,
+  planAllowsMultipleMembers,
+  relayAction,
+} from './access.ts';
 
 test('PKCE challenge matches RFC 7636 example', async () => {
   const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
@@ -23,7 +28,7 @@ test('OAuth return URL stays on the hosted app origin', () => {
   assert.equal(allowedReturnTo('not a URL', app), `${app}/`);
 });
 
-test('control plane accepts only stable AgentSight Node IDs', () => {
+test('Controller accepts only stable AgentSight Node IDs', () => {
   assert.equal(validNodeId('node_0123abcdef'), true);
   assert.equal(validNodeId('../../node_secret'), false);
   assert.equal(validNodeId('machine'), false);
@@ -36,26 +41,45 @@ test('Node deletion paths accept one validated Node ID only', () => {
   assert.equal(nodeIdFromPath('/v1/nodes/node_ok/extra'), null);
 });
 
-test('Node deletion is scoped to both Node ID and owner', async () => {
-  let query = '';
-  let bindings: unknown[] = [];
-  const db = {
-    prepare(value: string) {
-      query = value;
-      return {
-        bind(...values: unknown[]) {
-          bindings = values;
-          return { run: async () => ({}) };
-        },
-      };
-    },
-  };
-  await deleteOwnedNode(db, 'node_lab123', 'user_owner456');
-  assert.match(query, /WHERE id = \?1 AND owner_user_id = \?2/);
-  assert.deepEqual(bindings, ['node_lab123', 'user_owner456']);
+test('built-in roles grant semantic actions instead of HTTP routes', () => {
+  assert.equal(roleAllows('viewer', 'session.read'), true);
+  assert.equal(roleAllows('viewer', 'session.message'), false);
+  assert.equal(roleAllows('operator', 'session.message'), true);
+  assert.equal(roleAllows('operator', 'node.manage'), false);
+  assert.equal(roleAllows('admin', 'node.manage'), true);
+  assert.equal(roleAllows('admin', 'billing.manage'), false);
+  assert.equal(roleAllows('owner', 'billing.manage'), true);
 });
 
-test('GitHub API requests identify the control plane client', () => {
+test('pricing catalog matches launch prices and contributor boundary', () => {
+  const pricing = publicPricing();
+  const plans = Object.fromEntries(pricing.plans.map((plan) => [plan.id, plan]));
+  assert.equal(plans.free.monthly_cents, 0);
+  assert.equal(plans.pro.monthly_cents, 500);
+  assert.equal(plans.pro.annual_cents, 4900);
+  assert.equal(plans.team.monthly_cents, 1000);
+  assert.equal(plans.team.per_seat, true);
+  assert.equal(plans.enterprise.custom, true);
+  assert.equal(pricing.contributor_benefit.entitlement, 'pro_lifetime');
+  assert.equal(pricing.contributor_benefit.includes_team, false);
+});
+
+test('plan gates separate local, managed personal, and multi-member use', () => {
+  assert.equal(planAllowsManagedConnectivity('free'), false);
+  assert.equal(planAllowsManagedConnectivity('pro'), true);
+  assert.equal(planAllowsMultipleMembers('pro'), false);
+  assert.equal(planAllowsMultipleMembers('team'), true);
+  assert.equal(planAllowsMultipleMembers('enterprise'), true);
+});
+
+test('relay protocol routes map to the same semantic permissions as direct', () => {
+  assert.equal(relayAction('GET', '/api/v1/snapshot?audit_limit=100', false), 'evidence.read');
+  assert.equal(relayAction('GET', '/api/v1/sessions/s-1', false), 'session.read');
+  assert.equal(relayAction('POST', '/api/v1/sessions/s-1/messages', false), 'session.message');
+  assert.equal(relayAction('GET', null, true), 'node.read');
+});
+
+test('GitHub API requests identify the Controller client', () => {
   const headers = githubApiHeaders('test-token');
   assert.equal(headers.Authorization, 'Bearer test-token');
   assert.equal(headers['User-Agent'], 'AgentSight-Control');

--- a/controller/src/index.ts
+++ b/controller/src/index.ts
@@ -1,12 +1,43 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-import core from './core.ts';
+import core, { authenticateUser, HttpError } from './core.ts';
+import {
+  AccessError,
+  type Action,
+  type BillingStatus,
+  type Plan,
+  type Role,
+  acceptInvite,
+  createInvite,
+  createOrganization,
+  deleteNode,
+  ensurePersonalOrganization,
+  getConfig,
+  getNodeAccess,
+  getOrganizationAccess,
+  grantLifetimePro,
+  listMembers,
+  listNodes,
+  listOrganizations,
+  nodeIdFromPath,
+  publicPricing,
+  putConfig,
+  registerNode,
+  relayAction,
+  removeMember,
+  requireManagedPlan,
+  requireOrganizationAction,
+  setBilling,
+  updateMemberRole,
+  validNodeId,
+} from './access.ts';
 import {
   NodeRelay,
   browserRelayRoute,
   connectNodeRelay,
   proxyBrowserRelay,
+  proxyNodeRequest,
   relayNodeSocketId,
   saveRelayCredential,
   validRelayToken,
@@ -21,25 +52,33 @@ interface Env extends RelayEnv {
   GITHUB_CLIENT_SECRET?: string;
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
+  ADMIN_API_TOKEN?: string;
 }
+
+const NODE_CAPABILITY_ACTIONS = new Set<Action>([
+  'node.info',
+  'evidence.read',
+  'session.read',
+  'session.message',
+]);
+const BILLING_STATUSES = new Set<BillingStatus>(['inactive', 'trialing', 'active', 'past_due', 'canceled']);
+const PLANS = new Set<Plan>(['free', 'pro', 'team', 'enterprise']);
 
 export { NodeRelay };
 export {
   allowedReturnTo,
-  deleteOwnedNode,
   githubApiHeaders,
-  nodeIdFromPath,
   oauthStartAllowed,
   sha256Base64Url,
-  validNodeId,
 } from './core.ts';
+export { nodeIdFromPath, publicPricing, roleAllows, validNodeId } from './access.ts';
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    // Nodes authenticate with their persistent local bearer and keep one
-    // outbound WebSocket. This route is intentionally outside browser CORS.
+    // Node identity is deliberately separate from human identity. A Node
+    // authenticates its outbound relay with its local bootstrap credential.
     const relayNodeId = relayNodeSocketId(url.pathname);
     if (relayNodeId && request.method === 'GET') {
       return connectNodeRelay(request, env, relayNodeId);
@@ -49,66 +88,348 @@ export default {
     if (requestOrigin && requestOrigin !== new URL(env.APP_ORIGIN).origin) {
       return json({ error: 'origin_not_allowed' }, 403);
     }
+    if (request.method === 'OPTIONS') return cors(new Response(null, { status: 204 }), env);
 
-    if (request.method === 'GET' && url.pathname === '/v1/health') {
-      return cors(json({ status: 'ok', service: 'agentsight-controller' }), env);
-    }
+    try {
+      if (request.method === 'GET' && url.pathname === '/v1/pricing') {
+        return cors(json(publicPricing()), env);
+      }
 
-    const relayRoute = browserRelayRoute(request);
-    if (relayRoute) {
-      const ownerId = await authenticatedUserId(request, env);
-      if (!ownerId) return cors(json({ error: 'authentication_required' }, 401), env);
-      return cors(await proxyBrowserRelay(request, env, relayRoute, ownerId), env);
-    }
+      if (isCoreIdentityRoute(url.pathname)) {
+        return core.fetch(request, env);
+      }
 
-    // Node registration remains the same identity/ownership API. A locally
-    // bound browser may additionally enroll the same persistent bearer for
-    // relay. Only its SHA-256 hash is retained by Controller.
-    let relayEnrollment: { nodeId: string; token: string } | null = null;
-    if (request.method === 'POST' && url.pathname === '/v1/nodes') {
-      const body = await request.clone().json().catch(() => ({})) as {
-        id?: unknown;
-        relay_token?: unknown;
-      };
-      if (body.relay_token !== undefined) {
-        if (typeof body.id !== 'string'
-            || typeof body.relay_token !== 'string'
-            || !validRelayToken(body.relay_token)) {
-          return cors(json({ error: 'invalid_relay_token' }, 400), env);
+      if (url.pathname.startsWith('/v1/admin/')) {
+        return cors(await handleAdmin(request, env), env);
+      }
+
+      const user = await authenticateUser(request, env.DB);
+      await ensurePersonalOrganization(env.DB, user);
+
+      if (request.method === 'GET' && url.pathname === '/v1/organizations') {
+        return cors(json({ organizations: await listOrganizations(env.DB, user) }), env);
+      }
+
+      if (request.method === 'POST' && url.pathname === '/v1/organizations') {
+        const body = await readJson<{ name?: unknown }>(request);
+        if (typeof body.name !== 'string') throw new AccessError(400, 'invalid_organization_name');
+        const id = await createOrganization(env.DB, user.id, body.name);
+        const organization = await getOrganizationAccess(env.DB, user.id, id);
+        return cors(json({ organization }, 201), env);
+      }
+
+      if (request.method === 'POST' && url.pathname === '/v1/invitations/accept') {
+        const body = await readJson<{ token?: unknown }>(request);
+        if (typeof body.token !== 'string') throw new AccessError(400, 'invalid_invite');
+        const organizationId = await acceptInvite(env.DB, user, body.token);
+        return cors(json({ organization_id: organizationId, status: 'joined' }), env);
+      }
+
+      const organizationPath = organizationIdFromPath(url.pathname);
+      if (organizationPath && !url.pathname.includes('/members')
+          && !url.pathname.includes('/config/') && !url.pathname.endsWith('/billing')) {
+        if (request.method === 'PATCH') {
+          const access = await requireOrganizationAction(
+            env.DB, user.id, organizationPath, 'organization.manage',
+          );
+          const body = await readJson<{ name?: unknown }>(request);
+          const name = typeof body.name === 'string' ? body.name.trim() : '';
+          if (!name || name.length > 128) throw new AccessError(400, 'invalid_organization_name');
+          await env.DB.prepare('UPDATE organizations SET name = ?1, updated_at = ?2 WHERE id = ?3')
+            .bind(name, nowSeconds(), access.id).run();
+          return cors(json({ status: 'updated' }), env);
         }
-        relayEnrollment = { nodeId: body.id, token: body.relay_token };
+        if (request.method === 'DELETE') {
+          const access = await requireOrganizationAction(
+            env.DB, user.id, organizationPath, 'organization.manage',
+          );
+          if (access.kind === 'personal') throw new AccessError(409, 'personal_organization_cannot_be_deleted');
+          await env.DB.prepare('DELETE FROM organizations WHERE id = ?1').bind(access.id).run();
+          return cors(new Response(null, { status: 204 }), env);
+        }
       }
-    }
 
-    const response = await core.fetch(request, env);
-    if (relayEnrollment && response.ok) {
-      const ownerId = await authenticatedUserId(request, env);
-      if (!ownerId || !await saveRelayCredential(
-        env.DB,
-        relayEnrollment.nodeId,
-        ownerId,
-        relayEnrollment.token,
-      )) {
-        return cors(json({ error: 'relay_enrollment_failed' }, 400), env);
+      const membersPath = organizationMembersPath(url.pathname);
+      if (membersPath) {
+        if (!membersPath.memberId && request.method === 'GET') {
+          return cors(json({ members: await listMembers(env.DB, user.id, membersPath.organizationId) }), env);
+        }
+        if (!membersPath.memberId && request.method === 'POST') {
+          const body = await readJson<{ email?: unknown; role?: unknown }>(request);
+          if (typeof body.email !== 'string' || !isInviteRole(body.role)) {
+            throw new AccessError(400, 'invalid_invite');
+          }
+          const token = await createInvite(
+            env.DB, user.id, membersPath.organizationId, body.email, body.role,
+          );
+          return cors(json({
+            status: 'invited',
+            invite_url: `${new URL(env.APP_ORIGIN).origin}/#action=invite&token=${encodeURIComponent(token)}`,
+            expires_in: 7 * 24 * 60 * 60,
+          }, 201), env);
+        }
+        if (membersPath.memberId && request.method === 'PATCH') {
+          const body = await readJson<{ role?: unknown }>(request);
+          if (!isInviteRole(body.role)) throw new AccessError(400, 'invalid_role');
+          await updateMemberRole(
+            env.DB, user.id, membersPath.organizationId, membersPath.memberId, body.role,
+          );
+          return cors(json({ status: 'updated' }), env);
+        }
+        if (membersPath.memberId && request.method === 'DELETE') {
+          await removeMember(env.DB, user.id, membersPath.organizationId, membersPath.memberId);
+          return cors(new Response(null, { status: 204 }), env);
+        }
       }
+
+      const configPath = organizationConfigPath(url.pathname);
+      if (configPath) {
+        if (request.method === 'GET') {
+          return cors(json(await getConfig(
+            env.DB, user.id, configPath.organizationId, configPath.key,
+          )), env);
+        }
+        if (request.method === 'PUT') {
+          const body = await readJson<{ value?: unknown }>(request);
+          await putConfig(env.DB, user.id, configPath.organizationId, configPath.key, body.value);
+          return cors(json({ status: 'stored' }), env);
+        }
+      }
+
+      const billingOrganizationId = organizationBillingPath(url.pathname);
+      if (billingOrganizationId && request.method === 'GET') {
+        const access = await requireOrganizationAction(
+          env.DB, user.id, billingOrganizationId, 'billing.read',
+        );
+        return cors(json({
+          organization_id: access.id,
+          plan: access.plan,
+          effective_plan: access.effectivePlan,
+          billing_interval: access.billingInterval,
+          billing_status: access.billingStatus,
+          current_period_end: access.currentPeriodEnd,
+          contributor_pro: access.contributorPro,
+          price: publicPricing(),
+        }), env);
+      }
+
+      if (url.pathname === '/v1/nodes' && request.method === 'GET') {
+        const organizationId = url.searchParams.get('organization_id')
+          || await ensurePersonalOrganization(env.DB, user);
+        return cors(json({ nodes: await listNodes(env.DB, user.id, organizationId) }), env);
+      }
+
+      if (url.pathname === '/v1/nodes' && request.method === 'POST') {
+        const body = await readJson<{
+          id?: unknown;
+          organization_id?: unknown;
+          name?: unknown;
+          version?: unknown;
+          relay_token?: unknown;
+        }>(request);
+        if (typeof body.id !== 'string' || !validNodeId(body.id)
+            || typeof body.name !== 'string' || !body.name.trim() || body.name.length > 128) {
+          throw new AccessError(400, 'invalid_node');
+        }
+        const organizationId = typeof body.organization_id === 'string' && body.organization_id
+          ? body.organization_id
+          : await ensurePersonalOrganization(env.DB, user);
+        await registerNode(env.DB, user.id, organizationId, {
+          id: body.id,
+          name: body.name.trim(),
+          version: typeof body.version === 'string' ? body.version : null,
+        });
+        if (body.relay_token !== undefined) {
+          if (typeof body.relay_token !== 'string' || !validRelayToken(body.relay_token)) {
+            throw new AccessError(400, 'invalid_relay_token');
+          }
+          if (!await saveRelayCredential(env.DB, body.id, body.relay_token)) {
+            throw new AccessError(400, 'relay_enrollment_failed');
+          }
+        }
+        return cors(json({ id: body.id, organization_id: organizationId, status: 'registered' }, 201), env);
+      }
+
+      const capabilityNodeId = nodeCapabilityPath(url.pathname);
+      if (capabilityNodeId && request.method === 'POST') {
+        const body = await readJson<{
+          actions?: unknown;
+          session_id?: unknown;
+          ttl_seconds?: unknown;
+        }>(request);
+        const requested = Array.isArray(body.actions)
+          ? body.actions.filter((value): value is Action => typeof value === 'string')
+          : [];
+        if (!requested.length || requested.some((action) => !NODE_CAPABILITY_ACTIONS.has(action))) {
+          throw new AccessError(400, 'invalid_capability_actions');
+        }
+        let managedAccess = null;
+        for (const action of requested) {
+          const access = await getNodeAccess(env.DB, user.id, capabilityNodeId, action);
+          managedAccess ||= access.organization;
+        }
+        if (!managedAccess) throw new AccessError(403, 'permission_denied');
+        requireManagedPlan(managedAccess);
+        const ttlSeconds = typeof body.ttl_seconds === 'number' && Number.isFinite(body.ttl_seconds)
+          ? Math.max(30, Math.min(600, Math.floor(body.ttl_seconds)))
+          : 300;
+        const nodeResponse = await proxyNodeRequest(
+          env,
+          capabilityNodeId,
+          'POST',
+          '/api/v1/capabilities',
+          JSON.stringify({
+            actions: requested,
+            session_id: typeof body.session_id === 'string' ? body.session_id : null,
+            ttl_seconds: ttlSeconds,
+          }),
+        );
+        return cors(nodeResponse, env);
+      }
+
+      const deleteNodeId = nodeIdFromPath(url.pathname);
+      if (deleteNodeId && request.method === 'DELETE') {
+        await deleteNode(env.DB, user.id, deleteNodeId);
+        return cors(new Response(null, { status: 204 }), env);
+      }
+
+      const relayRoute = browserRelayRoute(request);
+      if (relayRoute) {
+        const action = relayAction(relayRoute.method, relayRoute.nodePath, relayRoute.statusOnly);
+        const access = await getNodeAccess(env.DB, user.id, relayRoute.nodeId, action);
+        requireManagedPlan(access.organization);
+        return cors(await proxyBrowserRelay(request, env, relayRoute), env);
+      }
+
+      return cors(json({ error: 'not_found' }, 404), env);
+    } catch (error) {
+      if (error instanceof AccessError || error instanceof HttpError) {
+        return cors(json({ error: error.code }, error.status), env);
+      }
+      console.error(error);
+      return cors(json({ error: 'internal_error' }, 500), env);
     }
-    return response;
   },
 } satisfies ExportedHandler<Env>;
 
-async function authenticatedUserId(request: Request, env: Env): Promise<string | null> {
-  const authorization = request.headers.get('Authorization');
-  if (!authorization) return null;
+async function handleAdmin(request: Request, env: Env): Promise<Response> {
+  const configured = env.ADMIN_API_TOKEN;
+  const supplied = request.headers.get('Authorization')?.match(/^Bearer (.+)$/)?.[1];
+  if (!configured || !supplied || supplied !== configured) return json({ error: 'admin_auth_required' }, 401);
   const url = new URL(request.url);
-  url.pathname = '/v1/me';
-  url.search = '';
-  const response = await core.fetch(new Request(url.toString(), {
-    method: 'GET',
-    headers: { Authorization: authorization },
-  }), env);
-  if (!response.ok) return null;
-  const body = await response.json().catch(() => ({})) as { id?: unknown };
-  return typeof body.id === 'string' ? body.id : null;
+
+  const billing = url.pathname.match(/^\/v1\/admin\/organizations\/([^/]+)\/billing$/);
+  if (billing && request.method === 'POST') {
+    const organizationId = decodeURIComponent(billing[1]);
+    const body = await readJson<{
+      plan?: unknown;
+      interval?: unknown;
+      status?: unknown;
+      external_customer_id?: unknown;
+      external_subscription_id?: unknown;
+      current_period_end?: unknown;
+    }>(request);
+    if (typeof body.plan !== 'string' || !PLANS.has(body.plan as Plan)
+        || typeof body.status !== 'string' || !BILLING_STATUSES.has(body.status as BillingStatus)
+        || (body.interval !== undefined && body.interval !== null
+          && body.interval !== 'monthly' && body.interval !== 'annual')) {
+      throw new AccessError(400, 'invalid_billing_state');
+    }
+    await setBilling(env.DB, organizationId, {
+      plan: body.plan as Plan,
+      interval: body.interval as 'monthly' | 'annual' | null | undefined,
+      status: body.status as BillingStatus,
+      externalCustomerId: typeof body.external_customer_id === 'string' ? body.external_customer_id : null,
+      externalSubscriptionId: typeof body.external_subscription_id === 'string' ? body.external_subscription_id : null,
+      currentPeriodEnd: typeof body.current_period_end === 'number' ? body.current_period_end : null,
+    });
+    return json({ status: 'updated' });
+  }
+
+  if (url.pathname === '/v1/admin/entitlements/pro-lifetime' && request.method === 'POST') {
+    const body = await readJson<{ email?: unknown; source?: unknown; source_ref?: unknown }>(request);
+    if (typeof body.email !== 'string') throw new AccessError(400, 'invalid_email');
+    const id = await grantLifetimePro(
+      env.DB,
+      body.email,
+      typeof body.source === 'string' ? body.source : 'contributor',
+      typeof body.source_ref === 'string' ? body.source_ref : null,
+    );
+    return json({ id, entitlement: 'pro_lifetime', status: 'active' }, 201);
+  }
+
+  return json({ error: 'not_found' }, 404);
+}
+
+function isCoreIdentityRoute(pathname: string): boolean {
+  return pathname === '/v1/health'
+    || pathname === '/v1/me'
+    || pathname === '/v1/auth/exchange'
+    || pathname === '/v1/auth/logout'
+    || pathname.startsWith('/v1/auth/start/')
+    || pathname.startsWith('/v1/auth/callback/');
+}
+
+function organizationIdFromPath(pathname: string): string | null {
+  const match = pathname.match(/^\/v1\/organizations\/([^/]+)$/);
+  if (!match) return null;
+  try { return decodeURIComponent(match[1]); } catch { return null; }
+}
+
+function organizationMembersPath(pathname: string): { organizationId: string; memberId: string | null } | null {
+  const match = pathname.match(/^\/v1\/organizations\/([^/]+)\/members(?:\/([^/]+))?$/);
+  if (!match) return null;
+  try {
+    return {
+      organizationId: decodeURIComponent(match[1]),
+      memberId: match[2] ? decodeURIComponent(match[2]) : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function organizationConfigPath(pathname: string): { organizationId: string; key: string } | null {
+  const match = pathname.match(/^\/v1\/organizations\/([^/]+)\/config\/([^/]+)$/);
+  if (!match) return null;
+  try {
+    return { organizationId: decodeURIComponent(match[1]), key: decodeURIComponent(match[2]) };
+  } catch {
+    return null;
+  }
+}
+
+function organizationBillingPath(pathname: string): string | null {
+  const match = pathname.match(/^\/v1\/organizations\/([^/]+)\/billing$/);
+  if (!match) return null;
+  try { return decodeURIComponent(match[1]); } catch { return null; }
+}
+
+function nodeCapabilityPath(pathname: string): string | null {
+  const match = pathname.match(/^\/v1\/nodes\/([^/]+)\/capabilities$/);
+  if (!match) return null;
+  try {
+    const id = decodeURIComponent(match[1]);
+    return validNodeId(id) ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+function isInviteRole(value: unknown): value is Exclude<Role, 'owner'> {
+  return value === 'viewer' || value === 'operator' || value === 'admin';
+}
+
+async function readJson<T>(request: Request): Promise<T> {
+  const declared = Number(request.headers.get('Content-Length') || '0');
+  if (declared > 96 * 1024) throw new AccessError(413, 'request_too_large');
+  const text = await request.text();
+  if (new TextEncoder().encode(text).byteLength > 96 * 1024) throw new AccessError(413, 'request_too_large');
+  try { return JSON.parse(text) as T; } catch { throw new AccessError(400, 'invalid_json'); }
+}
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000);
 }
 
 function json(body: unknown, status = 200): Response {
@@ -122,7 +443,7 @@ function cors(response: Response, env: Env): Response {
   const headers = new Headers(response.headers);
   headers.set('Access-Control-Allow-Origin', new URL(env.APP_ORIGIN).origin);
   headers.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
-  headers.set('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
+  headers.set('Access-Control-Allow-Methods', 'GET, POST, PUT, PATCH, DELETE, OPTIONS');
   headers.set('X-Content-Type-Options', 'nosniff');
   headers.set('Vary', 'Origin');
   return new Response(response.body, {

--- a/controller/src/relay.ts
+++ b/controller/src/relay.ts
@@ -111,14 +111,12 @@ export function validRelayToken(value: string): boolean {
 export async function saveRelayCredential(
   db: D1Database,
   nodeId: string,
-  ownerUserId: string,
   token: string,
 ): Promise<boolean> {
   if (!validRelayToken(token)) return false;
   const result = await db.prepare(
-    `UPDATE nodes SET relay_token_hash = ?1, connection_mode = 'relay'
-     WHERE id = ?2 AND owner_user_id = ?3`,
-  ).bind(await sha256(token), nodeId, ownerUserId).run();
+    `UPDATE nodes SET relay_token_hash = ?1, connection_mode = 'relay' WHERE id = ?2`,
+  ).bind(await sha256(token), nodeId).run();
   return Boolean(result.meta.changes);
 }
 
@@ -155,30 +153,30 @@ export async function proxyBrowserRelay(
   request: Request,
   env: RelayEnv,
   route: BrowserRelayRoute,
-  ownerUserId: string,
 ): Promise<Response> {
-  const owned = await env.DB.prepare(
-    'SELECT id FROM nodes WHERE id = ?1 AND owner_user_id = ?2',
-  ).bind(route.nodeId, ownerUserId).first<{ id: string }>();
-  if (!owned) return json({ error: 'node_not_found' }, 404);
-
-  const stub = relayStub(env, route.nodeId);
-  if (route.statusOnly) {
-    return stub.fetch(new Request('https://relay.internal/status'));
-  }
-
+  if (route.statusOnly) return relayStatus(env, route.nodeId);
   const body = route.method === 'POST' ? await boundedBody(request) : undefined;
   if (body instanceof Response) return body;
+  return proxyNodeRequest(env, route.nodeId, route.method, route.nodePath || '/', body);
+}
+
+export async function relayStatus(env: RelayEnv, nodeId: string): Promise<Response> {
+  return relayStub(env, nodeId).fetch(new Request('https://relay.internal/status'));
+}
+
+export async function proxyNodeRequest(
+  env: RelayEnv,
+  nodeId: string,
+  method: 'GET' | 'POST',
+  path: string,
+  body?: string,
+): Promise<Response> {
   const relayRequest = new Request('https://relay.internal/request', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      method: route.method,
-      path: route.nodePath,
-      body,
-    }),
+    body: JSON.stringify({ method, path, body }),
   });
-  return stub.fetch(relayRequest);
+  return relayStub(env, nodeId).fetch(relayRequest);
 }
 
 export class NodeRelay {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -17,14 +17,18 @@ import {
   CloudSessionExpiredError,
   type CloudIdentity,
   type CloudNode,
+  type CloudOrganization,
   type LocalConnection,
+  acceptOrganizationInvite,
   clearLocalConnection,
   consumeLaunchFragment,
+  createOrganization,
   detectEmbeddedServer,
   exchangeCloudCode,
   exchangeLocalPairing,
   fetchCloudIdentity,
   fetchCloudNodes,
+  fetchOrganizations,
   forgetCloudNode,
   loadCloudSession,
   loadLocalConnection,
@@ -48,6 +52,9 @@ import { displayEventsFromSnapshot } from '@/utils/eventProcessing';
 
 type AppMode = 'loading' | 'disconnected' | 'directory' | 'live' | 'demo';
 
+const ACTIVE_ORGANIZATION_KEY = 'agentsight.active-organization.v1';
+const PENDING_INVITE_KEY = 'agentsight.pending-invite.v1';
+
 function viewModeFromPath(pathname: string): ViewMode {
   const path = pathname.replace(/\/$/, '');
   if (path === '/overview') return 'overview';
@@ -69,6 +76,14 @@ function pathForViewMode(mode: ViewMode): string {
 
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
 
+function preferredOrganization(organizations: CloudOrganization[]): CloudOrganization | null {
+  if (!organizations.length) return null;
+  const saved = window.localStorage.getItem(ACTIVE_ORGANIZATION_KEY);
+  return organizations.find((organization) => organization.id === saved)
+    || organizations.find((organization) => organization.kind === 'personal')
+    || organizations[0];
+}
+
 export default function Home() {
   const [snapshot, setSnapshot] = useState<AgentSightSnapshot | null>(null);
   const [viewMode, setViewMode] = useState<ViewMode>('sessions');
@@ -77,6 +92,8 @@ export default function Home() {
   const [mode, setMode] = useState<AppMode>('loading');
   const [activeClient, setActiveClient] = useState<NodeClient | null>(null);
   const [identity, setIdentity] = useState<CloudIdentity | null>(null);
+  const [organizations, setOrganizations] = useState<CloudOrganization[]>([]);
+  const [activeOrganizationId, setActiveOrganizationId] = useState<string | null>(null);
   const [cloudNodes, setCloudNodes] = useState<CloudNode[]>([]);
   const [directConnections, setDirectConnections] = useState<Record<string, LocalConnection>>({});
   const [relayStatus, setRelayStatus] = useState<Record<string, boolean | null>>({});
@@ -89,11 +106,17 @@ export default function Home() {
   const displayEvents = useMemo(() => displayEventsFromSnapshot(snapshot), [snapshot]);
   const eventCount = displayEvents.length;
   const activeTransport: NodeTransport | null = activeClient?.transport ?? null;
+  const activeOrganization = useMemo(
+    () => organizations.find((organization) => organization.id === activeOrganizationId) || null,
+    [activeOrganizationId, organizations],
+  );
 
   const handleCloudError = useCallback((cause: unknown, fallback: string) => {
     const message = cause instanceof Error ? cause.message : fallback;
     if (cause instanceof CloudSessionExpiredError) {
       setIdentity(null);
+      setOrganizations([]);
+      setActiveOrganizationId(null);
       setCloudNodes([]);
       setRelayStatus({});
       setNodeError('');
@@ -144,20 +167,32 @@ export default function Home() {
     }));
   }, []);
 
-  const refreshCloudNodes = useCallback(async (token = loadCloudSession()) => {
-    if (!token) return;
+  const refreshCloudNodes = useCallback(async (
+    token = loadCloudSession(),
+    organizationId = activeOrganizationId,
+  ) => {
+    if (!token || !organizationId) return;
     setNodesLoading(true);
     try {
-      const nodes = await fetchCloudNodes(token);
+      const nodes = await fetchCloudNodes(token, organizationId);
       setCloudNodes(nodes);
       setNodeError('');
       void refreshRelayStatuses(nodes, token);
     } catch (cause) {
-      handleCloudError(cause, 'Could not load your Nodes.');
+      handleCloudError(cause, 'Could not load this organization’s Nodes.');
     } finally {
       setNodesLoading(false);
     }
-  }, [handleCloudError, refreshRelayStatuses]);
+  }, [activeOrganizationId, handleCloudError, refreshRelayStatuses]);
+
+  const loadOrganizations = useCallback(async (token: string): Promise<CloudOrganization | null> => {
+    const nextOrganizations = await fetchOrganizations(token);
+    const selected = preferredOrganization(nextOrganizations);
+    setOrganizations(nextOrganizations);
+    setActiveOrganizationId(selected?.id || null);
+    if (selected) window.localStorage.setItem(ACTIVE_ORGANIZATION_KEY, selected.id);
+    return selected;
+  }, []);
 
   const openNode = useCallback(async (nodeId: string) => {
     setLoadingNodeId(nodeId);
@@ -205,13 +240,13 @@ export default function Home() {
         setNodeError(`${relayMessage}${directMessage}`);
       }
     } else if (directFailure instanceof Error) {
-      setNodeError(`Direct failed: ${directFailure.message} Relay is unavailable; edit the Direct URL or access key.`);
+      setNodeError(`Direct failed: ${directFailure.message} Relay is unavailable; re-pair this Node to refresh its capability.`);
     } else if (cloudNode) {
       setNodeError(relay === null
-        ? 'No Direct path is saved for this browser. Relay is still being checked; configure Direct to connect by IP or URL without relay.'
-        : 'No reachable transport. Configure a Direct URL and access key, or bring Controller relay online.');
+        ? 'No Direct path is saved for this browser. Relay is still being checked.'
+        : 'No reachable transport. Re-pair Direct or bring Controller relay online.');
     } else {
-      setNodeError('This Node is not reachable from this browser. Configure a Direct URL and access key.');
+      setNodeError('This Node is not reachable from this browser. Pair it with agentsight bind.');
     }
     setLoadingNodeId(null);
   }, [cloudNodes, directConnections, relayStatus]);
@@ -219,12 +254,13 @@ export default function Home() {
   const connectDirect = useCallback(async (
     nodeId: string,
     endpoint: string,
-    accessToken: string,
+    bootstrapToken: string,
   ): Promise<boolean> => {
     setLoadingNodeId(nodeId);
     setNodeError('');
     try {
-      const connection = await probeDirectConnection(endpoint, accessToken);
+      const pairing = await probeDirectConnection(endpoint, bootstrapToken);
+      const connection = pairing.connection;
       if (connection.nodeId !== nodeId) {
         setNodeError(
           `That Direct URL belongs to ${connection.nodeName} (${connection.nodeId}), not the selected Node (${nodeId}).`,
@@ -236,8 +272,14 @@ export default function Home() {
       saveDirectConnection(connection);
       setDirectConnections(loadDirectConnections());
       const cloudToken = loadCloudSession();
-      if (cloudToken) {
-        void registerControllerNode(cloudToken, connection).catch(() => undefined);
+      if (cloudToken && activeOrganizationId) {
+        void registerControllerNode(
+          cloudToken,
+          activeOrganizationId,
+          connection,
+          pairing.bootstrapToken,
+        ).then(() => refreshCloudNodes(cloudToken, activeOrganizationId))
+          .catch((cause) => setNodeError(cause instanceof Error ? cause.message : 'Could not register this Node.'));
       }
       return true;
     } catch (cause) {
@@ -246,7 +288,7 @@ export default function Home() {
     } finally {
       setLoadingNodeId(null);
     }
-  }, [activateClient]);
+  }, [activateClient, activeOrganizationId, refreshCloudNodes]);
 
   const enterDemo = useCallback(async () => {
     setSyncing(true);
@@ -271,6 +313,8 @@ export default function Home() {
     const token = loadCloudSession();
     const wasRelay = activeClient?.transport === 'relay';
     setIdentity(null);
+    setOrganizations([]);
+    setActiveOrganizationId(null);
     setCloudNodes([]);
     setRelayStatus({});
     setNodeError('');
@@ -315,14 +359,51 @@ export default function Home() {
     setDirectConnections(loadDirectConnections());
   }, []);
 
+  const switchOrganization = useCallback((organizationId: string) => {
+    setActiveOrganizationId(organizationId);
+    window.localStorage.setItem(ACTIVE_ORGANIZATION_KEY, organizationId);
+    setCloudNodes([]);
+    setRelayStatus({});
+    setNodeError('');
+    if (activeClient?.transport === 'relay') {
+      setActiveClient(null);
+      setSnapshot(null);
+      setMode('directory');
+    }
+    void refreshCloudNodes(loadCloudSession(), organizationId);
+  }, [activeClient, refreshCloudNodes]);
+
+  const createTeam = useCallback(async () => {
+    const token = loadCloudSession();
+    if (!token) return;
+    const name = window.prompt('Organization name');
+    if (!name?.trim()) return;
+    setNodesLoading(true);
+    try {
+      const organization = await createOrganization(token, name.trim());
+      const next = [...organizations, organization];
+      setOrganizations(next);
+      switchOrganization(organization.id);
+    } catch (cause) {
+      handleCloudError(cause, 'Could not create organization.');
+    } finally {
+      setNodesLoading(false);
+    }
+  }, [handleCloudError, organizations, switchOrganization]);
+
   useEffect(() => {
     let cancelled = false;
     const initialize = async () => {
       setSyncing(true);
       try {
         const launch = consumeLaunchFragment();
+        if (launch?.get('action') === 'invite' && launch.get('token')) {
+          window.localStorage.setItem(PENDING_INVITE_KEY, launch.get('token')!);
+        }
+
         if (launch?.get('action') === 'bind') {
-          const bound = await exchangeLocalPairing(launch);
+          const pairing = await exchangeLocalPairing(launch);
+          const bound = pairing.connection;
           if (cancelled) return;
           setEmbeddedMode(bound.endpoint === window.location.origin);
           saveLocalConnection(bound);
@@ -333,14 +414,34 @@ export default function Home() {
           if (cloudToken) {
             try {
               setIdentity(await fetchCloudIdentity(cloudToken));
-              await registerControllerNode(cloudToken, bound);
-              const nodes = await fetchCloudNodes(cloudToken);
-              if (!cancelled) {
-                setCloudNodes(nodes);
-                void refreshRelayStatuses(nodes, cloudToken);
+              let selected = await loadOrganizations(cloudToken);
+              const pendingInvite = window.localStorage.getItem(PENDING_INVITE_KEY);
+              if (pendingInvite) {
+                const joined = await acceptOrganizationInvite(cloudToken, pendingInvite);
+                window.localStorage.removeItem(PENDING_INVITE_KEY);
+                const nextOrganizations = await fetchOrganizations(cloudToken);
+                setOrganizations(nextOrganizations);
+                selected = nextOrganizations.find((organization) => organization.id === joined) || selected;
+                if (selected) {
+                  setActiveOrganizationId(selected.id);
+                  window.localStorage.setItem(ACTIVE_ORGANIZATION_KEY, selected.id);
+                }
+              }
+              if (selected) {
+                await registerControllerNode(
+                  cloudToken,
+                  selected.id,
+                  bound,
+                  pairing.bootstrapToken,
+                );
+                const nodes = await fetchCloudNodes(cloudToken, selected.id);
+                if (!cancelled) {
+                  setCloudNodes(nodes);
+                  void refreshRelayStatuses(nodes, cloudToken);
+                }
               }
             } catch (cause) {
-              handleCloudError(cause, 'Could not register this Node.');
+              handleCloudError(cause, 'Direct mode is active, but this Node could not be registered in the selected organization.');
             }
           }
           return;
@@ -393,8 +494,8 @@ export default function Home() {
               localLoaded = true;
             }
           } catch {
-            // A saved Direct path is only an optimization. Login can recover
-            // the same Node through Controller relay from a fresh network.
+            // Scoped Direct capabilities expire; Controller relay or a new bind
+            // can recover without persisting the Node bootstrap key in browser storage.
           }
         }
 
@@ -402,17 +503,36 @@ export default function Home() {
           try {
             const me = await fetchCloudIdentity(cloudToken);
             if (!cancelled) setIdentity(me);
-            if (legacy && localLoaded) await registerControllerNode(cloudToken, legacy);
-            const nodes = await fetchCloudNodes(cloudToken);
-            if (!cancelled) {
-              setCloudNodes(nodes);
-              void refreshRelayStatuses(nodes, cloudToken);
-              if (!localLoaded) setMode('directory');
+            let selected = await loadOrganizations(cloudToken);
+            const pendingInvite = window.localStorage.getItem(PENDING_INVITE_KEY);
+            if (pendingInvite) {
+              const joined = await acceptOrganizationInvite(cloudToken, pendingInvite);
+              window.localStorage.removeItem(PENDING_INVITE_KEY);
+              const nextOrganizations = await fetchOrganizations(cloudToken);
+              setOrganizations(nextOrganizations);
+              selected = nextOrganizations.find((organization) => organization.id === joined) || selected;
+              if (selected) {
+                setActiveOrganizationId(selected.id);
+                window.localStorage.setItem(ACTIVE_ORGANIZATION_KEY, selected.id);
+              }
+            }
+            if (selected) {
+              const nodes = await fetchCloudNodes(cloudToken, selected.id);
+              if (!cancelled) {
+                setCloudNodes(nodes);
+                void refreshRelayStatuses(nodes, cloudToken);
+                if (!localLoaded) setMode('directory');
+              }
+            } else if (!localLoaded && !cancelled) {
+              setMode('directory');
             }
           } catch (cause) {
             if (!cancelled) handleCloudError(cause, 'Sign-in failed.');
           }
         } else if (!localLoaded && !cancelled) {
+          if (window.localStorage.getItem(PENDING_INVITE_KEY)) {
+            setError('Sign in first to accept your AgentSight organization invitation.');
+          }
           setMode('disconnected');
         }
       } catch (cause) {
@@ -426,14 +546,16 @@ export default function Home() {
     };
     void initialize();
     return () => { cancelled = true; };
-  }, [activateClient, handleCloudError, refreshRelayStatuses]);
+  }, [activateClient, handleCloudError, loadOrganizations, refreshRelayStatuses]);
 
   useEffect(() => { setViewMode(viewModeFromPath(window.location.pathname)); }, []);
 
   useEffect(() => {
     const handleLaunchFragment = () => {
       const action = new URLSearchParams(window.location.hash.slice(1)).get('action');
-      if (action === 'bind' || action === 'auth' || action === 'auth-error') window.location.reload();
+      if (action === 'bind' || action === 'auth' || action === 'auth-error' || action === 'invite') {
+        window.location.reload();
+      }
     };
     window.addEventListener('hashchange', handleLaunchFragment);
     return () => { window.removeEventListener('hashchange', handleLaunchFragment); };
@@ -481,6 +603,22 @@ export default function Home() {
         <div className="mx-auto flex max-w-[1500px] flex-wrap items-center justify-between gap-3 px-4 py-3 sm:px-6 lg:px-8">
           <div className="flex min-w-0 items-center gap-3">
             <a href="/" className="text-lg font-semibold tracking-tight">AgentSight</a>
+            {identity && activeOrganization && (
+              <div className="flex items-center gap-2">
+                <select value={activeOrganization.id} onChange={(event) => switchOrganization(event.target.value)}
+                  className="max-w-48 rounded-lg border border-slate-300 bg-white px-2.5 py-1.5 text-xs font-medium text-slate-700">
+                  {organizations.map((organization) => (
+                    <option key={organization.id} value={organization.id}>
+                      {organization.name} · {organization.effectivePlan}
+                    </option>
+                  ))}
+                </select>
+                <button type="button" onClick={() => { void createTeam(); }}
+                  className="hidden text-xs font-medium text-slate-500 hover:text-slate-900 sm:inline">
+                  + Organization
+                </button>
+              </div>
+            )}
             {activeClient && isLive && (
               <span className="flex min-w-0 items-center gap-2 rounded-full bg-slate-100 px-3 py-1.5 text-xs text-slate-700">
                 <span className="h-2 w-2 shrink-0 rounded-full bg-emerald-500" />

--- a/frontend/src/components/NodeManager.tsx
+++ b/frontend/src/components/NodeManager.tsx
@@ -29,7 +29,7 @@ interface NodeManagerProps {
   modal?: boolean;
   onClose?: () => void;
   onOpenNode: (nodeId: string) => void;
-  onConnectDirect: (nodeId: string, endpoint: string, accessToken: string) => Promise<boolean>;
+  onConnectDirect: (nodeId: string, endpoint: string, bootstrapToken: string) => Promise<boolean>;
   onRefresh: () => void;
   onForgetNode: (nodeId: string) => void;
   onForgetDirect: (nodeId: string) => void;
@@ -76,7 +76,7 @@ export function NodeManager({
   const [copyState, setCopyState] = useState<'idle' | 'copied' | 'failed'>('idle');
   const [directEditorNodeId, setDirectEditorNodeId] = useState<string | null>(null);
   const [directEndpoint, setDirectEndpoint] = useState('');
-  const [directAccessKey, setDirectAccessKey] = useState('');
+  const [directBootstrapKey, setDirectBootstrapKey] = useState('');
   const [directConnecting, setDirectConnecting] = useState(false);
 
   const visibleNodes = useMemo(() => {
@@ -85,6 +85,7 @@ export function NodeManager({
       if (!byId.has(connection.nodeId)) {
         byId.set(connection.nodeId, {
           id: connection.nodeId,
+          organizationId: '',
           name: connection.nodeName,
           version: connection.version,
           connectionMode: 'direct',
@@ -110,13 +111,15 @@ export function NodeManager({
     const direct = connections[nodeId];
     setDirectEditorNodeId(nodeId);
     setDirectEndpoint(direct?.endpoint || '');
-    setDirectAccessKey(direct?.accessToken || '');
+    // Saved Direct credentials are scoped capabilities. Re-pairing deliberately
+    // asks for the bootstrap key again rather than persisting root authority.
+    setDirectBootstrapKey('');
   };
 
   const closeDirectEditor = () => {
     setDirectEditorNodeId(null);
     setDirectEndpoint('');
-    setDirectAccessKey('');
+    setDirectBootstrapKey('');
   };
 
   const submitDirect = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -124,7 +127,7 @@ export function NodeManager({
     if (!directEditorNodeId || directConnecting) return;
     setDirectConnecting(true);
     try {
-      if (await onConnectDirect(directEditorNodeId, directEndpoint, directAccessKey)) {
+      if (await onConnectDirect(directEditorNodeId, directEndpoint, directBootstrapKey)) {
         closeDirectEditor();
       }
     } finally {
@@ -230,7 +233,7 @@ export function NodeManager({
                       disabled={loading || directConnecting}
                       className="inline-flex w-full items-center justify-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium text-blue-700 hover:bg-blue-50 hover:text-blue-900 disabled:opacity-50 sm:w-auto sm:py-1">
                       <CommandLineIcon className="h-3.5 w-3.5 shrink-0" />
-                      <span className="whitespace-nowrap">{editingDirect ? 'Cancel Direct' : direct ? 'Edit Direct' : 'Connect Direct'}</span>
+                      <span className="whitespace-nowrap">{editingDirect ? 'Cancel Direct' : direct ? 'Re-pair Direct' : 'Connect Direct'}</span>
                     </button>
                     {direct && (
                       <button type="button" onClick={() => onForgetDirect(node.id)} disabled={loading || directConnecting}
@@ -240,7 +243,7 @@ export function NodeManager({
                     )}
                     {cloudManaged && (
                       <button type="button" onClick={() => {
-                        if (window.confirm(`Remove ${node.name} from this account?`)) onForgetNode(node.id);
+                        if (window.confirm(`Remove ${node.name} from this organization?`)) onForgetNode(node.id);
                       }} disabled={loading || directConnecting}
                         className="inline-flex w-full items-center justify-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium text-slate-500 hover:bg-red-50 hover:text-red-700 disabled:opacity-50 sm:w-auto sm:py-1">
                         <TrashIcon className="h-3.5 w-3.5 shrink-0" />
@@ -261,19 +264,19 @@ export function NodeManager({
                           className="mt-1 min-w-0 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:border-blue-500" />
                       </div>
                       <div className="min-w-0">
-                        <label className="text-xs font-medium text-slate-700" htmlFor={`direct-key-${node.id}`}>Node access key</label>
-                        <input id={`direct-key-${node.id}`} type="password" required value={directAccessKey}
-                          onChange={(event) => setDirectAccessKey(event.target.value)}
-                          placeholder="Persistent access key from agentsight bind"
+                        <label className="text-xs font-medium text-slate-700" htmlFor={`direct-key-${node.id}`}>Node bootstrap key</label>
+                        <input id={`direct-key-${node.id}`} type="password" required value={directBootstrapKey}
+                          onChange={(event) => setDirectBootstrapKey(event.target.value)}
+                          placeholder="Bootstrap key from agentsight bind"
                           spellCheck={false} autoCapitalize="none" autoCorrect="off"
                           className="mt-1 min-w-0 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-sm text-slate-900 outline-none focus:border-blue-500" />
                       </div>
                       <p className="break-words text-xs leading-5 text-slate-500">
-                        This browser probes <code>/api/v1/info</code> directly and verifies that the URL belongs to this Node. Relay is not required.
+                        The bootstrap key is used once to verify the Node and mint a scoped browser capability. AgentSight stores the scoped capability, not the bootstrap key.
                       </p>
                       <button type="submit" disabled={directConnecting || loading}
                         className="w-full rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50 sm:w-auto">
-                        {directConnecting ? 'Testing Direct…' : 'Test and connect'}
+                        {directConnecting ? 'Pairing Direct…' : 'Pair and connect'}
                       </button>
                     </form>
                   )}
@@ -312,7 +315,7 @@ export function NodeManager({
         <div className="flex min-w-0 flex-wrap items-center justify-between gap-3 border-t border-slate-200 pt-4">
           <div className="flex min-w-0 items-center gap-2 text-xs text-slate-500">
             <SignalIcon className="h-4 w-4 shrink-0" />
-            <span>Controller stores identity and Node metadata; Direct and relay are independent Node transports.</span>
+            <span>Controller stores identity, organization access, plan, and Node metadata. Detailed runtime evidence remains on Nodes.</span>
           </div>
           <div className="flex items-center gap-4">
             <button type="button" onClick={onDemo} className="text-sm font-medium text-slate-600 hover:text-slate-950">

--- a/frontend/src/lib/connection.ts
+++ b/frontend/src/lib/connection.ts
@@ -6,8 +6,10 @@ const CLOUD_SESSION_KEY = 'agentsight.cloud-session.v1';
 const OAUTH_VERIFIER_KEY = 'agentsight.oauth-verifier.v1';
 const CLOUD_TIMEOUT_MS = 8_000;
 const LOCAL_TIMEOUT_MS = 8_000;
+const DIRECT_CAPABILITY_TTL_SECONDS = 12 * 60 * 60;
+const DIRECT_ACTIONS = ['node.info', 'evidence.read', 'session.read', 'session.message'] as const;
 let cachedLaunchFragment: URLSearchParams | null | undefined;
-let localPairingExchange: Promise<LocalConnection> | null = null;
+let localPairingExchange: Promise<LocalPairing> | null = null;
 let cloudCodeExchange: Promise<string> | null = null;
 
 export const controllerUrl = (
@@ -24,12 +26,34 @@ export interface LocalConnection {
   version: string;
 }
 
+export interface LocalPairing {
+  connection: LocalConnection;
+  bootstrapToken: string;
+}
+
 export interface CloudIdentity {
   id: string;
   email: string;
   name: string;
   avatarUrl?: string;
   provider?: 'github' | 'google';
+}
+
+export type OrganizationRole = 'viewer' | 'operator' | 'admin' | 'owner';
+export type OrganizationPlan = 'free' | 'pro' | 'team' | 'enterprise';
+
+export interface CloudOrganization {
+  id: string;
+  name: string;
+  kind: 'personal' | 'team';
+  role: OrganizationRole;
+  plan: OrganizationPlan;
+  effectivePlan: OrganizationPlan;
+  billingInterval: 'monthly' | 'annual' | null;
+  billingStatus: 'inactive' | 'trialing' | 'active' | 'past_due' | 'canceled';
+  currentPeriodEnd: number | null;
+  contributorPro: boolean;
+  createdAt: number;
 }
 
 export class CloudSessionExpiredError extends Error {
@@ -41,6 +65,7 @@ export class CloudSessionExpiredError extends Error {
 
 export interface CloudNode {
   id: string;
+  organizationId: string;
   name: string;
   version: string | null;
   connectionMode: 'direct' | 'relay';
@@ -116,6 +141,10 @@ function normalizeNodeEndpoint(raw: string): string {
   return endpoint.toString().replace(/\/$/, '');
 }
 
+function validCredential(value: string): boolean {
+  return /^[A-Za-z0-9_-]{32,256}$/.test(value);
+}
+
 export interface EmbeddedServer {
   authorizationRequired: boolean;
   connection: LocalConnection;
@@ -161,25 +190,25 @@ export function consumeLaunchFragment(): URLSearchParams | null {
   return cachedLaunchFragment;
 }
 
-export function exchangeLocalPairing(params: URLSearchParams): Promise<LocalConnection> {
+export function exchangeLocalPairing(params: URLSearchParams): Promise<LocalPairing> {
   if (!localPairingExchange) localPairingExchange = exchangeLocalPairingOnce(params);
   return localPairingExchange;
 }
 
-async function exchangeLocalPairingOnce(params: URLSearchParams): Promise<LocalConnection> {
+async function exchangeLocalPairingOnce(params: URLSearchParams): Promise<LocalPairing> {
   if (params.get('action') !== 'bind' || params.get('v') !== '1') {
     throw new Error('Unsupported AgentSight binding link.');
   }
-  const accessToken = params.get('token');
+  const bootstrapToken = params.get('token') || '';
   const endpoint = normalizeNodeEndpoint(params.get('endpoint') || '');
-  if (!accessToken || !/^[A-Za-z0-9_-]{32,256}$/.test(accessToken)) {
-    throw new Error('The binding link is missing a valid access key.');
+  if (!validCredential(bootstrapToken)) {
+    throw new Error('The binding link is missing a valid bootstrap key.');
   }
 
   let response: Response;
   try {
     response = await nodeFetch(`${endpoint}/api/v1/info`, {
-      headers: { Authorization: `Bearer ${accessToken}` },
+      headers: { Authorization: `Bearer ${bootstrapToken}` },
     });
   } catch {
     throw new Error(
@@ -193,12 +222,51 @@ async function exchangeLocalPairingOnce(params: URLSearchParams): Promise<LocalC
   if (!body.node?.id || !body.node.name) {
     throw new Error('AgentSight returned an invalid binding response.');
   }
-  return {
+  const scoped = await mintNodeCapability(
     endpoint,
-    accessToken,
-    nodeId: body.node.id,
-    nodeName: body.node.name,
-    version: body.node.version || 'unknown',
+    bootstrapToken,
+    [...DIRECT_ACTIONS],
+    DIRECT_CAPABILITY_TTL_SECONDS,
+  );
+  return {
+    bootstrapToken,
+    connection: {
+      endpoint,
+      accessToken: scoped.accessToken,
+      nodeId: body.node.id,
+      nodeName: body.node.name,
+      version: body.node.version || 'unknown',
+    },
+  };
+}
+
+export async function mintNodeCapability(
+  endpoint: string,
+  bootstrapToken: string,
+  actions: string[],
+  ttlSeconds: number,
+  sessionId?: string | null,
+): Promise<{ accessToken: string; expiresAt: number }> {
+  const response = await nodeFetch(`${normalizeNodeEndpoint(endpoint)}/api/v1/capabilities`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${bootstrapToken}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      actions,
+      session_id: sessionId || null,
+      ttl_seconds: ttlSeconds,
+    }),
+  });
+  if (!response.ok) throw new Error(`AgentSight capability exchange failed (${response.status}).`);
+  const body = await response.json() as { access_token?: unknown; expires_at?: unknown };
+  if (typeof body.access_token !== 'string' || !validCredential(body.access_token)) {
+    throw new Error('AgentSight returned an invalid capability.');
+  }
+  return {
+    accessToken: body.access_token,
+    expiresAt: typeof body.expires_at === 'number' ? body.expires_at : 0,
   };
 }
 
@@ -216,7 +284,7 @@ export function loadLocalConnection(): LocalConnection | null {
       || typeof parsed.nodeId !== 'string'
       || typeof parsed.nodeName !== 'string'
       || typeof parsed.version !== 'string'
-      || !/^[A-Za-z0-9_-]{32,256}$/.test(parsed.accessToken)) {
+      || !validCredential(parsed.accessToken)) {
       throw new Error('invalid saved local connection');
     }
     return { ...parsed, endpoint: normalizeNodeEndpoint(parsed.endpoint) } as LocalConnection;
@@ -267,12 +335,13 @@ export function loadCloudSession(): string | null {
   return window.localStorage.getItem(CLOUD_SESSION_KEY);
 }
 
-function throwCloudResponseError(response: Response, message: string): never {
+async function cloudResponseError(response: Response, message: string): Promise<never> {
   if (response.status === 401) {
     window.localStorage.removeItem(CLOUD_SESSION_KEY);
     throw new CloudSessionExpiredError();
   }
-  throw new Error(`${message} (${response.status}).`);
+  const body = await response.json().catch(() => ({})) as { error?: string };
+  throw new Error(body.error || `${message} (${response.status}).`);
 }
 
 export async function signOutCloud(token: string | null): Promise<void> {
@@ -289,21 +358,57 @@ export async function fetchCloudIdentity(token: string): Promise<CloudIdentity> 
     headers: { Authorization: `Bearer ${token}` },
     cache: 'no-store',
   });
-  if (!response.ok) {
-    throwCloudResponseError(response, 'The AgentSight Controller request failed');
-  }
+  if (!response.ok) await cloudResponseError(response, 'The AgentSight Controller request failed');
   return response.json() as Promise<CloudIdentity>;
 }
 
-export async function fetchCloudNodes(token: string): Promise<CloudNode[]> {
-  const response = await cloudFetch(`${controllerUrl}/v1/nodes`, {
+export async function fetchOrganizations(token: string): Promise<CloudOrganization[]> {
+  const response = await cloudFetch(`${controllerUrl}/v1/organizations`, {
     headers: { Authorization: `Bearer ${token}` },
     cache: 'no-store',
   });
-  if (!response.ok) throwCloudResponseError(response, 'Could not load your Nodes');
+  if (!response.ok) await cloudResponseError(response, 'Could not load organizations');
+  const body = await response.json() as { organizations?: CloudOrganization[] };
+  if (!Array.isArray(body.organizations)) throw new Error('The Controller returned an invalid organization list.');
+  return body.organizations;
+}
+
+export async function createOrganization(token: string, name: string): Promise<CloudOrganization> {
+  const response = await cloudFetch(`${controllerUrl}/v1/organizations`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!response.ok) await cloudResponseError(response, 'Could not create organization');
+  const body = await response.json() as { organization?: CloudOrganization };
+  if (!body.organization) throw new Error('The Controller returned an invalid organization.');
+  return body.organization;
+}
+
+export async function acceptOrganizationInvite(token: string, inviteToken: string): Promise<string> {
+  const response = await cloudFetch(`${controllerUrl}/v1/invitations/accept`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: inviteToken }),
+  });
+  if (!response.ok) await cloudResponseError(response, 'Could not accept invitation');
+  const body = await response.json() as { organization_id?: unknown };
+  if (typeof body.organization_id !== 'string') throw new Error('The Controller returned an invalid invitation response.');
+  return body.organization_id;
+}
+
+export async function fetchCloudNodes(token: string, organizationId: string): Promise<CloudNode[]> {
+  const url = new URL(`${controllerUrl}/v1/nodes`);
+  url.searchParams.set('organization_id', organizationId);
+  const response = await cloudFetch(url.toString(), {
+    headers: { Authorization: `Bearer ${token}` },
+    cache: 'no-store',
+  });
+  if (!response.ok) await cloudResponseError(response, 'Could not load Nodes');
   const body = await response.json() as {
     nodes?: Array<{
       id?: string;
+      organization_id?: string;
       name?: string;
       version?: string | null;
       connection_mode?: string;
@@ -316,6 +421,7 @@ export async function fetchCloudNodes(token: string): Promise<CloudNode[]> {
     .filter((node) => typeof node.id === 'string' && typeof node.name === 'string')
     .map((node) => ({
       id: node.id!,
+      organizationId: typeof node.organization_id === 'string' ? node.organization_id : organizationId,
       name: node.name!,
       version: typeof node.version === 'string' ? node.version : null,
       connectionMode: node.connection_mode === 'relay' ? 'relay' : 'direct',
@@ -329,5 +435,5 @@ export async function forgetCloudNode(token: string, nodeId: string): Promise<vo
     method: 'DELETE',
     headers: { Authorization: `Bearer ${token}` },
   });
-  if (!response.ok) throwCloudResponseError(response, 'Could not remove this Node');
+  if (!response.ok) await cloudResponseError(response, 'Could not remove this Node');
 }

--- a/frontend/src/lib/nodeClient.ts
+++ b/frontend/src/lib/nodeClient.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2026 eunomia-bpf org.
 
-import { controllerUrl, type CloudNode, type LocalConnection } from '@/lib/connection';
+import {
+  controllerUrl,
+  mintNodeCapability,
+  type CloudNode,
+  type LocalConnection,
+} from '@/lib/connection';
 import initProtocol, {
   session_message_body as sessionMessageBody,
   session_messages_path as sessionMessagesPath,
@@ -12,6 +17,8 @@ import type { AgentSightSnapshot } from '@/types/event';
 
 const DIRECT_CONNECTIONS_KEY = 'agentsight.direct-connections.v1';
 const REQUEST_TIMEOUT_MS = 12_000;
+const DIRECT_CAPABILITY_TTL_SECONDS = 12 * 60 * 60;
+const DIRECT_ACTIONS = ['node.info', 'evidence.read', 'session.read', 'session.message'];
 let protocolReady: Promise<unknown> | null = null;
 
 type NodeAddressSpace = 'local' | 'loopback';
@@ -39,6 +46,11 @@ export interface NodeClient {
   snapshot(): Promise<AgentSightSnapshot>;
   session(sessionId: string): Promise<SessionDetail>;
   submitMessage(sessionId: string, message: string): Promise<void>;
+}
+
+export interface DirectProbeResult {
+  connection: LocalConnection;
+  bootstrapToken: string;
 }
 
 export class NodeRequestError extends Error {
@@ -89,7 +101,7 @@ function normalizeDirectEndpoint(raw: string): string {
   return endpoint.toString().replace(/\/$/, '');
 }
 
-function validAccessToken(value: string): boolean {
+function validCredential(value: string): boolean {
   return /^[A-Za-z0-9_-]{32,256}$/.test(value);
 }
 
@@ -126,12 +138,12 @@ async function jsonResponse<T>(response: Response, fallback: string): Promise<T>
 
 export async function probeDirectConnection(
   rawEndpoint: string,
-  accessToken: string,
-): Promise<LocalConnection> {
+  bootstrapToken: string,
+): Promise<DirectProbeResult> {
   const endpoint = normalizeDirectEndpoint(rawEndpoint);
-  const token = accessToken.trim();
-  if (!validAccessToken(token)) {
-    throw new NodeRequestError(400, 'Access key must be the persistent AgentSight Node access key.');
+  const token = bootstrapToken.trim();
+  if (!validCredential(token)) {
+    throw new NodeRequestError(400, 'Bootstrap key must be a valid AgentSight Node credential.');
   }
 
   let response: Response;
@@ -151,12 +163,29 @@ export async function probeDirectConnection(
   if (!body.node?.id || !body.node.name) {
     throw new NodeRequestError(502, 'The Direct URL did not return valid AgentSight Node metadata.');
   }
+  let scoped: { accessToken: string };
+  try {
+    scoped = await mintNodeCapability(
+      endpoint,
+      token,
+      DIRECT_ACTIONS,
+      DIRECT_CAPABILITY_TTL_SECONDS,
+    );
+  } catch (cause) {
+    throw new NodeRequestError(
+      cause instanceof NodeRequestError ? cause.status : 401,
+      'That credential can inspect this Node but cannot mint Direct capabilities. Use the Node bootstrap key.',
+    );
+  }
   return {
-    endpoint,
-    accessToken: token,
-    nodeId: body.node.id,
-    nodeName: body.node.name,
-    version: body.node.version || 'unknown',
+    bootstrapToken: token,
+    connection: {
+      endpoint,
+      accessToken: scoped.accessToken,
+      nodeId: body.node.id,
+      nodeName: body.node.name,
+      version: body.node.version || 'unknown',
+    },
   };
 }
 
@@ -237,9 +266,35 @@ export async function relayOnline(token: string, nodeId: string): Promise<boolea
   return body.online === true;
 }
 
+export async function requestControllerNodeCapability(
+  token: string,
+  nodeId: string,
+  actions: string[],
+  sessionId?: string | null,
+): Promise<{ accessToken: string; expiresAt: number }> {
+  const response = await fetch(`${controllerUrl}/v1/nodes/${encodeURIComponent(nodeId)}/capabilities`, {
+    method: 'POST',
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ actions, session_id: sessionId || null, ttl_seconds: 300 }),
+  });
+  return jsonResponse<{
+    access_token: string;
+    expires_at: number;
+  }>(response, 'Could not obtain Node capability').then((body) => ({
+    accessToken: body.access_token,
+    expiresAt: body.expires_at,
+  }));
+}
+
 export async function registerControllerNode(
   token: string,
+  organizationId: string,
   connection: LocalConnection,
+  bootstrapToken: string,
 ): Promise<void> {
   const response = await fetch(`${controllerUrl}/v1/nodes`, {
     method: 'POST',
@@ -250,9 +305,10 @@ export async function registerControllerNode(
     },
     body: JSON.stringify({
       id: connection.nodeId,
+      organization_id: organizationId,
       name: connection.nodeName,
       version: connection.version,
-      ...(connection.accessToken ? { relay_token: connection.accessToken } : {}),
+      relay_token: bootstrapToken,
     }),
   });
   if (!response.ok) {
@@ -275,7 +331,8 @@ export function loadDirectConnections(): Record<string, LocalConnection> {
           && typeof connection.endpoint === 'string'
           && typeof connection.accessToken === 'string'
           && typeof connection.nodeName === 'string'
-          && typeof connection.version === 'string') {
+          && typeof connection.version === 'string'
+          && validCredential(connection.accessToken)) {
         result[nodeId] = connection;
       }
     }


### PR DESCRIPTION
## Summary

Replace account-owned Node authorization with an organization + capability model that supports Personal, Team, and Enterprise without teaching Nodes about users, owners, memberships, RBAC, or billing.

## Authorization model

- OAuth identifies a human user only.
- Organizations are the administrative and billing boundary; one user can belong to several.
- Every account gets a personal organization; team organizations use the same model.
- Membership roles are `viewer`, `operator`, `admin`, and `owner` and map to semantic actions rather than HTTP routes.
- Nodes are registered into an organization namespace, never owned by a user.
- The Node protocol locally enforces scoped capabilities: `node.info`, `evidence.read`, `session.read`, and `session.message`, optionally restricted to one session.
- The persistent Node credential is bootstrap/relay identity. Browser Direct pairing exchanges it for a `cap_*` credential and does not persist root authority.
- Long-lived Direct capabilities are persisted locally on the Node with expiry so a Node restart does not force re-pairing; short relay capabilities remain process-local.
- Relay requests are authorized by Controller membership/plan state, then translated by the Node relay client into a short-lived local Node capability before the WebServer sees the operation.
- Controller stores identity, membership, organization config, plan/entitlement metadata, Node discovery, and relay state. Runtime evidence stays authoritative on Nodes.

## Plans and entitlements

Canonical catalog is exposed at `GET /v1/pricing` and enforced at Controller boundaries:

- **Free**: $0; local/direct open-source use.
- **Pro**: $5/month or $49/year; managed Node registration/connectivity for a personal organization.
- **Team**: $10/user/month; multi-member organization/fleet plus built-in roles.
- **Enterprise**: custom.
- `pro_lifetime`: personal Pro entitlement for meaningful AgentSight contributors; it does not waive Team/Enterprise billing.

Billing state is provider-neutral (`trialing`, `active`, `past_due`, etc.) and can be updated by privileged deployment automation through `ADMIN_API_TOKEN`. Payment-processor checkout/webhook integration is intentionally outside the authorization primitive.

## Team/config surfaces

- organization create/list/update/delete
- member list/invite/accept/role update/remove
- organization config read/write
- organization-scoped Node registry
- role-checked Node relay and capability minting
- billing/entitlement state and plan gates

## Migration

`0005_organizations_pricing_capabilities.sql`:

- creates organizations, memberships, config, entitlements, and invites;
- creates personal organizations and owner memberships for existing users;
- rebuilds `nodes` with `organization_id` and removes `owner_user_id`;
- preserves existing Node metadata and relay credential hashes.

Migration was exercised locally against the actual `0001 -> 0004` schema with an existing user + relay Node. Node data migrated to the personal organization and `PRAGMA foreign_key_check` returned no violations.

## Validation

Temporary PR #172 is pinned to exact final head `248cc444e6d1c5895a9eb0e886af82de2acbb410` after the Direct capability persistence fix. Exact-head frontend/WASM build, Controller tests/typecheck/Wrangler dry-run, collector build, E2E canary, strict clippy, Rust tests, agentpprof checks, ASan, and macOS smoke have passed; the architecture release-binary job is the remaining final gate.