### PR TITLE
docs: add installation and startup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ Native Windows builds are exercised by the Windows CI workflow; until a Windows
 release asset is published, download its `agentsight-windows-x86_64` artifact or
 build the collector crate from source.
 
+For Linux and Windows installation, background monitoring, Node binding,
+automatic startup, upgrades, and removal, see
+[Installation and Automatic Startup](docs/installation.md).
+
 #### Docker
 
 Docker is useful for container, CI, or isolated Linux environments, but it still needs privileged host access for eBPF. See [docs/docker.md](https://github.com/eunomia-bpf/agentsight/blob/master/docs/docker.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,6 +100,9 @@ GitHub Release 为 Linux 提供 `agentsight-x86_64` 和 `agentsight-aarch64`；
 Windows 原生构建由 Windows CI 验证；正式发布 Windows Release 资产前，可以下载
 该工作流的 `agentsight-windows-x86_64` artifact，或从源码构建 collector crate。
 
+Linux 与 Windows 的安装、后台监控、Node 绑定、自动启动、升级和卸载步骤，参见
+[安装与开机启动](docs/installation.zh-CN.md)。
+
 #### Docker
 
 AgentSight 通过 Docker 运行，使用 `--privileged` 以支持 eBPF，`--pid=host` 以访问宿主机进程，`-v /sys:/sys:ro` 用于进程监控，`-v /usr:/usr:ro -v /lib:/lib:ro` 用于访问 SSL 库（在共享库如 `libssl.so` 上附加 uprobe 所需）。示例：

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,247 @@
+# Installation and Automatic Startup
+
+This guide installs the portable AgentSight CLI for one user and keeps its
+background processes running after restart.
+
+`monitor` and `bind` have different jobs:
+
+- `monitor` samples active agent sessions and writes weekly databases under
+  `~/.agentsight/monitor`.
+- `bind` serves the authenticated Node API and maintains the outbound Controller
+  relay. The examples below listen only on `127.0.0.1:7395`; they do not expose a
+  new LAN or public port.
+
+The portable commands use native Claude, Codex, Gemini, OpenCode, and OpenClaw
+session files on Windows, macOS, and Linux. The eBPF-backed `record` and debug
+commands remain Linux-only and have additional privilege requirements.
+
+## Linux
+
+### Install a release binary
+
+GitHub Releases publish Linux binaries for x86-64 and ARM64:
+
+```bash
+set -euo pipefail
+case "$(uname -m)" in
+  x86_64) asset=agentsight-x86_64 ;;
+  aarch64|arm64) asset=agentsight-aarch64 ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+mkdir -p "$HOME/.local/bin"
+curl -fL --retry 3 \
+  "https://github.com/eunomia-bpf/agentsight/releases/latest/download/$asset" \
+  -o "$HOME/.local/bin/agentsight"
+chmod 0755 "$HOME/.local/bin/agentsight"
+"$HOME/.local/bin/agentsight" --version
+```
+
+Before running the binary in a sensitive environment, compare its SHA-256
+digest with the digest shown for that asset on the GitHub Release page. Ensure
+`~/.local/bin` is in `PATH`, or keep using the absolute path.
+
+### Start the monitor at boot
+
+AgentSight creates and starts its systemd user unit:
+
+```bash
+"$HOME/.local/bin/agentsight" monitor install-service
+systemctl --user is-enabled agentsight-monitor.service
+systemctl --user is-active agentsight-monitor.service
+```
+
+On a headless machine, enable systemd user lingering so the unit starts during
+boot without waiting for an interactive login:
+
+```bash
+loginctl enable-linger "$USER"
+loginctl show-user "$USER" -p Linger --value
+```
+
+Some distributions require an administrator to enable lingering. The expected
+final value is `yes`.
+
+### Keep a bound Node running
+
+Run the first binding interactively so you can open its URL in a trusted
+browser:
+
+```bash
+"$HOME/.local/bin/agentsight" bind --no-open
+```
+
+The binding URL contains a bootstrap key. Treat it as a secret and do not paste
+it into public logs. Stop the foreground command after the browser completes
+binding; the key is stored in the user's platform config directory and is
+reused across Node restarts.
+
+For a headless remote host, forward its loopback port to the workstation that
+runs the browser:
+
+```bash
+ssh -L 7395:127.0.0.1:7395 user@remote-host
+```
+
+Run the preceding `agentsight bind --no-open` command in that SSH session, then
+open its URL on the workstation. If a persistent Bind service already occupies
+port 7395, stop it before this one-time pairing and start it again afterward.
+The SSH tunnel is not needed once Controller relay is registered.
+
+Create `~/.config/systemd/user/agentsight-bind.service`:
+
+```ini
+[Unit]
+Description=AgentSight local Node API and Controller relay
+Documentation=https://github.com/eunomia-bpf/agentsight
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/agentsight --listen 127.0.0.1 bind --no-open --server-port 7395 --app-url https://app.agentsight.us/
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+UMask=0077
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+```
+
+Enable and verify it:
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now agentsight-bind.service
+systemctl --user is-enabled agentsight-bind.service
+systemctl --user is-active agentsight-bind.service
+curl -fsS http://127.0.0.1:7395/api/v1/info
+```
+
+The public info response should say `"authorization_required":true`. A request
+to `/api/v1/snapshot` without an access token should return HTTP `401`.
+
+## Windows
+
+### Install the native artifact
+
+Until a Windows asset is attached to GitHub Releases, the repository's
+successful **Windows native** workflow uploads `agentsight-windows-x86_64`.
+Download the latest successful artifact with an authenticated GitHub CLI:
+
+```powershell
+$repo = 'eunomia-bpf/agentsight'
+$runId = gh run list --repo $repo --workflow windows.yml --limit 30 `
+  --json databaseId,conclusion `
+  --jq 'map(select(.conclusion == "success"))[0].databaseId'
+if (-not $runId) { throw 'No successful Windows native workflow was found.' }
+
+$download = Join-Path $env:TEMP 'agentsight-windows'
+New-Item -ItemType Directory -Force -Path $download | Out-Null
+gh run download $runId --repo $repo `
+  --name agentsight-windows-x86_64 --dir $download
+
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+Copy-Item (Join-Path $download 'agentsight.exe') $installDir -Force
+& (Join-Path $installDir 'agentsight.exe') --version
+```
+
+Actions artifacts are retained for a limited time. If none is available, build
+`collector/target/release/agentsight.exe` as described in
+[Build From Source](build.md).
+
+Optionally add the install directory to the user `PATH`:
+
+```powershell
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$parts = @($userPath -split ';' | Where-Object { $_ })
+if ($parts -notcontains $installDir) {
+  [Environment]::SetEnvironmentVariable(
+    'Path', (($parts + $installDir) -join ';'), 'User'
+  )
+}
+```
+
+New terminals see the updated `PATH`. Use the absolute executable path in the
+current terminal.
+
+### Start after sign-in
+
+The built-in `monitor install-service` command currently targets Linux systemd.
+On Windows, register two per-user scheduled tasks. They start after this user
+signs in, run without elevation, restart after failures, and are allowed to run
+on battery power:
+
+```powershell
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
+$exe = Join-Path $installDir 'agentsight.exe'
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+$principal = New-ScheduledTaskPrincipal `
+  -UserId $currentUser -LogonType Interactive -RunLevel Limited
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $currentUser
+$settings = New-ScheduledTaskSettingsSet `
+  -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+  -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
+  -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+
+$monitor = New-ScheduledTaskAction -Execute $exe -Argument 'monitor' `
+  -WorkingDirectory $installDir
+$bind = New-ScheduledTaskAction -Execute $exe `
+  -Argument '--listen 127.0.0.1 bind --no-open --server-port 7395 --app-url https://app.agentsight.us/' `
+  -WorkingDirectory $installDir
+
+Register-ScheduledTask -TaskName 'AgentSight Monitor' -Action $monitor `
+  -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+Register-ScheduledTask -TaskName 'AgentSight Bind' -Action $bind `
+  -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+Start-ScheduledTask -TaskName 'AgentSight Monitor'
+Start-ScheduledTask -TaskName 'AgentSight Bind'
+```
+
+If this Windows machine has not been added to the hosted app, run
+`agentsight bind` once in an interactive terminal before relying on the
+background Bind task. Its binding URL also contains a secret bootstrap key.
+
+Verify the tasks and API authorization boundary:
+
+```powershell
+Get-ScheduledTask -TaskName 'AgentSight Monitor','AgentSight Bind' |
+  Select-Object TaskName,State
+Get-Process agentsight
+Get-NetTCPConnection -State Listen -LocalPort 7395
+try {
+  Invoke-WebRequest http://127.0.0.1:7395/api/v1/snapshot -TimeoutSec 5
+} catch {
+  [int]$_.Exception.Response.StatusCode  # expected: 401
+}
+```
+
+## Upgrade or remove automatic startup
+
+After replacing the installed binary, restart the Linux services with
+`systemctl --user restart agentsight-monitor.service agentsight-bind.service`,
+or restart both Windows scheduled tasks.
+
+To remove automatic startup on Linux:
+
+```bash
+systemctl --user disable --now agentsight-monitor.service agentsight-bind.service
+rm -f ~/.config/systemd/user/agentsight-monitor.service \
+  ~/.config/systemd/user/agentsight-bind.service
+systemctl --user daemon-reload
+```
+
+To remove the Windows tasks:
+
+```powershell
+Unregister-ScheduledTask -TaskName 'AgentSight Monitor' -Confirm:$false
+Unregister-ScheduledTask -TaskName 'AgentSight Bind' -Confirm:$false
+```
+
+Removing startup units or tasks does not delete captures under
+`~/.agentsight/monitor` or the locally stored Bind access key. Remove those
+separately only when their data is no longer needed.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -133,14 +133,19 @@ Download the latest successful artifact with an authenticated GitHub CLI:
 
 ```powershell
 $repo = 'eunomia-bpf/agentsight'
-$runId = gh run list --repo $repo --workflow windows.yml --limit 30 `
-  --json databaseId,conclusion `
-  --jq 'map(select(.conclusion == "success"))[0].databaseId'
-if (-not $runId) { throw 'No successful Windows native workflow was found.' }
+$runs = gh run list --repo $repo --workflow windows.yml --limit 50 `
+  --json databaseId,conclusion,headSha,url | ConvertFrom-Json
+$run = $runs | Where-Object conclusion -eq 'success' | Where-Object {
+  $prs = gh api -H 'Accept: application/vnd.github+json' `
+    "repos/$repo/commits/$($_.headSha)/pulls" | ConvertFrom-Json
+  $prs | Where-Object { $_.merged_at -and $_.base.ref -eq 'master' }
+} | Select-Object -First 1
+if (-not $run) { throw 'No successful merged Windows workflow was found.' }
+$run | Select-Object databaseId,headSha,url
 
 $download = Join-Path $env:TEMP 'agentsight-windows'
 New-Item -ItemType Directory -Force -Path $download | Out-Null
