### PR TITLE
ci: retry short OpenCode capture once

### DIFF
--- a/script/e2e/latest_agent_cli_canary.sh
+++ b/script/e2e/latest_agent_cli_canary.sh
@@ -444,10 +444,21 @@ run_real_agent_mock_canary() {
         failures+=("claude")
     fi
 
-    if ! record_real_agent opencode \
-        "$OPENCODE_BIN" run --pure --model agentsight-mock/gpt-agentsight-mock \
-        --format json "$PROMPT"; then
-        failures+=("opencode")
+    local opencode_command=(
+        "$OPENCODE_BIN" run --pure --model agentsight-mock/gpt-agentsight-mock
+        --format json "$PROMPT"
+    )
+    if ! record_real_agent opencode "${opencode_command[@]}"; then
+        # OpenCode's mock invocation is a single-request, roughly three-second
+        # process. An occasional scheduler race can let it exit before the
+        # BoringSSL offset probe emits its first event even though the mock
+        # server received the exact request. Retry once so this canary still
+        # fails persistent binary-signature regressions without blocking a
+        # release on one short-process sampling miss.
+        echo "Retrying OpenCode capture after a short-process sampling miss" >&2
+        if ! record_real_agent opencode "${opencode_command[@]}"; then
+            failures+=("opencode")
+        fi
     fi
 
     if ((${#failures[@]} > 0)); then


### PR DESCRIPTION
## Summary

- retry the OpenCode real-agent canary once after a single short-process capture miss
- keep Codex and Claude strict, and still fail OpenCode when both attempts miss
- preserve the mock-server prompt assertion on every attempt, so the retry cannot turn a persistent binary/signature incompatibility into a pass

## Root cause

The post-merge master run for #187 showed that OpenCode 1.18.18 sent the exact canary request to the TLS mock server, while the roughly three-second process produced zero captured API calls on that one BoringSSL offset-probe sample. The same exact code and CLI versions passed on the PR run and repeated lab runs, identifying a short-process scheduling race rather than an API compatibility break.

## Validation

- `bash -n script/e2e/latest_agent_cli_canary.sh`
- `git diff --check`
- three consecutive full lab runs with eBPF required and latest Codex 0.147.0, Claude 2.1.233, and OpenCode 1.18.18; all three CLIs sent and captured the exact TLS canary prompt on every run

This PR is intentionally limited to the canary. Production Worker/API and browser/lab acceptance for #187 remain healthy while the release pipeline is blocked.
