### PR TITLE
ci: install wasm target for release builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,7 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+        target: wasm32-unknown-unknown
 
     - name: Set release version
       id: set_version


### PR DESCRIPTION
## Summary

- install the wasm32-unknown-unknown Rust target in the master-only release preparation job
- unblock wasm-pack when make build vendors the frontend into the release snapshot

## Evidence

The post-merge run for #175 passed its full Build and Test job, then failed only in Prepare Release Snapshot while running 
pm run build:wasm; wasm-pack exited before compilation because the release job had not installed the wasm target. The PR/Cloudflare paths already install this target separately.