### PR TITLE
fix: expose language switcher in first-run dialog

### DIFF
--- a/ext/web/components/ConnectionDialog.tsx
+++ b/ext/web/components/ConnectionDialog.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from 'react';
 import { fetchLoginProviders, startLogin, type LoginProvider } from '@/lib/controllerClient';
 import { useTranslation } from '@/i18n';
+import { LanguageSwitcher } from '@/components/common/LanguageSwitcher';
 
 interface ConnectionDialogProps {
   error: string;
@@ -47,9 +48,14 @@ export function ConnectionDialog({
             ×
           </button>
         )}
-        <div className="mb-6">
-          <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">AgentSight</p>
-          <h1 id="connect-title" className="mt-1 text-2xl font-bold text-slate-950">{t('connect.title')}</h1>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">AgentSight</p>
+            <h1 id="connect-title" className="mt-1 text-2xl font-bold text-slate-950">{t('connect.title')}</h1>
+          </div>
+          <div className={canClose ? 'mr-8' : ''}>
+            <LanguageSwitcher />
+          </div>
         </div>
 
         {error && (

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -26,9 +26,12 @@ test('anonymous entry offers both sign-in providers, language switching, and the
   await expect(page.getByRole('heading', { name: '打开你的 AgentSight 数据' })).toBeVisible();
   await expect(page.getByRole('button', { name: '使用 GitHub 继续' })).toBeVisible();
   await expect(page.getByRole('button', { name: '使用 Google 继续' })).toBeVisible();
-  await page.getByRole('button', { name: '进入演示' }).click();
-  await expect(page.getByText('录制演示').first()).toBeVisible();
-  await expect(page.getByRole('heading', { name: '当前机器上的 Agent' })).toBeVisible();
+  const dialog = page.getByRole('dialog');
+  await dialog.getByRole('button', { name: 'EN', exact: true }).click();
+  await expect(dialog.getByRole('heading', { name: 'Open your AgentSight data' })).toBeVisible();
+  await dialog.getByRole('button', { name: 'Enter demo' }).click();
+  await expect(page.getByText('Recorded demo').first()).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Agents on this machine' })).toBeVisible();
 });
 
 test('signed-in user opens a relay Node and sees machine value before session detail', async ({ page }) => {


### PR DESCRIPTION
## Summary
- place the existing language switcher inside the modal that owns first-run focus
- keep the control clear of the close button when the dialog is dismissible
- extend the browser flow to switch Chinese → English before entering the recorded demo

## Why
A real anonymous preview run exposed a usability/accessibility dead end: the page-level language switcher was visible behind the modal overlay but could not be reached while the first-run dialog was open. Users whose browser locale selected Chinese could not change the setup flow to English.

## Validation
Exact head `406565d83ba6cc2f95790d99ff6299437b86846e`:
- production Next.js build passed (10 static pages; / first-load JS 148 kB)
- all 6 Playwright E2E tests passed, including sign-in/demo entry, relay Node opening, message send, unsafe-resume blocking, organization/sign-out, and mobile layout
- focused test proves Chinese first-run → in-dialog EN switch → English demo and machine view
- `git diff --check` clean

No dependency, API, persistence, or bundle-library change.