### PR TITLE
ci: preserve crate publish arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,9 +360,10 @@ jobs:
       - name: Publish dependency-ordered crates
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: bash script/release/publish_crates.sh \
-          "${{ needs.release_prepare.outputs.version }}" \
-          "${{ needs.release_prepare.outputs.session_version }}"
+        run: |
+          bash script/release/publish_crates.sh \
+            "${{ needs.release_prepare.outputs.version }}" \
+            "${{ needs.release_prepare.outputs.session_version }}"
 
       - name: Smoke cargo installs
         env:


### PR DESCRIPTION
## Summary

- execute the dependency-ordered crates publisher as a YAML literal script block
- preserve the two release-version arguments across shell line continuation

## Failure evidence

Master run 31926874058 rendered the folded YAML scalar as:

```
bash script/release/publish_crates.sh \ 1.0.23 \ 0.5.6
```

The escaped spaces produced leading whitespace in both version arguments, so the first crates.io lookup failed with `curl: (3) URL rejected: Malformed input to a URL function` before any crate was published.

## Validation

- parsed `.github/workflows/ci.yml` with PyYAML
- asserted the publish `run` value contains three physical shell lines and both continuation backslashes
- `git diff --check`
- failed release produced no `v1.0.23` tag/release and no crate publication before this recovery PR