-gh run download $runId --repo $repo `
+gh run download $run.databaseId --repo $repo `
   --name agentsight-windows-x86_64 --dir $download
 
 $installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
@@ -151,7 +156,9 @@ Copy-Item (Join-Path $download 'agentsight.exe') $installDir -Force
 
 Actions artifacts are retained for a limited time. If none is available, build
 `collector/target/release/agentsight.exe` as described in
-[Build From Source](build.md).
+[Build From Source](build.md). The merged-PR check above excludes successful
+artifacts from unmerged pull-request heads, including in repositories that use
+squash merges.
 
 Optionally add the install directory to the user `PATH`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,13 +79,20 @@ For a headless remote host, forward its loopback port to the workstation that
 runs the browser:
 
 ```bash
-ssh -L 7395:127.0.0.1:7395 user@remote-host
+ssh -L 17400:127.0.0.1:7395 user@remote-host
 ```
 
-Run the preceding `agentsight bind --no-open` command in that SSH session, then
-open its URL on the workstation. If a persistent Bind service already occupies
-port 7395, stop it before this one-time pairing and start it again afterward.
-The SSH tunnel is not needed once Controller relay is registered.
+In that SSH session, run:
+
+```bash
+"$HOME/.local/bin/agentsight" bind --no-open \
+  --endpoint http://127.0.0.1:17400
+```
+
+Then open its URL on the workstation. If a persistent Bind service already
+occupies the remote port 7395, stop it before this one-time pairing and start it
+again afterward. The SSH tunnel is not needed once Controller relay is
+registered. Choose another unused workstation port if 17400 is also occupied.
 
 Create `~/.config/systemd/user/agentsight-bind.service`:
 

