### PR TITLE
fix: refresh Node version on relay reconnect

### DIFF
--- a/collector/src/server/relay_client.rs
+++ b/collector/src/server/relay_client.rs
@@ -23,6 +23,7 @@ const MAX_RELAY_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const RECONNECT_DELAY_SECS: u64 = 2;
 const HEARTBEAT_INTERVAL_SECS: u64 = 20;
 const RELAY_CAPABILITY_TTL_SECONDS: u64 = 60;
+const NODE_VERSION_HEADER: &str = "x-agentsight-node-version";
 
 fn install_tls_provider() -> Result<(), Box<dyn Error + Send + Sync>> {
     if rustls::crypto::CryptoProvider::get_default().is_some() {
@@ -91,9 +92,12 @@ async fn connect_once(
         "Authorization",
         HeaderValue::from_str(&format!("Bearer {bootstrap_token}"))?,
     );
+    request
+        .headers_mut()
+        .insert("User-Agent", HeaderValue::from_static("AgentSight-Node"));
     request.headers_mut().insert(
-        "User-Agent",
-        HeaderValue::from_static("AgentSight-Node"),
+        NODE_VERSION_HEADER,
+        HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
     );
 
     let (mut socket, _) = connect_async(request).await?;

--- a/controller/src/relay.test.ts
+++ b/controller/src/relay.test.ts
@@ -3,7 +3,14 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { browserRelayRoute, relayNodeSocketId, validRelayToken } from './relay.ts';
+import {
+  browserRelayRoute,
+  connectNodeRelay,
+  relayTokenHash,
+  relayNodeSocketId,
+  validRelayNodeVersion,
+  validRelayToken,
+} from './relay.ts';
 
 test('Node relay socket path accepts only stable Node IDs', () => {
   assert.equal(relayNodeSocketId('/v1/relay/nodes/node_0123abcdef'), 'node_0123abcdef');
@@ -48,4 +55,54 @@ test('relay tokens use the same Direct bearer shape', () => {
   assert.equal(validRelayToken('a'.repeat(64)), true);
   assert.equal(validRelayToken('short'), false);
   assert.equal(validRelayToken(`${'a'.repeat(63)}!`), false);
+});
+
+test('relay node versions accept release metadata and reject unsafe values', () => {
+  assert.equal(validRelayNodeVersion('1.0.23'), true);
+  assert.equal(validRelayNodeVersion('1.0.24-rc.1+build'), true);
+  assert.equal(validRelayNodeVersion(`1.${'0'.repeat(62)}`), true);
+  assert.equal(validRelayNodeVersion(''), false);
+  assert.equal(validRelayNodeVersion(' 1.0.23'), false);
+  assert.equal(validRelayNodeVersion('1.0.23\r\nX-Injected: yes'), false);
+  assert.equal(validRelayNodeVersion(`1.${'0'.repeat(63)}`), false);
+});
+
+test('authenticated relay reconnect persists reported version without breaking old Nodes', async () => {
+  const token = 'a'.repeat(64);
+  const expectedHash = await relayTokenHash(token);
+  const updates: unknown[][] = [];
+  const db = {
+    prepare: (query: string) => ({
+      bind: (...values: unknown[]) => ({
+        first: async () => ({ relay_token_hash: expectedHash }),
+        run: async () => {
+          assert.match(query, /version = COALESCE\(\?3, version\)/);
+          updates.push(values);
+          return { success: true };
+        },
+      }),
+    }),
+  } as D1Database;
+  const relay = {
+    idFromName: () => ({}) as DurableObjectId,
+    get: () => ({
+      fetch: async () => new Response(null, { status: 200 }),
+    }) as unknown as DurableObjectStub,
+  } as unknown as DurableObjectNamespace;
+
+  const connect = (version?: string) => connectNodeRelay(new Request(
+    'https://controller.example/v1/relay/nodes/node_test',
+    { headers: {
+      Upgrade: 'websocket', Authorization: `Bearer ${token}`,
+      ...(version ? { 'X-AgentSight-Node-Version': version } : {}),
+    } },
+  ), { DB: db, NODE_RELAY: relay }, 'node_test');
+
+  assert.equal((await connect('1.0.23')).status, 200);
+  assert.equal(updates[0][1], 'node_test');
+  assert.equal(updates[0][2], '1.0.23');
+  assert.equal((await connect()).status, 200);
+  assert.equal(updates[1][2], null);
+  assert.equal((await connect('invalid version')).status, 400);
+  assert.equal(updates.length, 2);
 });

--- a/controller/src/relay.ts
+++ b/controller/src/relay.ts
@@ -3,6 +3,7 @@
 
 const NODE_ID_PATTERN = /^node_[A-Za-z0-9_]{1,123}$/;
 const RELAY_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
+const NODE_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
 const RELAY_TIMEOUT_MS = 12_000;
 const MAX_BROWSER_BODY_BYTES = 96 * 1024;
 const MAX_RELAY_SUFFIX_BYTES = 4 * 1024;
@@ -76,6 +77,10 @@ export function validRelayToken(value: string): boolean {
   return RELAY_TOKEN_PATTERN.test(value);
 }
 
+export function validRelayNodeVersion(value: string): boolean {
+  return NODE_VERSION_PATTERN.test(value);
+}
+
 function relayStub(env: RelayEnv, nodeId: string): DurableObjectStub {
   return env.NODE_RELAY.get(env.NODE_RELAY.idFromName(nodeId));
 }
@@ -90,6 +95,10 @@ export async function connectNodeRelay(
   }
   const token = bearerToken(request);
   if (!token || !validRelayToken(token)) return json({ error: 'node_auth_required' }, 401);
+  const reportedVersion = request.headers.get('X-AgentSight-Node-Version');
+  if (reportedVersion !== null && !validRelayNodeVersion(reportedVersion)) {
+    return json({ error: 'invalid_node_version' }, 400);
+  }
 
   const row = await env.DB.prepare(
     'SELECT relay_token_hash FROM nodes WHERE id = ?1',
@@ -99,8 +108,9 @@ export async function connectNodeRelay(
   }
 
   await env.DB.prepare(
-    `UPDATE nodes SET last_seen_at = ?1, connection_mode = 'relay' WHERE id = ?2`,
-  ).bind(Math.floor(Date.now() / 1000), nodeId).run();
+    `UPDATE nodes SET last_seen_at = ?1, connection_mode = 'relay',
+       version = COALESCE(?3, version) WHERE id = ?2`,
+  ).bind(Math.floor(Date.now() / 1000), nodeId, reportedVersion).run();
 
   return relayStub(env, nodeId).fetch(request);
 }


### PR DESCRIPTION
## Summary

- report the running CLI version on the existing authenticated Node relay WebSocket
- validate and persist that version during relay reconnects
- preserve compatibility with older Nodes that do not send the header

## User impact

After upgrading and restarting a Node, the Controller previously refreshed `last_seen_at` but kept the version recorded during the original pairing. In production this left the lab Node displaying `v1.0.15` even though the running binary and authenticated Direct API were both `v1.0.23`.

The reconnect path now updates the persisted version automatically, so the fleet and Node manager reflect the version actually running without asking the user to re-pair Direct.

## Security and performance

- the new value is accepted only after the existing bearer shape check and is persisted only after the relay token hash matches the Node
- versions are restricted to 1-64 ASCII release-metadata characters; whitespace, control characters, and header injection are rejected
- no new request, polling loop, dependency, or D1 statement is added; the existing reconnect UPDATE gains one bound value
- old clients omit the header and retain their existing persisted version

## Validation

- Controller: 19 tests passed, including authenticated update, old-client compatibility, length bounds, and CRLF injection rejection
- Controller: `tsc --noEmit` passed
- `git diff --check` passed
- Rust change is compile-tested by the repository Linux/Windows/macOS CI matrix (local Windows host lacks MSVC `link.exe`)

## Rollback

Reverting this commit restores the prior last-seen-only reconnect update; no schema or migration is involved.