### PR TITLE
ci: preserve missing-version status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,9 @@ jobs:
                 SPATCH=$((SPATCH + 1))
                 SESSION_VERSION="${SMAJ}.${SMIN}.${SPATCH}"
                 continue
+              else
+                status=$?
               fi
-              status=$?
               [[ "$status" == 1 ]] || exit "$status"
               break
             done
@@ -211,6 +212,17 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "session_version=$SESSION_VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Validate selected release versions
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SESSION_VERSION: ${{ steps.version.outputs.session_version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$SESSION_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          [[ "$TAG" == "v$VERSION" ]]
 
       - name: Build release snapshot
         run: |


### PR DESCRIPTION
## Summary

- capture the `exists` exit status inside the `else` branch before Bash resets it to zero
- fail release preparation before building or committing when version outputs are empty or malformed

## Production evidence

The first post-merge release run exposed this path: `agent-session 0.5.5` exists and `0.5.6` returns 404. The old code read `$?` after `fi`, exited 0 early, committed an empty-version snapshot, and omitted `version`, `session_version`, and `tag` job outputs. Run 31925149123 was cancelled before publish jobs started, so no crate, tag, release, or Docker image was published.

## Validation

- exact Bash regression: existing 0.5.5 -> missing 0.5.6 selects 0.5.6
- direct missing version remains selected
- non-404 registry failure propagates status 2
- workflow YAML parses successfully
- `git diff --check`