--- a/docs/installation.zh-CN.md
+++ b/docs/installation.zh-CN.md
@@ -120,14 +120,19 @@ curl -fsS http://127.0.0.1:7395/api/v1/info
 
 ```powershell
 $repo = 'eunomia-bpf/agentsight'
-$runId = gh run list --repo $repo --workflow windows.yml --limit 30 `
-  --json databaseId,conclusion `
-  --jq 'map(select(.conclusion == "success"))[0].databaseId'
-if (-not $runId) { throw 'No successful Windows native workflow was found.' }
+$runs = gh run list --repo $repo --workflow windows.yml --limit 50 `
+  --json databaseId,conclusion,headSha,url | ConvertFrom-Json
+$run = $runs | Where-Object conclusion -eq 'success' | Where-Object {
+  $prs = gh api -H 'Accept: application/vnd.github+json' `
+    "repos/$repo/commits/$($_.headSha)/pulls" | ConvertFrom-Json
+  $prs | Where-Object { $_.merged_at -and $_.base.ref -eq 'master' }
+} | Select-Object -First 1
+if (-not $run) { throw 'No successful merged Windows workflow was found.' }
+$run | Select-Object databaseId,headSha,url
 
 $download = Join-Path $env:TEMP 'agentsight-windows'
 New-Item -ItemType Directory -Force -Path $download | Out-Null
-gh run download $runId --repo $repo `
+gh run download $run.databaseId --repo $repo `
   --name agentsight-windows-x86_64 --dir $download
 
 $installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
@@ -137,7 +142,8 @@ Copy-Item (Join-Path $download 'agentsight.exe') $installDir -Force
 ```
 
 Actions artifact 只保留有限时间。如果当前没有可下载的 artifact，请按照
-[从源码构建](build.md)生成 `collector/target/release/agentsight.exe`。
+[从源码构建](build.md)生成 `collector/target/release/agentsight.exe`。上面的 PR 合并状态检查会排除
+尚未合并的 pull request head 所生成的成功 artifact，并兼容 squash merge。
 
 可以把安装目录加入当前用户的 `PATH`：
 

--- a/docs/installation.zh-CN.md
+++ b/docs/installation.zh-CN.md
@@ -1,0 +1,228 @@
+# 安装与开机启动
+
+本手册把 AgentSight CLI 安装到当前用户目录，并让后台进程在重启后自动运行。
+
+`monitor` 和 `bind` 的作用不同：
+
+- `monitor` 采样活动 Agent session，并把每周数据库写入 `~/.agentsight/monitor`。
+- `bind` 提供需要鉴权的 Node API，并维持出站 Controller relay。下文只监听
+  `127.0.0.1:7395`，不会新增局域网或公网监听端口。
+
+Windows、macOS 和 Linux 上的可移植命令可以读取 Claude、Codex、Gemini、OpenCode 和
+OpenClaw 原生 session 文件。`record` 和基于 eBPF 的调试命令只支持 Linux，还需要额外权限。
+
+## Linux
+
+### 安装 Release 二进制
+
+GitHub Release 提供 Linux x86-64 和 ARM64 二进制：
+
+```bash
+set -euo pipefail
+case "$(uname -m)" in
+  x86_64) asset=agentsight-x86_64 ;;
+  aarch64|arm64) asset=agentsight-aarch64 ;;
+  *) echo "unsupported architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+mkdir -p "$HOME/.local/bin"
+curl -fL --retry 3 \
+  "https://github.com/eunomia-bpf/agentsight/releases/latest/download/$asset" \
+  -o "$HOME/.local/bin/agentsight"
+chmod 0755 "$HOME/.local/bin/agentsight"
+"$HOME/.local/bin/agentsight" --version
+```
+
+在敏感环境运行前，请把下载文件的 SHA-256 与 GitHub Release 页面展示的对应资产摘要比较。
+确保 `~/.local/bin` 在 `PATH` 中，否则继续使用绝对路径。
+
+### 随系统启动 monitor
+
+AgentSight 可以自动创建并启动 systemd user unit：
+
+```bash
+"$HOME/.local/bin/agentsight" monitor install-service
+systemctl --user is-enabled agentsight-monitor.service
+systemctl --user is-active agentsight-monitor.service
+```
+
+无人值守主机还应开启 systemd user linger，避免必须先 SSH 登录才启动：
+
+```bash
+loginctl enable-linger "$USER"
+loginctl show-user "$USER" -p Linger --value
+```
+
+部分发行版要求管理员开启 linger；最终输出应为 `yes`。
+
+### 让绑定的 Node 长期运行
+
+第一次绑定先在前台运行，以便在可信浏览器中打开绑定 URL：
+
+```bash
+"$HOME/.local/bin/agentsight" bind --no-open
+```
+
+绑定 URL 包含 bootstrap key，必须按密钥处理，不能粘贴到公开日志。浏览器完成绑定后停止前台命令；
+密钥保存在当前用户的平台配置目录中，Node 重启后继续复用。
+
+对于无图形界面的远程主机，把它的 loopback 端口转发到运行浏览器的工作站：
+
+```bash
+ssh -L 7395:127.0.0.1:7395 user@remote-host
+```
+
+在这个 SSH session 中执行前面的 `agentsight bind --no-open`，再在工作站打开它输出的 URL。
+如果常驻 Bind service 已占用 7395，先停止它，完成一次性配对后再启动。Controller relay 注册完成后
+不再需要保留 SSH tunnel。
+
+创建 `~/.config/systemd/user/agentsight-bind.service`：
+
+```ini
+[Unit]
+Description=AgentSight local Node API and Controller relay
+Documentation=https://github.com/eunomia-bpf/agentsight
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/agentsight --listen 127.0.0.1 bind --no-open --server-port 7395 --app-url https://app.agentsight.us/
+Restart=on-failure
+RestartSec=5
+KillSignal=SIGTERM
+UMask=0077
+StandardOutput=null
+StandardError=journal
+
+[Install]
+WantedBy=default.target
+```
+
+启用并验证：
+
+```bash
+systemctl --user daemon-reload
+systemctl --user enable --now agentsight-bind.service
+systemctl --user is-enabled agentsight-bind.service
+systemctl --user is-active agentsight-bind.service
+curl -fsS http://127.0.0.1:7395/api/v1/info
+```
+
+公开 info 应包含 `"authorization_required":true`；不带 access token 请求
+`/api/v1/snapshot` 应返回 HTTP `401`。
+
+## Windows
+
+### 安装原生 artifact
+
+在 GitHub Release 正式附带 Windows 资产之前，仓库成功的 **Windows native** workflow 会上传
+`agentsight-windows-x86_64`。使用已登录的 GitHub CLI 下载最新成功 artifact：
+
+```powershell
+$repo = 'eunomia-bpf/agentsight'
+$runId = gh run list --repo $repo --workflow windows.yml --limit 30 `
+  --json databaseId,conclusion `
+  --jq 'map(select(.conclusion == "success"))[0].databaseId'
+if (-not $runId) { throw 'No successful Windows native workflow was found.' }
+
+$download = Join-Path $env:TEMP 'agentsight-windows'
+New-Item -ItemType Directory -Force -Path $download | Out-Null
+gh run download $runId --repo $repo `
+  --name agentsight-windows-x86_64 --dir $download
+
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
+New-Item -ItemType Directory -Force -Path $installDir | Out-Null
+Copy-Item (Join-Path $download 'agentsight.exe') $installDir -Force
+& (Join-Path $installDir 'agentsight.exe') --version
+```
+
+Actions artifact 只保留有限时间。如果当前没有可下载的 artifact，请按照
+[从源码构建](build.md)生成 `collector/target/release/agentsight.exe`。
+
+可以把安装目录加入当前用户的 `PATH`：
+
+```powershell
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
+$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+$parts = @($userPath -split ';' | Where-Object { $_ })
+if ($parts -notcontains $installDir) {
+  [Environment]::SetEnvironmentVariable(
+    'Path', (($parts + $installDir) -join ';'), 'User'
+  )
+}
+```
+
+新终端会读取更新后的 `PATH`；当前终端请继续使用绝对路径。
+
+### 用户登录后自动启动
+
+内置 `monitor install-service` 当前只支持 Linux systemd。Windows 使用两个用户级计划任务：
+当前用户登录后启动、无需提权、失败后重启，并允许在电池供电时运行。
+
+```powershell
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\AgentSight'
+$exe = Join-Path $installDir 'agentsight.exe'
+$currentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+$principal = New-ScheduledTaskPrincipal `
+  -UserId $currentUser -LogonType Interactive -RunLevel Limited
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $currentUser
+$settings = New-ScheduledTaskSettingsSet `
+  -StartWhenAvailable -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+  -RestartCount 999 -RestartInterval (New-TimeSpan -Minutes 1) `
+  -ExecutionTimeLimit ([TimeSpan]::Zero) -MultipleInstances IgnoreNew
+
+$monitor = New-ScheduledTaskAction -Execute $exe -Argument 'monitor' `
+  -WorkingDirectory $installDir
+$bind = New-ScheduledTaskAction -Execute $exe `
+  -Argument '--listen 127.0.0.1 bind --no-open --server-port 7395 --app-url https://app.agentsight.us/' `
+  -WorkingDirectory $installDir
+
+Register-ScheduledTask -TaskName 'AgentSight Monitor' -Action $monitor `
+  -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+Register-ScheduledTask -TaskName 'AgentSight Bind' -Action $bind `
+  -Trigger $trigger -Principal $principal -Settings $settings -Force | Out-Null
+Start-ScheduledTask -TaskName 'AgentSight Monitor'
+Start-ScheduledTask -TaskName 'AgentSight Bind'
+```
+
+如果这台 Windows 机器还没有加入托管应用，请先在交互终端运行一次 `agentsight bind`，再依赖后台
+Bind 任务。与 Linux 相同，绑定 URL 包含秘密 bootstrap key。
+
+验证任务和 API 鉴权边界：
+
+```powershell
+Get-ScheduledTask -TaskName 'AgentSight Monitor','AgentSight Bind' |
+  Select-Object TaskName,State
+Get-Process agentsight
+Get-NetTCPConnection -State Listen -LocalPort 7395
+try {
+  Invoke-WebRequest http://127.0.0.1:7395/api/v1/snapshot -TimeoutSec 5
+} catch {
+  [int]$_.Exception.Response.StatusCode  # 预期为 401
+}
+```
+
+## 升级或删除自动启动
+
+替换安装的二进制后，使用
+`systemctl --user restart agentsight-monitor.service agentsight-bind.service`
+重启 Linux 服务，或重启两个 Windows 计划任务。
+
+删除 Linux 自动启动：
+
+```bash
+systemctl --user disable --now agentsight-monitor.service agentsight-bind.service
+rm -f ~/.config/systemd/user/agentsight-monitor.service \
+  ~/.config/systemd/user/agentsight-bind.service
+systemctl --user daemon-reload
+```
+
+删除 Windows 计划任务：
+
+```powershell
+Unregister-ScheduledTask -TaskName 'AgentSight Monitor' -Confirm:$false
+Unregister-ScheduledTask -TaskName 'AgentSight Bind' -Confirm:$false
+```
+
+删除 unit 或计划任务不会删除 `~/.agentsight/monitor` 下的采集数据，也不会删除本地保存的 Bind
+access key。只有确认这些数据不再需要时，才单独删除。

--- a/docs/installation.zh-CN.md
+++ b/docs/installation.zh-CN.md
@@ -68,12 +68,19 @@ loginctl show-user "$USER" -p Linger --value
 对于无图形界面的远程主机，把它的 loopback 端口转发到运行浏览器的工作站：
 
 ```bash
-ssh -L 7395:127.0.0.1:7395 user@remote-host
+ssh -L 17400:127.0.0.1:7395 user@remote-host
 ```
 
-在这个 SSH session 中执行前面的 `agentsight bind --no-open`，再在工作站打开它输出的 URL。
-如果常驻 Bind service 已占用 7395，先停止它，完成一次性配对后再启动。Controller relay 注册完成后
-不再需要保留 SSH tunnel。
+在这个 SSH session 中运行：
+
+```bash
+"$HOME/.local/bin/agentsight" bind --no-open \
+  --endpoint http://127.0.0.1:17400
+```
+
+再在工作站打开它输出的 URL。如果常驻 Bind service 已占用远端 7395，先停止它，完成一次性配对后
+再启动。Controller relay 注册完成后不再需要保留 SSH tunnel。如果工作站的 17400 也已占用，
+请选择另一个未使用的本地端口，并同步修改 `--endpoint`。
 
 创建 `~/.config/systemd/user/agentsight-bind.service`：
 


### PR DESCRIPTION
## Summary
- add verified Linux x86-64/ARM64 release installation and systemd user startup
- add Windows CI-artifact installation and per-user scheduled-task startup
- document secure loopback Bind, headless SSH forwarding, verification, upgrade, and removal
- link the English and Chinese guides from the existing Installation sections

## Validation
- executed the Windows installation and scheduled-task flow with AgentSight 1.0.19
- executed the ARM64/systemd flow on a DGX Spark and verified both services enabled and active
- verified loopback-only TCP 7395 and unauthenticated snapshot HTTP 401 on both systems
- checked UTF-8, Markdown fences, local links, bilingual command parity, secret patterns, and git diff --check