### PR TITLE
chore: clean up local environment files

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-LANGFUSE_SECRET_KEY="sk-lf-61429568-d49f-4475-8988-58c74dcd8bcd"
-LANGFUSE_PUBLIC_KEY="pk-lf-aee3e31f-18a8-4372-8a7e-b502cc5e5230"
-LANGFUSE_HOST="https://cloud.langfuse.com"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+LANGFUSE_SECRET_KEY=""
+LANGFUSE_PUBLIC_KEY=""
+LANGFUSE_HOST="https://cloud.langfuse.com"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .direnv
+.env
+.env.*
+!.env.example
 /build
 output
 target/
@@ -24,9 +27,6 @@ record.log.*
 frontend/public/sample-snapshot.json
 # Generated Rust/WASM browser bindings
 frontend/src/generated/
-# Log files
-*.log
-
 # Log files
 *.log
 docs/blog


### PR DESCRIPTION
## Summary

- remove the committed local `.env`
- ignore local `.env` variants while keeping `.env.example`
- add a placeholder `.env.example` for optional Langfuse configuration
- remove the duplicate log-ignore block

## Scope

Repository hygiene only; no runtime or product behavior changes.

## Follow-up

Any credential that was previously committed should be rotated separately because removing the file does not remove it from Git history.