### PR TITLE
fix: preserve provider session messaging compatibility

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -180,7 +180,18 @@ jobs:
               -ContentType "application/json" `
               -Body '{"message":"windows bind smoke"}' `
               -SkipHttpErrorCheck
-            if ([int]$messageProbe.StatusCode -ne 202) {
+            $principal = [Security.Principal.WindowsPrincipal]::new(
+              [Security.Principal.WindowsIdentity]::GetCurrent()
+            )
+            $elevated = $principal.IsInRole(
+              [Security.Principal.WindowsBuiltInRole]::Administrator
+            )
+            if ($elevated) {
+              if ([int]$messageProbe.StatusCode -ne 502 -or
+                  $messageProbe.Content -notmatch "elevated Windows") {
+                throw "elevated agentsight bind did not fail closed before starting the provider"
+              }
+            } elseif ([int]$messageProbe.StatusCode -ne 202) {
               throw "agentsight bind did not submit through the Windows codex.cmd shim"
             }
           } finally {

--- a/collector/src/server/relay_client.rs
+++ b/collector/src/server/relay_client.rs
@@ -3,7 +3,7 @@
 
 use crate::server::capability;
 use futures::{SinkExt, StreamExt};
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, Limited};
 use hyper::body::Bytes;
 use hyper::{Method, Request};
 use hyper_util::client::legacy::Client;
@@ -11,7 +11,9 @@ use hyper_util::client::legacy::connect::HttpConnector;
 use hyper_util::rt::TokioExecutor;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
+use std::future::Future;
 use std::time::Duration;
+use tokio::task::JoinSet;
 use tokio::time::MissedTickBehavior;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
@@ -23,6 +25,12 @@ const MAX_RELAY_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const RECONNECT_DELAY_SECS: u64 = 2;
 const HEARTBEAT_INTERVAL_SECS: u64 = 20;
 const RELAY_CAPABILITY_TTL_SECONDS: u64 = 60;
+const RELAY_REQUEST_TIMEOUT: Duration = Duration::from_secs(24);
+// A response may be as large as MAX_RELAY_RESPONSE_BYTES. Keeping this below
+// the Controller's global pending cap bounds a single Node to 128 MiB of relay
+// response buffers while still allowing slow provider requests and UI reads to
+// make progress independently.
+const MAX_IN_FLIGHT_RELAY_REQUESTS: usize = 8;
 const NODE_VERSION_HEADER: &str = "x-agentsight-node-version";
 
 fn install_tls_provider() -> Result<(), Box<dyn Error + Send + Sync>> {
@@ -100,8 +108,10 @@ async fn connect_once(
         HeaderValue::from_static(env!("CARGO_PKG_VERSION")),
     );
 
-    let (mut socket, _) = connect_async(request).await?;
+    let (socket, _) = connect_async(request).await?;
     log::debug!("AgentSight Node relay connected");
+    let (mut relay_writer, mut relay_reader) = socket.split();
+    let mut requests = JoinSet::new();
 
     let mut heartbeat = tokio::time::interval(Duration::from_secs(HEARTBEAT_INTERVAL_SECS));
     heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
@@ -112,18 +122,42 @@ async fn connect_once(
             _ = heartbeat.tick() => {
                 // The Durable Object handles this with WebSocket auto-response,
                 // so the heartbeat does not wake a hibernating relay instance.
-                socket.send(Message::Text("ping".into())).await?;
+                relay_writer.send(Message::Text("ping".into())).await?;
             }
-            message = socket.next() => {
+            response = requests.join_next(), if !requests.is_empty() => {
+                let response = response
+                    .ok_or("relay request task disappeared")?
+                    .map_err(|error| format!("relay request task failed: {error}"))?;
+                relay_writer
+                    .send(Message::Text(serde_json::to_string(&response)?.into()))
+                    .await?;
+            }
+            message = relay_reader.next() => {
                 let Some(message) = message else { break };
                 match message? {
                     Message::Text(text) if text.as_str() == "pong" => {}
                     Message::Text(text) => {
-                        let response = handle_request(text.as_str(), local_endpoint, bootstrap_token).await;
-                        socket.send(Message::Text(serde_json::to_string(&response)?.into())).await?;
+                        if requests.len() >= MAX_IN_FLIGHT_RELAY_REQUESTS {
+                            let response = relay_overloaded_response(text.as_str());
+                            relay_writer
+                                .send(Message::Text(serde_json::to_string(&response)?.into()))
+                                .await?;
+                            continue;
+                        }
+                        let local_endpoint = local_endpoint.to_string();
+                        let bootstrap_token = bootstrap_token.to_string();
+                        requests.spawn(async move {
+                            let id = relay_request_id(text.as_str());
+                            timeout_relay_response(
+                                id,
+                                RELAY_REQUEST_TIMEOUT,
+                                handle_request(text.as_str(), &local_endpoint, &bootstrap_token),
+                            )
+                            .await
+                        });
                     }
                     Message::Ping(payload) => {
-                        socket.send(Message::Pong(payload)).await?;
+                        relay_writer.send(Message::Pong(payload)).await?;
                     }
                     Message::Close(_) => break,
                     _ => {}
@@ -131,7 +165,44 @@ async fn connect_once(
             }
         }
     }
+    requests.abort_all();
     Ok(())
+}
+
+fn relay_overloaded_response(raw: &str) -> RelayResponseEnvelope {
+    RelayResponseEnvelope {
+        r#type: "response",
+        id: relay_request_id(raw),
+        status: 429,
+        body: json_error("node_relay_busy"),
+    }
+}
+
+fn relay_request_id(raw: &str) -> String {
+    serde_json::from_str::<RelayRequestEnvelope>(raw)
+        .ok()
+        .filter(|request| request.r#type == "request")
+        .map(|request| request.id)
+        .unwrap_or_default()
+}
+
+async fn timeout_relay_response<F>(
+    id: String,
+    timeout: Duration,
+    response: F,
+) -> RelayResponseEnvelope
+where
+    F: Future<Output = RelayResponseEnvelope>,
+{
+    match tokio::time::timeout(timeout, response).await {
+        Ok(response) => response,
+        Err(_) => RelayResponseEnvelope {
+            r#type: "response",
+            id,
+            status: 504,
+            body: json_error("node_request_timeout"),
+        },
+    }
 }
 
 async fn handle_request(
@@ -166,7 +237,8 @@ async fn handle_request(
     let credential = if request.method == "POST" && request.path == "/api/v1/capabilities" {
         bootstrap_token.to_string()
     } else {
-        let Some((action, session_id)) = capability::action_for_request(&request.method, &request.path)
+        let Some((action, session_id)) =
+            capability::action_for_request(&request.method, &request.path)
         else {
             return RelayResponseEnvelope {
                 r#type: "response",
@@ -218,8 +290,9 @@ async fn handle_request(
             r#type: "response",
             id: request.id,
             status: 502,
-            body: serde_json::json!({ "error": "node_request_failed", "detail": error.to_string() })
-                .to_string(),
+            body:
+                serde_json::json!({ "error": "node_request_failed", "detail": error.to_string() })
+                    .to_string(),
         },
     }
 }
@@ -278,10 +351,11 @@ async fn forward_local(
     let request = builder.body(Full::new(Bytes::from(body.unwrap_or_default().to_owned())))?;
     let response = client.request(request).await?;
     let status = response.status().as_u16();
-    let bytes = response.into_body().collect().await?.to_bytes();
-    if bytes.len() > MAX_RELAY_RESPONSE_BYTES {
-        return Err("Node response exceeded relay limit".into());
-    }
+    let bytes = Limited::new(response.into_body(), MAX_RELAY_RESPONSE_BYTES)
+        .collect()
+        .await
+        .map_err(|error| format!("Node response exceeded relay limit: {error}"))?
+        .to_bytes();
     Ok((status, String::from_utf8_lossy(&bytes).into_owned()))
 }
 
@@ -301,16 +375,17 @@ fn relay_url(controller_url: &str, node_id: &str) -> Result<String, Box<dyn Erro
 }
 
 fn allowed_relay_path(method: &str, value: &str) -> bool {
-    let (path, query) = value.split_once('?').map_or((value, None), |(path, query)| {
-        (path, Some(query))
-    });
+    let (path, query) = value
+        .split_once('?')
+        .map_or((value, None), |(path, query)| (path, Some(query)));
     if method == "POST" && path == "/api/v1/capabilities" && query.is_none() {
         return true;
     }
     if method == "GET" && path == "/api/v1/snapshot" {
         return query.is_none_or(|query| {
-            query.strip_prefix("audit_limit=")
-                .is_some_and(|value| !value.is_empty() && value.len() <= 6 && value.bytes().all(|b| b.is_ascii_digit()))
+            query.strip_prefix("audit_limit=").is_some_and(|value| {
+                !value.is_empty() && value.len() <= 6 && value.bytes().all(|b| b.is_ascii_digit())
+            })
         });
     }
     if method == "GET" && path == "/api/v1/overview" {
@@ -343,6 +418,15 @@ fn json_error(error: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use hyper::Response;
+    use hyper::server::conn::http1;
+    use hyper::service::service_fn;
+    use hyper_util::rt::TokioIo;
+    use std::convert::Infallible;
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+    use tokio::sync::Barrier;
+    use tokio_tungstenite::accept_async;
 
     #[test]
     fn relay_url_maps_https_to_wss() {
@@ -355,10 +439,16 @@ mod tests {
     #[test]
     fn relay_only_accepts_the_node_protocol_and_internal_mint_surface() {
         assert!(allowed_relay_path("POST", "/api/v1/capabilities"));
-        assert!(allowed_relay_path("GET", "/api/v1/snapshot?audit_limit=50000"));
+        assert!(allowed_relay_path(
+            "GET",
+            "/api/v1/snapshot?audit_limit=50000"
+        ));
         assert!(allowed_relay_path("GET", "/api/v1/overview"));
         assert!(allowed_relay_path("GET", "/api/v1/sessions/session-123"));
-        assert!(allowed_relay_path("POST", "/api/v1/sessions/session-123/messages"));
+        assert!(allowed_relay_path(
+            "POST",
+            "/api/v1/sessions/session-123/messages"
+        ));
         assert!(!allowed_relay_path("POST", "/api/v1/snapshot"));
         assert!(!allowed_relay_path("GET", "/etc/passwd"));
         assert!(!allowed_relay_path("GET", "/api/v1/sessions/../secret"));
@@ -368,5 +458,113 @@ mod tests {
     fn relay_installs_a_tls_provider() {
         install_tls_provider().unwrap();
         assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
+
+    #[test]
+    fn overloaded_relay_response_preserves_the_request_id() {
+        let response = relay_overloaded_response(
+            r#"{"type":"request","id":"request-7","method":"GET","path":"/api/v1/overview"}"#,
+        );
+        assert_eq!(response.id, "request-7");
+        assert_eq!(response.status, 429);
+        assert_eq!(response.body, r#"{"error":"node_relay_busy"}"#);
+    }
+
+    #[tokio::test]
+    async fn timed_out_relay_request_releases_its_slot_with_the_same_id() {
+        let response = timeout_relay_response(
+            "request-8".into(),
+            Duration::from_millis(10),
+            std::future::pending(),
+        )
+        .await;
+
+        assert_eq!(response.id, "request-8");
+        assert_eq!(response.status, 504);
+        assert_eq!(response.body, r#"{"error":"node_request_timeout"}"#);
+    }
+
+    #[tokio::test]
+    async fn relay_forwards_independent_requests_concurrently() {
+        let node_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let node_address = node_listener.local_addr().unwrap();
+        let concurrent_requests = Arc::new(Barrier::new(2));
+        let node = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = node_listener.accept().await else {
+                    break;
+                };
+                let concurrent_requests = Arc::clone(&concurrent_requests);
+                tokio::spawn(async move {
+                    let service = service_fn(move |request: Request<hyper::body::Incoming>| {
+                        let concurrent_requests = Arc::clone(&concurrent_requests);
+                        async move {
+                            let (status, body) = if request.uri().path() == "/api/v1/capabilities" {
+                                (201, r#"{"access_token":"cap_test"}"#)
+                            } else {
+                                concurrent_requests.wait().await;
+                                (200, "{}")
+                            };
+                            Ok::<_, Infallible>(
+                                Response::builder()
+                                    .status(status)
+                                    .body(Full::new(Bytes::from(body)))
+                                    .unwrap(),
+                            )
+                        }
+                    });
+                    let _ = http1::Builder::new()
+                        .serve_connection(TokioIo::new(stream), service)
+                        .await;
+                });
+            }
+        });
+
+        let relay_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let relay_address = relay_listener.local_addr().unwrap();
+        let controller = tokio::spawn(async move {
+            let (stream, _) = relay_listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            for id in ["request-1", "request-2"] {
+                socket
+                    .send(Message::Text(
+                        serde_json::json!({
+                            "type":"request",
+                            "id":id,
+                            "method":"GET",
+                            "path":"/api/v1/overview"
+                        })
+                        .to_string()
+                        .into(),
+                    ))
+                    .await
+                    .unwrap();
+            }
+            let mut responses = Vec::new();
+            while responses.len() < 2 {
+                let Some(Ok(Message::Text(text))) = socket.next().await else {
+                    continue;
+                };
+                let value: serde_json::Value = serde_json::from_str(text.as_str()).unwrap();
+                responses.push(value["id"].as_str().unwrap().to_string());
+            }
+            responses.sort();
+            assert_eq!(responses, ["request-1", "request-2"]);
+            socket.close(None).await.unwrap();
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            connect_once(
+                &format!("ws://{relay_address}"),
+                "bootstrap",
+                &format!("http://{node_address}"),
+            ),
+        )
+        .await
+        .unwrap();
+        result.unwrap();
+        controller.await.unwrap();
+        node.abort();
     }
 }

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -9,6 +9,7 @@ use std::ffi::OsStr;
 #[cfg(unix)]
 use std::ffi::{CStr, OsString};
 use std::fs::File;
+use std::future::Future;
 use std::io::{BufRead, BufReader as StdBufReader, Read};
 #[cfg(unix)]
 use std::os::unix::{
@@ -40,8 +41,8 @@ const GEMINI_BIN_ENV: &str = "AGENTSIGHT_GEMINI_BIN";
 type CodexResponse = Result<(), String>;
 type PendingClaudeResponse = Arc<StdMutex<Option<oneshot::Sender<CodexResponse>>>>;
 type PendingCodexResponses = Arc<StdMutex<HashMap<u64, oneshot::Sender<CodexResponse>>>>;
-type SharedCodexStdin = Arc<AsyncMutex<ChildStdin>>;
-type WeakCodexStdin = Weak<AsyncMutex<ChildStdin>>;
+type SharedCodexStdin = Arc<AsyncMutex<Option<ChildStdin>>>;
+type WeakCodexStdin = Weak<AsyncMutex<Option<ChildStdin>>>;
 
 #[derive(Debug, Eq, PartialEq)]
 enum ProviderLine {
@@ -183,7 +184,10 @@ impl Runtime {
                     .insert(request_id, response_tx);
                 let send_result = {
                     let mut stdin = stdin.lock().await;
-                    send_json(&mut stdin, request).await
+                    match stdin.as_mut() {
+                        Some(stdin) => send_json(stdin, request).await,
+                        None => Err(failed("Codex transport is closed")),
+                    }
                 };
                 if let Err(error) = send_result {
                     if let Ok(mut pending) = responses.lock() {
@@ -230,9 +234,14 @@ pub async fn submit_message(
                 .or_insert_with(|| Arc::new(AsyncMutex::new(None))),
         )
     };
-    let mut runtime_slot = slot.lock().await;
+    let mut runtime_slot = slot.try_lock().map_err(|_| {
+        SubmitError::Conflict(
+            "this session is already accepting another message; retry after it is acknowledged"
+                .into(),
+        )
+    })?;
     if let Some(runtime) = runtime_slot.as_mut() {
-        match runtime.send(message).await {
+        match timeout_provider_operation(PROVIDER_REQUEST_TIMEOUT, runtime.send(message)).await {
             Ok(transport) => return Ok(SubmitResult { transport }),
             Err(SubmitError::Conflict(error)) => return Err(SubmitError::Conflict(error)),
             Err(SubmitError::Failed(error)) => {
@@ -245,41 +254,60 @@ pub async fn submit_message(
     }
 
     if session_is_running(session) {
+        drop(runtime_slot);
+        remove_empty_runtime_slot(&session.session_id, &slot).await;
         return Err(SubmitError::Conflict(
             "session is already running outside AgentSight; this runtime cannot be attached safely"
                 .into(),
         ));
     }
 
-    let (runtime, transport) = match session.agent_type.as_str() {
-        agent_session::AGENT_CLAUDE => {
-            let mut runtime = start_claude(session)?;
-            let transport = runtime.send(message).await?;
-            (Some(runtime), transport)
+    let started = timeout_provider_operation(PROVIDER_REQUEST_TIMEOUT, async {
+        match session.agent_type.as_str() {
+            agent_session::AGENT_CLAUDE => {
+                let mut runtime = start_claude(session)?;
+                let transport = runtime.send(message).await?;
+                Ok((Some(runtime), transport))
+            }
+            agent_session::AGENT_CODEX => {
+                let mut runtime = start_codex(session).await?;
+                let transport = runtime.send(message).await?;
+                Ok((Some(runtime), transport))
+            }
+            agent_session::AGENT_GEMINI => {
+                resume_gemini(session, message).await?;
+                Ok((None, "gemini-resume"))
+            }
+            other => Err(failed(format!(
+                "messaging {other} sessions is not supported"
+            ))),
         }
-        agent_session::AGENT_CODEX => {
-            let mut runtime = start_codex(session).await?;
-            let transport = runtime.send(message).await?;
-            (Some(runtime), transport)
-        }
-        agent_session::AGENT_GEMINI => {
-            resume_gemini(session, message).await?;
+    })
+    .await;
+    let (runtime, transport) = match started {
+        Ok(started) => started,
+        Err(error) => {
             drop(runtime_slot);
             remove_empty_runtime_slot(&session.session_id, &slot).await;
-            return Ok(SubmitResult {
-                transport: "gemini-resume",
-            });
-        }
-        other => {
-            return Err(failed(format!(
-                "messaging {other} sessions is not supported"
-            )));
+            return Err(error);
         }
     };
     if let Some(runtime) = runtime {
         *runtime_slot = Some(runtime);
+    } else {
+        drop(runtime_slot);
+        remove_empty_runtime_slot(&session.session_id, &slot).await;
     }
     Ok(SubmitResult { transport })
+}
+
+async fn timeout_provider_operation<T, F>(timeout: Duration, operation: F) -> Result<T, SubmitError>
+where
+    F: Future<Output = Result<T, SubmitError>>,
+{
+    tokio::time::timeout(timeout, operation)
+        .await
+        .map_err(|_| failed("provider did not accept the message within 20 seconds"))?
 }
 
 async fn remove_empty_runtime_slot(session_id: &str, slot: &RuntimeSlot) {
@@ -415,6 +443,7 @@ async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
     let mut command = codex_command(session);
     command.args(["app-server", "--listen", "stdio://"]);
     configure(&mut command, session, true)?;
+    command.kill_on_drop(true);
     let mut child = command
         .spawn()
         .map_err(|error| failed(format!("failed to start Codex app-server: {error}")))?;
@@ -459,7 +488,7 @@ async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
         starting: false,
     }));
     let responses = Arc::new(StdMutex::new(HashMap::new()));
-    let stdin = Arc::new(AsyncMutex::new(stdin));
+    let stdin = Arc::new(AsyncMutex::new(Some(stdin)));
     tokio::spawn(read_codex(
         reader,
         Arc::clone(&state),
@@ -494,7 +523,10 @@ async fn read_codex<R>(
     loop {
         match read_provider_line(&mut reader, &mut line, MAX_CODEX_MESSAGE_BYTES).await {
             Ok(ProviderLine::Complete) => {}
-            Ok(ProviderLine::Oversized) => continue,
+            Ok(ProviderLine::Oversized) => {
+                fail_oversized_codex_transport(&state, &responses, &stdin).await;
+                break;
+            }
             Ok(ProviderLine::Eof) | Err(_) => break,
         }
         let Ok(value) = serde_json::from_slice::<Value>(&line) else {
@@ -506,7 +538,10 @@ async fn read_codex<R>(
             };
             let result = {
                 let mut stdin = stdin.lock().await;
-                send_json(&mut stdin, rejection).await
+                match stdin.as_mut() {
+                    Some(stdin) => send_json(stdin, rejection).await,
+                    None => break,
+                }
             };
             if let Err(error) = result {
                 fail_codex_responses(&responses, submit_error_message(error));
@@ -536,6 +571,29 @@ async fn read_codex<R>(
         &responses,
         "Codex transport closed before acknowledging the request".into(),
     );
+}
+
+async fn fail_oversized_codex_transport(
+    state: &Arc<StdMutex<CodexState>>,
+    responses: &PendingCodexResponses,
+    stdin: &WeakCodexStdin,
+) {
+    if let Ok(mut state) = state.lock() {
+        state.active_turn = None;
+        state.starting = false;
+    }
+    fail_codex_responses(
+        responses,
+        format!(
+            "Codex message exceeded the {} byte transport limit",
+            MAX_CODEX_MESSAGE_BYTES
+        ),
+    );
+    if let Some(stdin) = stdin.upgrade() {
+        // ChildStdin::shutdown is a no-op on Unix. Removing and dropping the
+        // handle is what actually closes the provider pipe and lets it exit.
+        stdin.lock().await.take();
+    }
 }
 
 fn complete_codex_response(value: &Value, responses: &PendingCodexResponses) {
@@ -622,7 +680,12 @@ where
             .map_err(|error| failed(error.to_string()))?
         {
             ProviderLine::Complete => {}
-            ProviderLine::Oversized => continue,
+            ProviderLine::Oversized => {
+                return Err(failed(format!(
+                    "Codex message exceeded the {} byte transport limit during initialization",
+                    MAX_CODEX_MESSAGE_BYTES
+                )));
+            }
             ProviderLine::Eof => {
                 return Err(failed("provider transport closed during initialization"));
             }
@@ -747,11 +810,24 @@ fn session_is_running(session: &AgentSession) -> bool {
 
 async fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
     let mut command = provider_command_with_override("gemini", GEMINI_BIN_ENV);
-    command.args(["--resume", &session.session_id, message]);
+    command.args(gemini_resume_args(&session.session_id));
     configure(&mut command, session, false)?;
+    command.stdin(Stdio::piped()).kill_on_drop(true);
     let mut child = command
         .spawn()
         .map_err(|error| failed(format!("failed to resume Gemini session: {error}")))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| failed("Gemini stdin unavailable"))?;
+    stdin
+        .write_all(message.as_bytes())
+        .await
+        .map_err(|error| failed(format!("failed to send the Gemini message: {error}")))?;
+    stdin
+        .shutdown()
+        .await
+        .map_err(|error| failed(format!("failed to finish the Gemini message: {error}")))?;
     tokio::time::sleep(Duration::from_millis(300)).await;
     if let Some(status) = child
         .try_wait()
@@ -765,6 +841,10 @@ async fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), Subm
     }
     reap(child, "gemini", session.session_id.clone());
     Ok(())
+}
+
+fn gemini_resume_args(session_id: &str) -> [&str; 2] {
+    ["--resume", session_id]
 }
 
 fn provider_command(name: &str) -> Command {
@@ -861,7 +941,7 @@ fn standalone_codex_binary(home: &Path, version: &str) -> Option<PathBuf> {
         let Some(name) = entry.file_name().to_str().map(str::to_string) else {
             continue;
         };
-        if name != version && !name.starts_with(&prefix) {
+        if !standalone_release_matches_platform(&name, version, &prefix) {
             continue;
         }
         let path = entry.path().join("bin").join(&executable);
@@ -874,6 +954,35 @@ fn standalone_codex_binary(home: &Path, version: &str) -> Option<PathBuf> {
         }
     }
     best.map(|(_, path)| path)
+}
+
+fn standalone_release_matches_platform(name: &str, version: &str, prefix: &str) -> bool {
+    if name == version {
+        return true;
+    }
+    name.starts_with(prefix)
+        && name.contains(std::env::consts::ARCH)
+        && name.contains(standalone_target_marker())
+}
+
+#[cfg(target_os = "linux")]
+fn standalone_target_marker() -> &'static str {
+    "unknown-linux"
+}
+
+#[cfg(target_os = "macos")]
+fn standalone_target_marker() -> &'static str {
+    "apple-darwin"
+}
+
+#[cfg(target_os = "windows")]
+fn standalone_target_marker() -> &'static str {
+    "pc-windows"
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+fn standalone_target_marker() -> &'static str {
+    std::env::consts::OS
 }
 
 #[cfg(unix)]
@@ -956,7 +1065,12 @@ fn configure_provider_identity(
     )?;
     let account = provider_account(uid)?;
     let provider_home = provider_session_home(session_path).unwrap_or(account.home);
+    let preserved_environment = std::env::vars_os()
+        .filter(|(key, _)| provider_environment_allowed(key))
+        .collect::<Vec<_>>();
+    command.env_clear();
     command
+        .envs(preserved_environment)
         .env("HOME", provider_home)
         .env("USER", &account.name)
         .env("LOGNAME", &account.name);
@@ -977,12 +1091,98 @@ fn configure_provider_identity(
     Ok(())
 }
 
-#[cfg(not(unix))]
+#[cfg(unix)]
+fn provider_environment_allowed(key: &std::ffi::OsStr) -> bool {
+    let key = key.to_string_lossy();
+    key.starts_with("LC_")
+        || matches!(
+            key.as_ref(),
+            "PATH"
+                | "LANG"
+                | "TZ"
+                | "TERM"
+                | "COLORTERM"
+                | "NO_COLOR"
+                | "SSL_CERT_FILE"
+                | "SSL_CERT_DIR"
+        )
+}
+
+#[cfg(target_os = "windows")]
+fn configure_provider_identity(
+    _command: &mut Command,
+    session_path: &Path,
+) -> Result<(), SubmitError> {
+    let provider_homes = ["HOME", "USERPROFILE"]
+        .into_iter()
+        .filter_map(std::env::var_os)
+        .filter(|home| !home.is_empty())
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+    if provider_homes.is_empty() {
+        return Err(failed(
+            "refusing to run a Windows session provider because the current user profile is unknown",
+        ));
+    }
+    validate_windows_provider_context(windows_process_is_elevated(), session_path, &provider_homes)
+}
+
+#[cfg(target_os = "windows")]
+fn validate_windows_provider_context(
+    elevated: bool,
+    session_path: &Path,
+    provider_homes: &[PathBuf],
+) -> Result<(), SubmitError> {
+    if elevated {
+        return Err(failed(
+            "refusing to run a session provider from an elevated Windows process; run AgentSight as the transcript owner",
+        ));
+    }
+    let session_path = session_path.canonicalize().map_err(|error| {
+        failed(format!(
+            "cannot validate the Windows provider session path {}: {error}",
+            session_path.display()
+        ))
+    })?;
+    let provider_homes = provider_homes
+        .iter()
+        .filter_map(|home| home.canonicalize().ok())
+        .collect::<Vec<_>>();
+    if provider_homes.is_empty() {
+        return Err(failed(
+            "refusing to run a Windows session provider because no current user profile path is usable",
+        ));
+    }
+    if !provider_homes
+        .iter()
+        .any(|provider_home| session_path.starts_with(provider_home))
+    {
+        return Err(failed(format!(
+            "refusing to run a provider for a Windows session outside the current user profile: {}",
+            session_path.display()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn windows_process_is_elevated() -> bool {
+    #[link(name = "shell32")]
+    unsafe extern "system" {
+        fn IsUserAnAdmin() -> i32;
+    }
+
+    unsafe { IsUserAnAdmin() != 0 }
+}
+
+#[cfg(not(any(unix, target_os = "windows")))]
 fn configure_provider_identity(
     _command: &mut Command,
     _session_path: &Path,
 ) -> Result<(), SubmitError> {
-    Ok(())
+    Err(failed(
+        "session provider execution is unsupported on this platform",
+    ))
 }
 
 #[cfg(unix)]
@@ -1098,6 +1298,37 @@ fn failed(message: impl Into<String>) -> SubmitError {
 mod tests {
     use super::*;
 
+    #[cfg(unix)]
+    static PROVIDER_ENV_LOCK: OnceLock<AsyncMutex<()>> = OnceLock::new();
+
+    #[cfg(unix)]
+    fn provider_env_lock() -> &'static AsyncMutex<()> {
+        PROVIDER_ENV_LOCK.get_or_init(|| AsyncMutex::new(()))
+    }
+
+    fn test_session(session_id: &str, agent_type: &str) -> AgentSession {
+        AgentSession {
+            agent_type: agent_type.into(),
+            session_id: session_id.into(),
+            conversation_id: None,
+            display_id: session_id.into(),
+            path: PathBuf::from(format!("{session_id}.jsonl")),
+            updated: SystemTime::now(),
+            start_timestamp_ms: None,
+            end_timestamp_ms: None,
+            model: None,
+            usage: Default::default(),
+            model_usage: Default::default(),
+            tools: Default::default(),
+            files: Default::default(),
+            prompt_preview: None,
+            duration_ms: 0,
+            cwd: None,
+            last_message_at: None,
+            events: Default::default(),
+        }
+    }
+
     #[cfg(target_os = "windows")]
     #[test]
     fn provider_resolution_accepts_cmd_shims() {
@@ -1118,6 +1349,32 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn windows_provider_execution_is_limited_to_a_non_elevated_profile() {
+        let profile = tempfile::tempdir().unwrap();
+        let alternate_profile = tempfile::tempdir().unwrap();
+        let session = profile.path().join(".codex/sessions/session.jsonl");
+        std::fs::create_dir_all(session.parent().unwrap()).unwrap();
+        std::fs::write(&session, b"{}\n").unwrap();
+        let profiles = [
+            alternate_profile.path().to_path_buf(),
+            profile.path().to_path_buf(),
+        ];
+
+        assert!(validate_windows_provider_context(false, &session, &profiles).is_ok());
+        assert!(matches!(
+            validate_windows_provider_context(true, &session, &profiles),
+            Err(SubmitError::Failed(message)) if message.contains("elevated Windows")
+        ));
+
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        assert!(matches!(
+            validate_windows_provider_context(false, outside.path(), &profiles),
+            Err(SubmitError::Failed(message)) if message.contains("outside the current user profile")
+        ));
+    }
+
     #[test]
     fn codex_session_version_selects_the_matching_standalone_binary() {
         let temp = tempfile::tempdir().unwrap();
@@ -1133,19 +1390,34 @@ mod tests {
         .unwrap();
         let wrong_arch = temp
             .path()
-            .join(".codex/packages/standalone/releases/0.147.0-aaa-wrong-arch/bin")
+            .join(format!(
+                ".codex/packages/standalone/releases/0.147.0-aaa-{}/bin",
+                standalone_target_marker()
+            ))
+            .join(format!("codex{}", std::env::consts::EXE_SUFFIX));
+        let wrong_os = temp
+            .path()
+            .join(format!(
+                ".codex/packages/standalone/releases/0.147.0-{}-wrong-platform/bin",
+                std::env::consts::ARCH
+            ))
             .join(format!("codex{}", std::env::consts::EXE_SUFFIX));
         let executable = temp
             .path()
             .join(format!(
-                ".codex/packages/standalone/releases/0.147.0-{}-test/bin",
-                std::env::consts::ARCH
+                ".codex/packages/standalone/releases/0.147.0-{}-{}/bin",
+                std::env::consts::ARCH,
+                standalone_target_marker()
             ))
             .join(format!("codex{}", std::env::consts::EXE_SUFFIX));
         std::fs::create_dir_all(wrong_arch.parent().unwrap()).unwrap();
         std::fs::write(&wrong_arch, b"wrong architecture").unwrap();
         #[cfg(unix)]
         std::fs::set_permissions(&wrong_arch, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::create_dir_all(wrong_os.parent().unwrap()).unwrap();
+        std::fs::write(&wrong_os, b"wrong operating system").unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&wrong_os, std::fs::Permissions::from_mode(0o755)).unwrap();
         std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
         std::fs::write(&executable, b"probe").unwrap();
         #[cfg(unix)]
@@ -1156,6 +1428,73 @@ mod tests {
             standalone_codex_binary(temp.path(), "0.147.0"),
             Some(executable)
         );
+    }
+
+    #[test]
+    fn codex_session_version_rejects_a_wrong_platform_only_release() {
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp
+            .path()
+            .join(format!(
+                ".codex/packages/standalone/releases/0.147.0-{}-wrong-platform/bin",
+                std::env::consts::ARCH
+            ))
+            .join(format!("codex{}", std::env::consts::EXE_SUFFIX));
+        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        std::fs::write(&executable, b"wrong operating system").unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(standalone_codex_binary(temp.path(), "0.147.0"), None);
+    }
+
+    #[test]
+    fn gemini_resume_command_never_places_the_message_in_process_arguments() {
+        assert_eq!(gemini_resume_args("session-1"), ["--resume", "session-1"]);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn gemini_resume_streams_the_full_public_message_over_stdin() {
+        let _environment_guard = provider_env_lock().lock().await;
+        let temp = tempfile::tempdir().unwrap();
+        let program = temp.path().join("gemini-probe");
+        let arguments = temp.path().join("arguments");
+        let input = temp.path().join("input");
+        std::fs::write(
+            &program,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$@\" > '{}'\ncat > '{}'\n",
+                arguments.display(),
+                input.display()
+            ),
+        )
+        .unwrap();
+        std::fs::set_permissions(&program, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let mut session = test_session("gemini-session", agent_session::AGENT_GEMINI);
+        session.path = temp.path().join("session.json");
+        session.cwd = Some(temp.path().to_string_lossy().to_string());
+        std::fs::write(&session.path, b"{}\n").unwrap();
+        let previous_program = std::env::var_os(GEMINI_BIN_ENV);
+        unsafe {
+            std::env::set_var(GEMINI_BIN_ENV, &program);
+        }
+        let message = "x".repeat(65_536);
+
+        let result = resume_gemini(&session, &message).await;
+
+        unsafe {
+            match previous_program {
+                Some(value) => std::env::set_var(GEMINI_BIN_ENV, value),
+                None => std::env::remove_var(GEMINI_BIN_ENV),
+            }
+        }
+        result.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(arguments).unwrap(),
+            "--resume\ngemini-session\n"
+        );
+        assert_eq!(std::fs::read_to_string(input).unwrap(), message);
     }
 
     #[test]
@@ -1177,8 +1516,9 @@ mod tests {
     fn codex_session_version_skips_non_executable_standalone_binary() {
         let temp = tempfile::tempdir().unwrap();
         let executable = temp.path().join(format!(
-            ".codex/packages/standalone/releases/0.147.0-{}-test/bin/codex",
-            std::env::consts::ARCH
+            ".codex/packages/standalone/releases/0.147.0-{}-{}/bin/codex",
+            std::env::consts::ARCH,
+            standalone_target_marker()
         ));
         std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
         std::fs::write(&executable, b"not executable").unwrap();
@@ -1247,9 +1587,17 @@ mod tests {
         if unsafe { libc::geteuid() } != 0 {
             return;
         }
+        let _environment_guard = provider_env_lock().lock().await;
         let Some((expected_uid, expected_gid)) = crate::cmd_exec::target_user_ids() else {
             return;
         };
+        let previous_sentinel = std::env::var_os("AGENTSIGHT_TEST_PARENT_SECRET");
+        unsafe {
+            std::env::set_var(
+                "AGENTSIGHT_TEST_PARENT_SECRET",
+                "must-not-cross-uid-boundary",
+            );
+        }
         let temp = tempfile::tempdir().unwrap();
         let session_path = temp.path().join(".claude/projects/test/session.jsonl");
         std::fs::create_dir_all(session_path.parent().unwrap()).unwrap();
@@ -1259,7 +1607,7 @@ mod tests {
         command
             .args([
                 "-c",
-                "printf '%s\\n' \"$(id -u)\" \"$(id -g)\" \"$(id -G)\" \"$HOME\" \"$USER\" \"$LOGNAME\"",
+                "printf '%s\\n' \"$(id -u)\" \"$(id -g)\" \"$(id -G)\" \"$HOME\" \"$USER\" \"$LOGNAME\" \"${AGENTSIGHT_TEST_PARENT_SECRET+present}\"",
             ])
             .stdout(Stdio::piped());
         configure_provider_identity(&mut command, &session_path).unwrap();
@@ -1274,6 +1622,13 @@ mod tests {
         assert_eq!(Path::new(lines[3]), temp.path());
         assert_eq!(lines[4], account.name.to_string_lossy());
         assert_eq!(lines[5], account.name.to_string_lossy());
+        assert_eq!(lines[6], "");
+        unsafe {
+            match previous_sentinel {
+                Some(value) => std::env::set_var("AGENTSIGHT_TEST_PARENT_SECRET", value),
+                None => std::env::remove_var("AGENTSIGHT_TEST_PARENT_SECRET"),
+            }
+        }
     }
 
     #[cfg(unix)]
@@ -1286,7 +1641,7 @@ mod tests {
             .stderr(Stdio::null())
             .spawn()
             .unwrap();
-        let stdin = Arc::new(AsyncMutex::new(child.stdin.take().unwrap()));
+        let stdin = Arc::new(AsyncMutex::new(Some(child.stdin.take().unwrap())));
         let reader_handle = Arc::downgrade(&stdin);
 
         drop(stdin);
@@ -1302,7 +1657,7 @@ mod tests {
     #[tokio::test]
     async fn runtime_slot_cleanup_does_not_remove_a_slot_held_by_a_waiter() {
         let session_id = format!("cleanup-waiter-{}", now_ms());
-        let slot = Arc::new(AsyncMutex::new(None));
+        let slot: RuntimeSlot = Arc::new(AsyncMutex::new(None));
         runtimes()
             .lock()
             .await
@@ -1314,6 +1669,54 @@ mod tests {
 
         drop(waiter);
         remove_empty_runtime_slot(&session_id, &slot).await;
+        assert!(!runtimes().lock().await.contains_key(&session_id));
+    }
+
+    #[tokio::test]
+    async fn runtime_slot_rejects_a_concurrent_message_without_waiting() {
+        let session_id = format!("concurrent-message-{}", now_ms());
+        let session = test_session(&session_id, "unsupported");
+        let slot: RuntimeSlot = Arc::new(AsyncMutex::new(None));
+        runtimes()
+            .lock()
+            .await
+            .insert(session_id.clone(), Arc::clone(&slot));
+        let active_request = slot.lock().await;
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(100),
+            submit_message(&session, "must not wait"),
+        )
+        .await
+        .expect("a concurrent submit must fail without waiting");
+
+        assert!(matches!(result, Err(SubmitError::Conflict(_))));
+        drop(active_request);
+        runtimes().lock().await.remove(&session_id);
+    }
+
+    #[tokio::test]
+    async fn new_provider_start_and_first_send_share_one_deadline() {
+        let result = timeout_provider_operation(
+            Duration::from_millis(10),
+            std::future::pending::<Result<(Option<Runtime>, &'static str), SubmitError>>(),
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(SubmitError::Failed(message)) if message.contains("within 20 seconds"))
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_runtime_start_does_not_leave_an_empty_slot() {
+        let session_id = format!("failed-runtime-start-{}", now_ms());
+        let session = test_session(&session_id, "unsupported");
+
+        assert!(matches!(
+            submit_message(&session, "unsupported").await,
+            Err(SubmitError::Failed(_))
+        ));
         assert!(!runtimes().lock().await.contains_key(&session_id));
     }
 
@@ -1373,6 +1776,43 @@ mod tests {
             serde_json::from_slice::<Value>(&line).unwrap()["method"],
             json!("turn/completed")
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn oversized_codex_message_closes_transport_and_clears_state() {
+        let mut child = Command::new("sh")
+            .args(["-c", "cat >/dev/null"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdin = Arc::new(AsyncMutex::new(Some(child.stdin.take().unwrap())));
+        let state = Arc::new(StdMutex::new(CodexState {
+            thread_id: "thread-1".into(),
+            active_turn: Some("turn-1".into()),
+            starting: true,
+        }));
+        let responses = Arc::new(StdMutex::new(HashMap::new()));
+        let (response_tx, response_rx) = oneshot::channel();
+        responses.lock().unwrap().insert(7, response_tx);
+
+        fail_oversized_codex_transport(&state, &responses, &Arc::downgrade(&stdin)).await;
+
+        let error = response_rx.await.unwrap().unwrap_err();
+        assert!(error.contains("transport limit"));
+        assert!(responses.lock().unwrap().is_empty());
+        {
+            let state = state.lock().unwrap();
+            assert!(!state.starting);
+            assert!(state.active_turn.is_none());
+        }
+        let status = tokio::time::timeout(Duration::from_secs(2), child.wait())
+            .await
+            .expect("closing an oversized transport should stop the provider")
+            .unwrap();
+        assert!(status.success());
     }
 
     #[test]

--- a/collector/src/server/session_runtime.rs
+++ b/collector/src/server/session_runtime.rs
@@ -6,22 +6,52 @@ use serde_json::{Value, json};
 use std::collections::{HashMap, HashSet};
 #[cfg(target_os = "windows")]
 use std::ffi::OsStr;
-#[cfg(target_os = "windows")]
+#[cfg(unix)]
+use std::ffi::{CStr, OsString};
+use std::fs::File;
+use std::io::{BufRead, BufReader as StdBufReader, Read};
+#[cfg(unix)]
+use std::os::unix::{
+    ffi::OsStringExt,
+    fs::{MetadataExt, PermissionsExt},
+};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::{Arc, Mutex as StdMutex, OnceLock};
-use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use std::sync::{Arc, Mutex as StdMutex, OnceLock, Weak};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::{Child, ChildStdin, Command};
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex as AsyncMutex, oneshot};
 
 use crate::sources::proc as procfs;
 use crate::view::process_select;
 
-static RUNTIMES: OnceLock<Mutex<HashMap<String, Runtime>>> = OnceLock::new();
+type RuntimeSlot = Arc<AsyncMutex<Option<Runtime>>>;
 
-fn runtimes() -> &'static Mutex<HashMap<String, Runtime>> {
-    RUNTIMES.get_or_init(|| Mutex::new(HashMap::new()))
+static RUNTIMES: OnceLock<AsyncMutex<HashMap<String, RuntimeSlot>>> = OnceLock::new();
+const PROVIDER_REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
+const MAX_PROVIDER_MESSAGE_BYTES: usize = 1024 * 1024;
+const MAX_CODEX_MESSAGE_BYTES: usize = 16 * 1024 * 1024;
+const SESSION_HEADER_SCAN_LIMIT: u64 = 64 * 1024;
+const CODEX_BIN_ENV: &str = "AGENTSIGHT_CODEX_BIN";
+const CLAUDE_BIN_ENV: &str = "AGENTSIGHT_CLAUDE_BIN";
+const GEMINI_BIN_ENV: &str = "AGENTSIGHT_GEMINI_BIN";
+
+type CodexResponse = Result<(), String>;
+type PendingClaudeResponse = Arc<StdMutex<Option<oneshot::Sender<CodexResponse>>>>;
+type PendingCodexResponses = Arc<StdMutex<HashMap<u64, oneshot::Sender<CodexResponse>>>>;
+type SharedCodexStdin = Arc<AsyncMutex<ChildStdin>>;
+type WeakCodexStdin = Weak<AsyncMutex<ChildStdin>>;
+
+#[derive(Debug, Eq, PartialEq)]
+enum ProviderLine {
+    Complete,
+    Oversized,
+    Eof,
+}
+
+fn runtimes() -> &'static AsyncMutex<HashMap<String, RuntimeSlot>> {
+    RUNTIMES.get_or_init(|| AsyncMutex::new(HashMap::new()))
 }
 
 #[derive(Debug)]
@@ -35,12 +65,22 @@ pub struct SubmitResult {
 }
 
 enum Runtime {
-    Claude(ChildStdin),
-    Codex {
+    Claude {
         stdin: ChildStdin,
+        state: Arc<StdMutex<ClaudeState>>,
+        response: PendingClaudeResponse,
+    },
+    Codex {
+        stdin: SharedCodexStdin,
         state: Arc<StdMutex<CodexState>>,
+        responses: PendingCodexResponses,
         next_id: u64,
     },
+}
+
+struct ClaudeState {
+    starting: bool,
+    active: bool,
 }
 
 struct CodexState {
@@ -52,20 +92,59 @@ struct CodexState {
 impl Runtime {
     async fn send(&mut self, message: &str) -> Result<&'static str, SubmitError> {
         match self {
-            Self::Claude(stdin) => {
-                send_json(
+            Self::Claude {
+                stdin,
+                state,
+                response,
+            } => {
+                {
+                    let mut state = state
+                        .lock()
+                        .map_err(|_| failed("Claude state lock poisoned"))?;
+                    if state.starting || state.active {
+                        return Err(SubmitError::Conflict(
+                            "Claude is still handling the previous message".into(),
+                        ));
+                    }
+                    state.starting = true;
+                }
+                let (response_tx, response_rx) = oneshot::channel();
+                *response
+                    .lock()
+                    .map_err(|_| failed("Claude response lock poisoned"))? = Some(response_tx);
+                if let Err(error) = send_json(
                     stdin,
                     json!({
                         "type":"user",
                         "message":{"role":"user","content":[{"type":"text","text":message}]}
                     }),
                 )
-                .await?;
-                Ok("claude-stream-json")
+                .await
+                {
+                    if let Ok(mut pending) = response.lock() {
+                        pending.take();
+                    }
+                    if let Ok(mut state) = state.lock() {
+                        state.starting = false;
+                    }
+                    return Err(error);
+                }
+                match tokio::time::timeout(PROVIDER_REQUEST_TIMEOUT, response_rx).await {
+                    Ok(Ok(Ok(()))) => Ok("claude-stream-json"),
+                    Ok(Ok(Err(error))) => Err(failed(error)),
+                    Ok(Err(_)) => Err(failed("Claude response channel closed")),
+                    Err(_) => {
+                        if let Ok(mut pending) = response.lock() {
+                            pending.take();
+                        }
+                        Err(failed("Claude did not produce output within 20 seconds"))
+                    }
+                }
             }
             Self::Codex {
                 stdin,
                 state,
+                responses,
                 next_id,
             } => {
                 let (thread_id, active_turn, starting) = state
@@ -74,7 +153,8 @@ impl Runtime {
                     .map_err(|_| failed("Codex state lock poisoned"))?;
                 if starting {
                     return Err(SubmitError::Conflict(
-                        "Codex is accepting the previous message; retry after the turn starts".into(),
+                        "Codex is accepting the previous message; retry after the turn starts"
+                            .into(),
                     ));
                 }
                 *next_id += 1;
@@ -85,20 +165,55 @@ impl Runtime {
                             "input":[{"type":"text","text":message}]}
                     })
                 } else {
-                    state.lock().map_err(|_| failed("Codex state lock poisoned"))?.starting = true;
+                    state
+                        .lock()
+                        .map_err(|_| failed("Codex state lock poisoned"))?
+                        .starting = true;
                     json!({
                         "method":"turn/start","id":*next_id,
                         "params":{"threadId":thread_id,
                             "input":[{"type":"text","text":message}]}
                     })
                 };
-                if let Err(error) = send_json(stdin, request).await {
+                let request_id = *next_id;
+                let (response_tx, response_rx) = oneshot::channel();
+                responses
+                    .lock()
+                    .map_err(|_| failed("Codex response lock poisoned"))?
+                    .insert(request_id, response_tx);
+                let send_result = {
+                    let mut stdin = stdin.lock().await;
+                    send_json(&mut stdin, request).await
+                };
+                if let Err(error) = send_result {
+                    if let Ok(mut pending) = responses.lock() {
+                        pending.remove(&request_id);
+                    }
                     if let Ok(mut state) = state.lock() {
                         state.starting = false;
                     }
                     return Err(error);
                 }
-                Ok("codex-app-server")
+                let response = tokio::time::timeout(PROVIDER_REQUEST_TIMEOUT, response_rx).await;
+                let result = match response {
+                    Ok(Ok(Ok(()))) => Ok("codex-app-server"),
+                    Ok(Ok(Err(error))) => Err(failed(error)),
+                    Ok(Err(_)) => Err(failed("Codex response channel closed")),
+                    Err(_) => {
+                        if let Ok(mut pending) = responses.lock() {
+                            pending.remove(&request_id);
+                        }
+                        Err(failed(
+                            "Codex did not acknowledge the message within 20 seconds",
+                        ))
+                    }
+                };
+                if result.is_err()
+                    && let Ok(mut state) = state.lock()
+                {
+                    state.starting = false;
+                }
+                result
             }
         }
     }
@@ -108,13 +223,23 @@ pub async fn submit_message(
     session: &AgentSession,
     message: &str,
 ) -> Result<SubmitResult, SubmitError> {
-    let mut map = runtimes().lock().await;
-    if let Some(runtime) = map.get_mut(&session.session_id) {
+    let slot = {
+        let mut map = runtimes().lock().await;
+        Arc::clone(
+            map.entry(session.session_id.clone())
+                .or_insert_with(|| Arc::new(AsyncMutex::new(None))),
+        )
+    };
+    let mut runtime_slot = slot.lock().await;
+    if let Some(runtime) = runtime_slot.as_mut() {
         match runtime.send(message).await {
             Ok(transport) => return Ok(SubmitResult { transport }),
             Err(SubmitError::Conflict(error)) => return Err(SubmitError::Conflict(error)),
-            Err(SubmitError::Failed(_)) => {
-                map.remove(&session.session_id);
+            Err(SubmitError::Failed(error)) => {
+                *runtime_slot = None;
+                drop(runtime_slot);
+                remove_empty_runtime_slot(&session.session_id, &slot).await;
+                return Err(SubmitError::Failed(error));
             }
         }
     }
@@ -138,22 +263,41 @@ pub async fn submit_message(
             (Some(runtime), transport)
         }
         agent_session::AGENT_GEMINI => {
-            drop(map);
-            resume_gemini(session, message)?;
+            resume_gemini(session, message).await?;
+            drop(runtime_slot);
+            remove_empty_runtime_slot(&session.session_id, &slot).await;
             return Ok(SubmitResult {
                 transport: "gemini-resume",
             });
         }
-        other => return Err(failed(format!("messaging {other} sessions is not supported"))),
+        other => {
+            return Err(failed(format!(
+                "messaging {other} sessions is not supported"
+            )));
+        }
     };
     if let Some(runtime) = runtime {
-        map.insert(session.session_id.clone(), runtime);
+        *runtime_slot = Some(runtime);
     }
     Ok(SubmitResult { transport })
 }
 
+async fn remove_empty_runtime_slot(session_id: &str, slot: &RuntimeSlot) {
+    let mut map = runtimes().lock().await;
+    if map
+        .get(session_id)
+        .is_some_and(|candidate| Arc::ptr_eq(candidate, slot))
+        // The map and this function must be the only owners. A cloned slot
+        // represents a waiter that may initialize it after we release the map.
+        && Arc::strong_count(slot) == 2
+        && slot.try_lock().is_ok_and(|runtime| runtime.is_none())
+    {
+        map.remove(session_id);
+    }
+}
+
 fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
-    let mut command = provider_command("claude");
+    let mut command = provider_command_with_override("claude", CLAUDE_BIN_ENV);
     command.args([
         "-p",
         "--resume",
@@ -162,72 +306,215 @@ fn start_claude(session: &AgentSession) -> Result<Runtime, SubmitError> {
         "--output-format=stream-json",
         "--verbose",
     ]);
-    configure(&mut command, session, true);
+    configure(&mut command, session, true)?;
     let mut child = command
         .spawn()
         .map_err(|error| failed(format!("failed to start Claude live session: {error}")))?;
-    let stdin = child.stdin.take().ok_or_else(|| failed("Claude stdin unavailable"))?;
-    let stdout = child.stdout.take().ok_or_else(|| failed("Claude stdout unavailable"))?;
-    tokio::spawn(drain(stdout));
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| failed("Claude stdin unavailable"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| failed("Claude stdout unavailable"))?;
+    let state = Arc::new(StdMutex::new(ClaudeState {
+        starting: false,
+        active: false,
+    }));
+    let response = Arc::new(StdMutex::new(None));
+    tokio::spawn(read_claude(
+        BufReader::new(stdout),
+        Arc::clone(&state),
+        Arc::clone(&response),
+    ));
     reap(child, "claude", session.session_id.clone());
-    Ok(Runtime::Claude(stdin))
+    Ok(Runtime::Claude {
+        stdin,
+        state,
+        response,
+    })
+}
+
+async fn read_claude<R>(
+    mut reader: BufReader<R>,
+    state: Arc<StdMutex<ClaudeState>>,
+    response: PendingClaudeResponse,
+) where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut line = Vec::new();
+    loop {
+        match read_provider_line(&mut reader, &mut line, MAX_PROVIDER_MESSAGE_BYTES).await {
+            Ok(ProviderLine::Complete) => {}
+            Ok(ProviderLine::Oversized) => continue,
+            Ok(ProviderLine::Eof) | Err(_) => break,
+        }
+        let Ok(value) = serde_json::from_slice::<Value>(&line) else {
+            continue;
+        };
+        let event_type = value.get("type").and_then(Value::as_str);
+        if matches!(event_type, Some("user" | "assistant")) {
+            complete_claude_response(&response, Ok(()));
+            if let Ok(mut state) = state.lock() {
+                state.starting = false;
+                state.active = true;
+            }
+        } else if event_type == Some("result") {
+            let is_error = value.get("is_error").and_then(Value::as_bool) == Some(true)
+                || value
+                    .get("subtype")
+                    .and_then(Value::as_str)
+                    .is_some_and(|subtype| subtype.contains("error"));
+            if is_error {
+                complete_claude_response(&response, Err(claude_error_message(&value)));
+            } else {
+                complete_claude_response(&response, Ok(()));
+            }
+            if let Ok(mut state) = state.lock() {
+                state.starting = false;
+                state.active = false;
+            }
+        } else if event_type == Some("error") {
+            complete_claude_response(&response, Err(claude_error_message(&value)));
+            if let Ok(mut state) = state.lock() {
+                state.starting = false;
+                state.active = false;
+            }
+        }
+    }
+    complete_claude_response(
+        &response,
+        Err("Claude transport closed before producing output".into()),
+    );
+    if let Ok(mut state) = state.lock() {
+        state.starting = false;
+        state.active = false;
+    }
+}
+
+fn complete_claude_response(response: &PendingClaudeResponse, result: CodexResponse) {
+    let pending = response.lock().ok().and_then(|mut pending| pending.take());
+    if let Some(pending) = pending {
+        let _ = pending.send(result);
+    }
+}
+
+fn claude_error_message(value: &Value) -> String {
+    value
+        .get("error")
+        .or_else(|| value.get("result"))
+        .or_else(|| value.get("message"))
+        .and_then(Value::as_str)
+        .filter(|message| !message.is_empty())
+        .map(|message| format!("Claude rejected the request: {message}"))
+        .unwrap_or_else(|| "Claude rejected the request".into())
 }
 
 async fn start_codex(session: &AgentSession) -> Result<Runtime, SubmitError> {
-    let mut command = provider_command("codex");
+    let mut command = codex_command(session);
     command.args(["app-server", "--listen", "stdio://"]);
-    configure(&mut command, session, true);
+    configure(&mut command, session, true)?;
     let mut child = command
         .spawn()
         .map_err(|error| failed(format!("failed to start Codex app-server: {error}")))?;
-    let mut stdin = child.stdin.take().ok_or_else(|| failed("Codex stdin unavailable"))?;
-    let stdout = child.stdout.take().ok_or_else(|| failed("Codex stdout unavailable"))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| failed("Codex stdin unavailable"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| failed("Codex stdout unavailable"))?;
     let mut reader = BufReader::new(stdout);
 
     send_json(
         &mut stdin,
         json!({"method":"initialize","id":1,"params":{
             "clientInfo":{"name":"agentsight","title":"AgentSight","version":env!("CARGO_PKG_VERSION")},
-            "capabilities":{"experimentalApi":true}
+            "capabilities":{
+                "experimentalApi":true,
+                "optOutNotificationMethods":[
+                    "item/started",
+                    "item/completed",
+                    "item/agentMessage/delta",
+                    "item/commandExecution/outputDelta",
+                    "item/reasoning/summaryTextDelta",
+                    "item/reasoning/textDelta",
+                    "item/plan/delta",
+                    "turn/diff/updated"
+                ]
+            }
         }}),
     )
     .await?;
-    wait_response(&mut reader, 1).await?;
+    wait_response(&mut reader, &mut stdin, 1, "initialize").await?;
     send_json(&mut stdin, json!({"method":"initialized","params":{}})).await?;
-    send_json(
-        &mut stdin,
-        json!({"method":"thread/resume","id":2,"params":{"threadId":session.session_id}}),
-    )
-    .await?;
-    wait_response(&mut reader, 2).await?;
+    send_json(&mut stdin, codex_resume_request(&session.session_id)).await?;
+    wait_response(&mut reader, &mut stdin, 2, "resume the thread").await?;
 
     let state = Arc::new(StdMutex::new(CodexState {
         thread_id: session.session_id.clone(),
         active_turn: None,
         starting: false,
     }));
-    tokio::spawn(read_codex(reader, Arc::clone(&state)));
+    let responses = Arc::new(StdMutex::new(HashMap::new()));
+    let stdin = Arc::new(AsyncMutex::new(stdin));
+    tokio::spawn(read_codex(
+        reader,
+        Arc::clone(&state),
+        Arc::clone(&responses),
+        Arc::downgrade(&stdin),
+    ));
     reap(child, "codex", session.session_id.clone());
     Ok(Runtime::Codex {
         stdin,
         state,
+        responses,
         next_id: 2,
     })
 }
 
-async fn read_codex<R>(mut reader: BufReader<R>, state: Arc<StdMutex<CodexState>>)
-where
+fn codex_resume_request(thread_id: &str) -> Value {
+    json!({"method":"thread/resume","id":2,"params":{
+        "threadId":thread_id,
+        "excludeTurns":true
+    }})
+}
+
+async fn read_codex<R>(
+    mut reader: BufReader<R>,
+    state: Arc<StdMutex<CodexState>>,
+    responses: PendingCodexResponses,
+    stdin: WeakCodexStdin,
+) where
     R: tokio::io::AsyncRead + Unpin,
 {
-    let mut line = String::new();
+    let mut line = Vec::new();
     loop {
-        line.clear();
-        if reader.read_line(&mut line).await.ok().filter(|n| *n > 0).is_none() {
-            break;
+        match read_provider_line(&mut reader, &mut line, MAX_CODEX_MESSAGE_BYTES).await {
+            Ok(ProviderLine::Complete) => {}
+            Ok(ProviderLine::Oversized) => continue,
+            Ok(ProviderLine::Eof) | Err(_) => break,
         }
-        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+        let Ok(value) = serde_json::from_slice::<Value>(&line) else {
             continue;
         };
+        if let Some(rejection) = codex_server_request_rejection(&value) {
+            let Some(stdin) = stdin.upgrade() else {
+                break;
+            };
+            let result = {
+                let mut stdin = stdin.lock().await;
+                send_json(&mut stdin, rejection).await
+            };
+            if let Err(error) = result {
+                fail_codex_responses(&responses, submit_error_message(error));
+                break;
+            }
+            continue;
+        }
+        complete_codex_response(&value, &responses);
         let method = value.get("method").and_then(Value::as_str);
         let turn = value
             .pointer("/params/turn/id")
@@ -245,31 +532,157 @@ where
             }
         }
     }
+    fail_codex_responses(
+        &responses,
+        "Codex transport closed before acknowledging the request".into(),
+    );
 }
 
-async fn wait_response<R>(reader: &mut BufReader<R>, id: u64) -> Result<(), SubmitError>
+fn complete_codex_response(value: &Value, responses: &PendingCodexResponses) {
+    let Some(id) = value.get("id").and_then(Value::as_u64) else {
+        return;
+    };
+    let Some(result) = codex_response(value) else {
+        return;
+    };
+    let response = responses
+        .lock()
+        .ok()
+        .and_then(|mut pending| pending.remove(&id));
+    if let Some(response) = response {
+        let _ = response.send(result);
+    }
+}
+
+fn codex_response(value: &Value) -> Option<CodexResponse> {
+    if value.get("method").is_some() {
+        return None;
+    }
+    if let Some(error) = value.get("error") {
+        return Some(Err(format!("Codex rejected the request: {error}")));
+    }
+    value.get("result").map(|_| Ok(()))
+}
+
+fn codex_server_request_rejection(value: &Value) -> Option<Value> {
+    let id = value.get("id")?;
+    value.get("method").and_then(Value::as_str)?;
+    Some(json!({
+        "id": id,
+        "error": {
+            "code": -32601,
+            "message": "AgentSight does not support Codex server requests"
+        }
+    }))
+}
+
+fn fail_codex_responses(responses: &PendingCodexResponses, message: String) {
+    if let Ok(mut pending) = responses.lock() {
+        for (_, response) in pending.drain() {
+            let _ = response.send(Err(message.clone()));
+        }
+    }
+}
+
+fn submit_error_message(error: SubmitError) -> String {
+    match error {
+        SubmitError::Conflict(message) | SubmitError::Failed(message) => message,
+    }
+}
+
+async fn wait_response<R>(
+    reader: &mut BufReader<R>,
+    stdin: &mut ChildStdin,
+    id: u64,
+    operation: &str,
+) -> Result<(), SubmitError>
 where
     R: tokio::io::AsyncRead + Unpin,
 {
-    let mut line = String::new();
+    tokio::time::timeout(
+        PROVIDER_REQUEST_TIMEOUT,
+        wait_response_inner(reader, stdin, id),
+    )
+    .await
+    .map_err(|_| failed(format!("Codex timed out while trying to {operation}")))?
+}
+
+async fn wait_response_inner<R>(
+    reader: &mut BufReader<R>,
+    stdin: &mut ChildStdin,
+    id: u64,
+) -> Result<(), SubmitError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut line = Vec::new();
     loop {
-        line.clear();
-        if reader
-            .read_line(&mut line)
+        match read_provider_line(reader, &mut line, MAX_CODEX_MESSAGE_BYTES)
             .await
             .map_err(|error| failed(error.to_string()))?
-            == 0
         {
-            return Err(failed("provider transport closed during initialization"));
+            ProviderLine::Complete => {}
+            ProviderLine::Oversized => continue,
+            ProviderLine::Eof => {
+                return Err(failed("provider transport closed during initialization"));
+            }
         }
-        let Ok(value) = serde_json::from_str::<Value>(line.trim()) else {
+        let Ok(value) = serde_json::from_slice::<Value>(&line) else {
             continue;
         };
+        if let Some(rejection) = codex_server_request_rejection(&value) {
+            send_json(stdin, rejection).await?;
+            continue;
+        }
         if value.get("id").and_then(Value::as_u64) == Some(id) {
-            return value
-                .get("error")
-                .map(|error| Err(failed(format!("provider rejected request: {error}"))))
-                .unwrap_or(Ok(()));
+            if let Some(response) = codex_response(&value) {
+                return response.map_err(failed);
+            }
+        }
+    }
+}
+
+async fn read_provider_line<R>(
+    reader: &mut R,
+    line: &mut Vec<u8>,
+    max_bytes: usize,
+) -> std::io::Result<ProviderLine>
+where
+    R: AsyncBufRead + Unpin,
+{
+    line.clear();
+    let mut oversized = false;
+    let mut saw_data = false;
+    loop {
+        let buffer = reader.fill_buf().await?;
+        if buffer.is_empty() {
+            return Ok(if !saw_data {
+                ProviderLine::Eof
+            } else if oversized {
+                ProviderLine::Oversized
+            } else {
+                ProviderLine::Complete
+            });
+        }
+        saw_data = true;
+        let consumed = buffer
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map_or(buffer.len(), |index| index + 1);
+        let complete = buffer.get(consumed.saturating_sub(1)) == Some(&b'\n');
+        if !oversized {
+            let remaining = max_bytes.saturating_sub(line.len());
+            let copied = consumed.min(remaining);
+            line.extend_from_slice(&buffer[..copied]);
+            oversized = copied < consumed;
+        }
+        reader.consume(consumed);
+        if complete {
+            return Ok(if oversized {
+                ProviderLine::Oversized
+            } else {
+                ProviderLine::Complete
+            });
         }
     }
 }
@@ -288,12 +701,8 @@ fn session_is_running(session: &AgentSession) -> bool {
             (process_select::known_agent_label(&root.comm, &root.command)
                 == Some(session.agent_type.as_str()))
             .then(|| {
-                let family = procfs::process_family_excluding(
-                    root_pid,
-                    &children,
-                    &sample.procs,
-                    &root_set,
-                );
+                let family =
+                    procfs::process_family_excluding(root_pid, &children, &sample.procs, &root_set);
                 let members = family
                     .into_iter()
                     .filter_map(|pid| sample.procs.get(&pid).map(procfs::ProcInfo::process_key))
@@ -313,7 +722,10 @@ fn session_is_running(session: &AgentSession) -> bool {
             })
         })
         .collect::<Vec<_>>();
-    let trees = candidates.iter().map(|candidate| candidate.tree.clone()).collect::<Vec<_>>();
+    let trees = candidates
+        .iter()
+        .map(|candidate| candidate.tree.clone())
+        .collect::<Vec<_>>();
     let fd_paths = procfs::collect_fd_paths(&trees);
     let input = agent_session::SessionProcessInput {
         id: session.session_id.clone(),
@@ -333,13 +745,24 @@ fn session_is_running(session: &AgentSession) -> bool {
     matches.by_session_id.contains_key(&session.session_id)
 }
 
-fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
-    let mut command = provider_command("gemini");
+async fn resume_gemini(session: &AgentSession, message: &str) -> Result<(), SubmitError> {
+    let mut command = provider_command_with_override("gemini", GEMINI_BIN_ENV);
     command.args(["--resume", &session.session_id, message]);
-    configure(&mut command, session, false);
-    let child = command
+    configure(&mut command, session, false)?;
+    let mut child = command
         .spawn()
         .map_err(|error| failed(format!("failed to resume Gemini session: {error}")))?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    if let Some(status) = child
+        .try_wait()
+        .map_err(|error| failed(format!("failed to inspect Gemini session: {error}")))?
+    {
+        return status.success().then_some(()).ok_or_else(|| {
+            failed(format!(
+                "Gemini exited before accepting the message: {status}"
+            ))
+        });
+    }
     reap(child, "gemini", session.session_id.clone());
     Ok(())
 }
@@ -355,6 +778,113 @@ fn provider_command(name: &str) -> Command {
     #[cfg(not(target_os = "windows"))]
     let program = name;
     Command::new(program)
+}
+
+fn provider_command_with_override(name: &str, variable: &str) -> Command {
+    std::env::var_os(variable)
+        .filter(|value| !value.is_empty())
+        .map(Command::new)
+        .unwrap_or_else(|| provider_command(name))
+}
+
+fn codex_command(session: &AgentSession) -> Command {
+    if let Some(program) = std::env::var_os(CODEX_BIN_ENV).filter(|value| !value.is_empty()) {
+        return Command::new(program);
+    }
+    if let Some(version) = codex_cli_version(&session.path)
+        && let Some(home) = codex_install_home(&session.path)
+        && let Some(program) = standalone_codex_binary(&home, &version)
+    {
+        return Command::new(program);
+    }
+    provider_command("codex")
+}
+
+fn codex_cli_version(path: &Path) -> Option<String> {
+    let reader = StdBufReader::new(File::open(path).ok()?.take(SESSION_HEADER_SCAN_LIMIT));
+    for line in reader.lines().take(32) {
+        let Ok(line) = line else {
+            break;
+        };
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if value.get("type").and_then(Value::as_str) != Some("session_meta") {
+            continue;
+        }
+        let Some(version) = value
+            .pointer("/payload/cli_version")
+            .or_else(|| value.pointer("/payload/cliVersion"))
+            .and_then(Value::as_str)
+        else {
+            continue;
+        };
+        if valid_provider_version(version) {
+            return Some(version.to_string());
+        }
+    }
+    None
+}
+
+fn codex_install_home(session_path: &Path) -> Option<PathBuf> {
+    let mut directory = session_path.parent();
+    while let Some(candidate) = directory {
+        if candidate
+            .file_name()
+            .is_some_and(|name| name.to_string_lossy().eq_ignore_ascii_case(".codex"))
+        {
+            return candidate.parent().map(Path::to_path_buf);
+        }
+        directory = candidate.parent();
+    }
+    dirs::home_dir()
+}
+
+fn valid_provider_version(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 64
+        && version.starts_with(|character: char| character.is_ascii_digit())
+        && version
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+'))
+}
+
+fn standalone_codex_binary(home: &Path, version: &str) -> Option<PathBuf> {
+    if !valid_provider_version(version) {
+        return None;
+    }
+    let releases = home.join(".codex/packages/standalone/releases");
+    let prefix = format!("{version}-");
+    let executable = format!("codex{}", std::env::consts::EXE_SUFFIX);
+    let mut best: Option<(bool, PathBuf)> = None;
+    for entry in std::fs::read_dir(releases).ok()?.filter_map(Result::ok) {
+        let Some(name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+        if name != version && !name.starts_with(&prefix) {
+            continue;
+        }
+        let path = entry.path().join("bin").join(&executable);
+        if !provider_binary_is_executable(&path) {
+            continue;
+        }
+        let candidate = (!name.contains(std::env::consts::ARCH), path);
+        if best.as_ref().is_none_or(|current| candidate < *current) {
+            best = Some(candidate);
+        }
+    }
+    best.map(|(_, path)| path)
+}
+
+#[cfg(unix)]
+fn provider_binary_is_executable(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .is_ok_and(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+}
+
+#[cfg(not(unix))]
+fn provider_binary_is_executable(path: &Path) -> bool {
+    path.is_file()
 }
 
 #[cfg(target_os = "windows")]
@@ -384,13 +914,150 @@ fn resolve_windows_program(
     None
 }
 
-fn configure(command: &mut Command, session: &AgentSession, piped: bool) {
+fn configure(
+    command: &mut Command,
+    session: &AgentSession,
+    piped: bool,
+) -> Result<(), SubmitError> {
     if let Some(cwd) = session.cwd.as_deref().filter(|cwd| !cwd.is_empty()) {
         command.current_dir(cwd);
     }
     command.stdin(if piped { Stdio::piped() } else { Stdio::null() });
     command.stdout(if piped { Stdio::piped() } else { Stdio::null() });
     command.stderr(Stdio::null());
+    configure_provider_identity(command, &session.path)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn configure_provider_identity(
+    command: &mut Command,
+    session_path: &Path,
+) -> Result<(), SubmitError> {
+    let metadata = std::fs::metadata(session_path).map_err(|error| {
+        failed(format!(
+            "cannot identify the provider session owner for {}: {error}",
+            session_path.display()
+        ))
+    })?;
+    let effective_uid = unsafe { libc::geteuid() } as u32;
+    if effective_uid != 0 {
+        if metadata.uid() != effective_uid {
+            return Err(failed(format!(
+                "refusing to run a provider for a session owned by uid {} as uid {effective_uid}",
+                metadata.uid()
+            )));
+        }
+        return Ok(());
+    }
+    let (uid, gid) = provider_user_ids(
+        (metadata.uid(), metadata.gid()),
+        crate::cmd_exec::target_user_ids(),
+    )?;
+    let account = provider_account(uid)?;
+    let provider_home = provider_session_home(session_path).unwrap_or(account.home);
+    command
+        .env("HOME", provider_home)
+        .env("USER", &account.name)
+        .env("LOGNAME", &account.name);
+    unsafe {
+        command.pre_exec(move || {
+            if libc::setgroups(0, std::ptr::null()) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::setgid(gid as libc::gid_t) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::setuid(uid as libc::uid_t) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn configure_provider_identity(
+    _command: &mut Command,
+    _session_path: &Path,
+) -> Result<(), SubmitError> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn provider_user_ids(
+    session_owner: (u32, u32),
+    sudo_user: Option<(u32, u32)>,
+) -> Result<(u32, u32), SubmitError> {
+    [Some(session_owner), sudo_user]
+        .into_iter()
+        .flatten()
+        .find(|(uid, gid)| *uid != 0 && *gid != 0)
+        .ok_or_else(|| {
+            failed("refusing to run a session provider as root because no non-root owner is known")
+        })
+}
+
+#[cfg(unix)]
+struct ProviderAccount {
+    name: OsString,
+    home: PathBuf,
+}
+
+#[cfg(unix)]
+fn provider_account(uid: u32) -> Result<ProviderAccount, SubmitError> {
+    let configured_size = unsafe { libc::sysconf(libc::_SC_GETPW_R_SIZE_MAX) };
+    let buffer_size = if configured_size > 0 {
+        configured_size as usize
+    } else {
+        16 * 1024
+    }
+    .clamp(1024, 1024 * 1024);
+    let mut buffer = vec![0_u8; buffer_size];
+    let mut passwd = unsafe { std::mem::zeroed::<libc::passwd>() };
+    let mut result = std::ptr::null_mut();
+    let status = unsafe {
+        libc::getpwuid_r(
+            uid as libc::uid_t,
+            &mut passwd,
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+            &mut result,
+        )
+    };
+    if status != 0 || result.is_null() || passwd.pw_name.is_null() || passwd.pw_dir.is_null() {
+        return Err(failed(format!(
+            "refusing to run a session provider because uid {uid} has no usable account"
+        )));
+    }
+    let name = unsafe { CStr::from_ptr(passwd.pw_name) }.to_bytes();
+    let home = unsafe { CStr::from_ptr(passwd.pw_dir) }.to_bytes();
+    if name.is_empty() || home.is_empty() {
+        return Err(failed(format!(
+            "refusing to run a session provider because uid {uid} has no usable account"
+        )));
+    }
+    Ok(ProviderAccount {
+        name: OsString::from_vec(name.to_vec()),
+        home: PathBuf::from(OsString::from_vec(home.to_vec())),
+    })
+}
+
+#[cfg(any(unix, test))]
+fn provider_session_home(session_path: &Path) -> Option<PathBuf> {
+    let mut directory = session_path.parent();
+    while let Some(candidate) = directory {
+        if candidate.file_name().is_some_and(|name| {
+            [".claude", ".codex", ".gemini"]
+                .iter()
+                .any(|marker| name.to_string_lossy().eq_ignore_ascii_case(marker))
+        }) {
+            return candidate.parent().map(Path::to_path_buf);
+        }
+        directory = candidate.parent();
+    }
+    None
 }
 
 async fn send_json(stdin: &mut ChildStdin, value: Value) -> Result<(), SubmitError> {
@@ -404,11 +1071,6 @@ async fn send_json(stdin: &mut ChildStdin, value: Value) -> Result<(), SubmitErr
         .flush()
         .await
         .map_err(|error| failed(format!("provider transport flush failed: {error}")))
-}
-
-async fn drain<R: tokio::io::AsyncRead + Unpin>(stdout: R) {
-    let mut lines = BufReader::new(stdout).lines();
-    while let Ok(Some(_)) = lines.next_line().await {}
 }
 
 fn reap(mut child: Child, agent: &'static str, session_id: String) {
@@ -432,10 +1094,11 @@ fn failed(message: impl Into<String>) -> SubmitError {
     SubmitError::Failed(message.into())
 }
 
-#[cfg(all(test, target_os = "windows"))]
+#[cfg(test)]
 mod tests {
     use super::*;
 
+    #[cfg(target_os = "windows")]
     #[test]
     fn provider_resolution_accepts_cmd_shims() {
         let temp = tempfile::tempdir().unwrap();
@@ -449,6 +1112,413 @@ mod tests {
             Some(OsStr::new(".EXE;.CMD")),
         )
         .unwrap();
-        assert_eq!(resolved.canonicalize().unwrap(), shim.canonicalize().unwrap());
+        assert_eq!(
+            resolved.canonicalize().unwrap(),
+            shim.canonicalize().unwrap()
+        );
+    }
+
+    #[test]
+    fn codex_session_version_selects_the_matching_standalone_binary() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = temp.path().join("session.jsonl");
+        std::fs::write(
+            &session,
+            concat!(
+                "{\"type\":\"session_meta\",\"payload\":{",
+                "\"id\":\"thread-1\",\"cli_version\":\"0.147.0\"}}\n",
+                "{\"type\":\"event_msg\",\"payload\":{}}\n",
+            ),
+        )
+        .unwrap();
+        let wrong_arch = temp
+            .path()
+            .join(".codex/packages/standalone/releases/0.147.0-aaa-wrong-arch/bin")
+            .join(format!("codex{}", std::env::consts::EXE_SUFFIX));
+        let executable = temp
+            .path()
+            .join(format!(
+                ".codex/packages/standalone/releases/0.147.0-{}-test/bin",
+                std::env::consts::ARCH
+            ))
+            .join(format!("codex{}", std::env::consts::EXE_SUFFIX));
+        std::fs::create_dir_all(wrong_arch.parent().unwrap()).unwrap();
+        std::fs::write(&wrong_arch, b"wrong architecture").unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&wrong_arch, std::fs::Permissions::from_mode(0o755)).unwrap();
+        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        std::fs::write(&executable, b"probe").unwrap();
+        #[cfg(unix)]
+        std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert_eq!(codex_cli_version(&session).as_deref(), Some("0.147.0"));
+        assert_eq!(
+            standalone_codex_binary(temp.path(), "0.147.0"),
+            Some(executable)
+        );
+    }
+
+    #[test]
+    fn codex_session_version_rejects_path_injection() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = temp.path().join("session.jsonl");
+        std::fs::write(
+            &session,
+            "{\"type\":\"session_meta\",\"payload\":{\"cli_version\":\"../../bin/sh\"}}\n",
+        )
+        .unwrap();
+
+        assert_eq!(codex_cli_version(&session), None);
+        assert_eq!(standalone_codex_binary(temp.path(), "../../bin/sh"), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_session_version_skips_non_executable_standalone_binary() {
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join(format!(
+            ".codex/packages/standalone/releases/0.147.0-{}-test/bin/codex",
+            std::env::consts::ARCH
+        ));
+        std::fs::create_dir_all(executable.parent().unwrap()).unwrap();
+        std::fs::write(&executable, b"not executable").unwrap();
+
+        assert_eq!(standalone_codex_binary(temp.path(), "0.147.0"), None);
+    }
+
+    #[test]
+    fn codex_session_version_skips_malformed_prefix_lines() {
+        let temp = tempfile::tempdir().unwrap();
+        let session = temp.path().join("session.jsonl");
+        std::fs::write(
+            &session,
+            concat!(
+                "not-json\n",
+                "{\"type\":\"event_msg\",\"payload\":{}}\n",
+                "{\"type\":\"session_meta\",\"payload\":{\"cliVersion\":\"0.147.0\"}}\n",
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(codex_cli_version(&session).as_deref(), Some("0.147.0"));
+    }
+
+    #[test]
+    fn codex_install_home_follows_the_transcript_instead_of_the_service_user() {
+        let expected = PathBuf::from("service-user");
+        let path = expected.join(".CoDeX/sessions/2026/08/16/session.jsonl");
+
+        assert_eq!(codex_install_home(&path), Some(expected.clone()));
+        assert_eq!(provider_session_home(&path), Some(expected));
+        assert_eq!(
+            provider_session_home(Path::new(
+                "service-user/.claude/projects/repo/session.jsonl"
+            )),
+            Some(PathBuf::from("service-user"))
+        );
+        assert_eq!(
+            provider_session_home(Path::new(
+                "service-user/.gemini/tmp/repo/chats/session.json"
+            )),
+            Some(PathBuf::from("service-user"))
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn root_provider_execution_uses_a_non_root_session_identity() {
+        assert_eq!(
+            provider_user_ids((1001, 1002), Some((2001, 2002))).unwrap(),
+            (1001, 1002)
+        );
+        assert_eq!(
+            provider_user_ids((0, 0), Some((2001, 2002))).unwrap(),
+            (2001, 2002)
+        );
+        assert!(matches!(
+            provider_user_ids((0, 0), None),
+            Err(SubmitError::Failed(_))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn provider_child_drops_root_before_exec() {
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+        let Some((expected_uid, expected_gid)) = crate::cmd_exec::target_user_ids() else {
+            return;
+        };
+        let temp = tempfile::tempdir().unwrap();
+        let session_path = temp.path().join(".claude/projects/test/session.jsonl");
+        std::fs::create_dir_all(session_path.parent().unwrap()).unwrap();
+        std::fs::write(&session_path, b"{}\n").unwrap();
+        let account = provider_account(expected_uid).unwrap();
+        let mut command = Command::new("sh");
+        command
+            .args([
+                "-c",
+                "printf '%s\\n' \"$(id -u)\" \"$(id -g)\" \"$(id -G)\" \"$HOME\" \"$USER\" \"$LOGNAME\"",
+            ])
+            .stdout(Stdio::piped());
+        configure_provider_identity(&mut command, &session_path).unwrap();
+
+        let output = command.output().await.unwrap();
+        assert!(output.status.success());
+        let output = String::from_utf8(output.stdout).unwrap();
+        let lines = output.lines().collect::<Vec<_>>();
+        assert_eq!(lines[0], expected_uid.to_string());
+        assert_eq!(lines[1], expected_gid.to_string());
+        assert_eq!(lines[2], expected_gid.to_string());
+        assert_eq!(Path::new(lines[3]), temp.path());
+        assert_eq!(lines[4], account.name.to_string_lossy());
+        assert_eq!(lines[5], account.name.to_string_lossy());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dropping_the_runtime_closes_the_codex_reader_stdin_handle() {
+        let mut child = Command::new("sh")
+            .args(["-c", "cat >/dev/null"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .unwrap();
+        let stdin = Arc::new(AsyncMutex::new(child.stdin.take().unwrap()));
+        let reader_handle = Arc::downgrade(&stdin);
+
+        drop(stdin);
+
+        assert!(reader_handle.upgrade().is_none());
+        let status = tokio::time::timeout(Duration::from_secs(2), child.wait())
+            .await
+            .expect("closing the last stdin owner should stop the provider")
+            .unwrap();
+        assert!(status.success());
+    }
+
+    #[tokio::test]
+    async fn runtime_slot_cleanup_does_not_remove_a_slot_held_by_a_waiter() {
+        let session_id = format!("cleanup-waiter-{}", now_ms());
+        let slot = Arc::new(AsyncMutex::new(None));
+        runtimes()
+            .lock()
+            .await
+            .insert(session_id.clone(), Arc::clone(&slot));
+        let waiter = Arc::clone(&slot);
+
+        remove_empty_runtime_slot(&session_id, &slot).await;
+        assert!(runtimes().lock().await.contains_key(&session_id));
+
+        drop(waiter);
+        remove_empty_runtime_slot(&session_id, &slot).await;
+        assert!(!runtimes().lock().await.contains_key(&session_id));
+    }
+
+    #[tokio::test]
+    async fn oversized_provider_line_is_discarded_without_losing_the_next_message() {
+        let (mut writer, reader) = tokio::io::duplex(64 * 1024);
+        let task = tokio::spawn(async move {
+            writer
+                .write_all(&vec![b'x'; MAX_PROVIDER_MESSAGE_BYTES + 1])
+                .await
+                .unwrap();
+            writer
+                .write_all(b"\n{\"id\":7,\"result\":{}}\n")
+                .await
+                .unwrap();
+        });
+        let mut reader = BufReader::new(reader);
+        let mut line = Vec::new();
+
+        assert_eq!(
+            read_provider_line(&mut reader, &mut line, MAX_PROVIDER_MESSAGE_BYTES)
+                .await
+                .unwrap(),
+            ProviderLine::Oversized
+        );
+        assert!(line.len() <= MAX_PROVIDER_MESSAGE_BYTES);
+        assert_eq!(
+            read_provider_line(&mut reader, &mut line, MAX_PROVIDER_MESSAGE_BYTES)
+                .await
+                .unwrap(),
+            ProviderLine::Complete
+        );
+        assert_eq!(
+            serde_json::from_slice::<Value>(&line).unwrap(),
+            json!({"id":7,"result":{}})
+        );
+        task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn codex_reader_accepts_a_bounded_turn_completion_above_one_megabyte() {
+        let payload = format!(
+            "{{\"method\":\"turn/completed\",\"params\":{{\"turn\":{{\"id\":\"turn-1\",\"status\":\"completed\",\"items\":[{{\"type\":\"agentMessage\",\"text\":\"{}\"}}]}}}}}}\n",
+            "x".repeat(MAX_PROVIDER_MESSAGE_BYTES + 1)
+        );
+        let mut reader = BufReader::new(payload.as_bytes());
+        let mut line = Vec::new();
+
+        assert_eq!(
+            read_provider_line(&mut reader, &mut line, MAX_CODEX_MESSAGE_BYTES)
+                .await
+                .unwrap(),
+            ProviderLine::Complete
+        );
+        assert!(line.len() > MAX_PROVIDER_MESSAGE_BYTES);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&line).unwrap()["method"],
+            json!("turn/completed")
+        );
+    }
+
+    #[test]
+    fn codex_resume_omits_reconstructed_turn_history() {
+        assert_eq!(
+            codex_resume_request("thread-1"),
+            json!({"method":"thread/resume","id":2,"params":{
+                "threadId":"thread-1","excludeTurns":true
+            }})
+        );
+    }
+
+    #[tokio::test]
+    async fn codex_request_errors_are_returned_to_the_submitter() {
+        let pending = Arc::new(StdMutex::new(HashMap::new()));
+        let (response_tx, response_rx) = oneshot::channel();
+        pending.lock().unwrap().insert(7, response_tx);
+
+        complete_codex_response(
+            &json!({"id":7,"error":{"code":-32602,"message":"unsupported input"}}),
+            &pending,
+        );
+
+        let error = response_rx.await.unwrap().unwrap_err();
+        assert!(error.contains("unsupported input"));
+        assert!(pending.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn codex_server_request_id_collision_does_not_complete_client_request() {
+        let pending = Arc::new(StdMutex::new(HashMap::new()));
+        let (response_tx, response_rx) = oneshot::channel();
+        pending.lock().unwrap().insert(7, response_tx);
+
+        let server_request =
+            json!({"id":7,"method":"item/commandExecution/requestApproval","params":{}});
+        complete_codex_response(&server_request, &pending);
+        assert!(pending.lock().unwrap().contains_key(&7));
+        assert_eq!(
+            codex_server_request_rejection(&server_request),
+            Some(json!({"id":7,"error":{
+                "code":-32601,
+                "message":"AgentSight does not support Codex server requests"
+            }}))
+        );
+
+        complete_codex_response(&json!({"id":7,"result":{}}), &pending);
+        assert!(response_rx.await.unwrap().is_ok());
+        assert!(pending.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn claude_assistant_output_acknowledges_then_completes_the_turn() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let state = Arc::new(StdMutex::new(ClaudeState {
+            starting: true,
+            active: false,
+        }));
+        let response = Arc::new(StdMutex::new(None));
+        let (response_tx, response_rx) = oneshot::channel();
+        *response.lock().unwrap() = Some(response_tx);
+        let task = tokio::spawn(read_claude(
+            BufReader::new(reader),
+            Arc::clone(&state),
+            Arc::clone(&response),
+        ));
+
+        writer
+            .write_all(b"{\"type\":\"assistant\",\"message\":{}}\n")
+            .await
+            .unwrap();
+        assert!(response_rx.await.unwrap().is_ok());
+        assert!(state.lock().unwrap().active);
+
+        writer
+            .write_all(b"{\"type\":\"result\",\"subtype\":\"success\"}\n")
+            .await
+            .unwrap();
+        writer.shutdown().await.unwrap();
+        task.await.unwrap();
+        let state = state.lock().unwrap();
+        assert!(!state.starting);
+        assert!(!state.active);
+    }
+
+    #[tokio::test]
+    async fn claude_user_echo_acknowledges_message_acceptance() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let state = Arc::new(StdMutex::new(ClaudeState {
+            starting: true,
+            active: false,
+        }));
+        let response = Arc::new(StdMutex::new(None));
+        let (response_tx, response_rx) = oneshot::channel();
+        *response.lock().unwrap() = Some(response_tx);
+        let task = tokio::spawn(read_claude(
+            BufReader::new(reader),
+            Arc::clone(&state),
+            Arc::clone(&response),
+        ));
+
+        writer
+            .write_all(b"{\"type\":\"user\",\"message\":{}}\n")
+            .await
+            .unwrap();
+        assert!(response_rx.await.unwrap().is_ok());
+        assert!(state.lock().unwrap().active);
+
+        writer
+            .write_all(b"{\"type\":\"result\",\"subtype\":\"success\"}\n")
+            .await
+            .unwrap();
+        writer.shutdown().await.unwrap();
+        task.await.unwrap();
+        assert!(!state.lock().unwrap().active);
+    }
+
+    #[tokio::test]
+    async fn claude_result_errors_are_returned_to_the_submitter() {
+        let (mut writer, reader) = tokio::io::duplex(1024);
+        let state = Arc::new(StdMutex::new(ClaudeState {
+            starting: true,
+            active: false,
+        }));
+        let response = Arc::new(StdMutex::new(None));
+        let (response_tx, response_rx) = oneshot::channel();
+        *response.lock().unwrap() = Some(response_tx);
+        let task = tokio::spawn(read_claude(
+            BufReader::new(reader),
+            Arc::clone(&state),
+            Arc::clone(&response),
+        ));
+
+        writer
+            .write_all(
+                b"{\"type\":\"result\",\"subtype\":\"error_during_execution\",\"error\":\"authentication required\"}\n",
+            )
+            .await
+            .unwrap();
+        let error = response_rx.await.unwrap().unwrap_err();
+        assert!(error.contains("authentication required"));
+
+        writer.shutdown().await.unwrap();
+        task.await.unwrap();
+        let state = state.lock().unwrap();
+        assert!(!state.starting);
+        assert!(!state.active);
     }
 }

--- a/collector/src/server/web.rs
+++ b/collector/src/server/web.rs
@@ -14,7 +14,7 @@ use crate::view::live_top::{LiveCaptureSnapshot, LiveView};
 use agentsight_protocol::{
     PRODUCT, PROTOCOL_VERSION, SessionMessageRequest, session_detail_id, session_message_id,
 };
-use http_body_util::{BodyExt, Full};
+use http_body_util::{BodyExt, Full, LengthLimitError, Limited};
 use hyper::header::{AUTHORIZATION, CACHE_CONTROL, HeaderValue, ORIGIN};
 use hyper::server::conn::http1;
 use hyper::service::service_fn;
@@ -27,6 +27,17 @@ use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::net::TcpListener;
+
+const MAX_CAPABILITY_BODY_BYTES: usize = 16 * 1024;
+// SessionMessageRequest permits 65,536 decoded bytes. JSON escaping can expand
+// control bytes to six source bytes, so preserve the public contract while
+// still bounding authenticated request allocation.
+const MAX_SESSION_MESSAGE_BODY_BYTES: usize = 512 * 1024;
+
+enum BodyReadError {
+    TooLarge,
+    Failed(String),
+}
 
 #[derive(Clone)]
 struct DirectAuth {
@@ -383,21 +394,21 @@ async fn serve_capability_mint_api(
             "Node bootstrap credential required",
         ));
     }
-    let body = match req.into_body().collect().await {
-        Ok(body) => body.to_bytes(),
-        Err(error) => {
+    let body = match read_limited_body(req, MAX_CAPABILITY_BODY_BYTES).await {
+        Ok(body) => body,
+        Err(BodyReadError::TooLarge) => {
+            return Ok(json_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "request too large",
+            ));
+        }
+        Err(BodyReadError::Failed(error)) => {
             return Ok(json_error(
                 StatusCode::BAD_REQUEST,
                 &format!("failed to read request body: {error}"),
             ));
         }
     };
-    if body.len() > 16 * 1024 {
-        return Ok(json_error(
-            StatusCode::PAYLOAD_TOO_LARGE,
-            "request too large",
-        ));
-    }
     let request: CapabilityMintRequest = match serde_json::from_slice(&body) {
         Ok(request) => request,
         Err(error) => {
@@ -583,9 +594,15 @@ async fn serve_session_message_api(
     sessions: Arc<Mutex<SessionCache>>,
     session_id: &str,
 ) -> std::result::Result<Response<Full<Bytes>>, Infallible> {
-    let body = match req.into_body().collect().await {
-        Ok(body) => body.to_bytes(),
-        Err(error) => {
+    let body = match read_limited_body(req, MAX_SESSION_MESSAGE_BODY_BYTES).await {
+        Ok(body) => body,
+        Err(BodyReadError::TooLarge) => {
+            return Ok(json_error(
+                StatusCode::PAYLOAD_TOO_LARGE,
+                "request too large",
+            ));
+        }
+        Err(BodyReadError::Failed(error)) => {
             return Ok(json_error(
                 StatusCode::BAD_REQUEST,
                 &format!("failed to read request body: {error}"),
@@ -654,6 +671,27 @@ async fn serve_session_message_api(
         Err(crate::server::session_runtime::SubmitError::Failed(error)) => {
             Ok(json_error(StatusCode::BAD_GATEWAY, &error))
         }
+    }
+}
+
+async fn read_limited_body(
+    req: Request<hyper::body::Incoming>,
+    max_bytes: usize,
+) -> Result<Bytes, BodyReadError> {
+    collect_limited_body(req.into_body(), max_bytes).await
+}
+
+async fn collect_limited_body<B>(body: B, max_bytes: usize) -> Result<Bytes, BodyReadError>
+where
+    B: hyper::body::Body<Data = Bytes>,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    match Limited::new(body, max_bytes).collect().await {
+        Ok(body) => Ok(body.to_bytes()),
+        Err(error) if error.downcast_ref::<LengthLimitError>().is_some() => {
+            Err(BodyReadError::TooLarge)
+        }
+        Err(error) => Err(BodyReadError::Failed(error.to_string())),
     }
 }
 
@@ -842,6 +880,17 @@ mod tests {
             session_detail_id("/api/v1/sessions/session-1/messages"),
             None
         );
+    }
+
+    #[tokio::test]
+    async fn authenticated_request_bodies_are_bounded_while_reading() {
+        let accepted = collect_limited_body(Full::new(Bytes::from_static(b"1234")), 4)
+            .await
+            .unwrap_or_else(|_| panic!("body at the limit should be accepted"));
+        assert_eq!(accepted, Bytes::from_static(b"1234"));
+
+        let rejected = collect_limited_body(Full::new(Bytes::from_static(b"12345")), 4).await;
+        assert!(matches!(rejected, Err(BodyReadError::TooLarge)));
     }
 
     fn test_auth() -> DirectAuth {

--- a/controller/README.md
+++ b/controller/README.md
@@ -100,7 +100,7 @@ The production `agentsight` connection disables builds for non-production branch
 Production deploy command:
 
 ```bash
-npm --prefix controller ci && ./controller/node_modules/.bin/wrangler d1 migrations apply DB --remote --config wrangler.jsonc && ./controller/node_modules/.bin/wrangler deploy --config wrangler.jsonc
+npm --prefix controller ci && ./controller/node_modules/.bin/wrangler deploy --config wrangler.jsonc
 ```
 
 The isolated `agentsight-preview` connection enables builds for non-production branches. Both its deploy and version commands use `wrangler.preview.jsonc`:
@@ -111,6 +111,6 @@ npm --prefix controller ci && ./controller/node_modules/.bin/wrangler d1 migrati
 
 Cloudflare does not generate native version preview URLs for Workers that implement Durable Objects. Non-production builds therefore perform a full deploy to the stable, isolated `agentsight-preview` Worker. That staging Worker has its own workers.dev URL, D1 database, Durable Object namespace, rate-limit namespaces, and Build connection; it never receives production secrets or production data. Each new non-production build replaces the previous staging revision.
 
-D1 migrations run before both production and staging deploys and are idempotent, so each frontend and API deployment comes from the same revision. `npm run deploy` remains available for production recovery/debugging, but it is not the normal production path.
+Production code deployment never applies D1 migrations implicitly. An operator must review and run `npm --prefix controller run migrate:remote` as a separate, explicit maintenance action before deploying a revision that genuinely requires a schema change. This keeps ordinary automatic frontend/API deployments database-compatible and prevents a code merge from mutating production data. Staging remains isolated and may apply its own preview-database migrations before deployment. `npm run deploy` remains available for production recovery/debugging, but it deploys code only and is not the normal production path.
 
 The old `control-plane` path is retained only as a compatibility symlink for existing scripts; new code and documentation should use `controller`.

--- a/controller/package.json
+++ b/controller/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "check": "tsc --noEmit",
     "test": "tsx --test src/*.test.ts",
-    "deploy": "wrangler d1 migrations apply DB --remote --config ../wrangler.jsonc && cd .. && wrangler deploy --config wrangler.jsonc",
+    "deploy": "cd .. && wrangler deploy --config wrangler.jsonc",
+    "migrate:remote": "wrangler d1 migrations apply DB --remote --config ../wrangler.jsonc",
     "dev": "cd .. && wrangler dev --config wrangler.jsonc"
   },
   "devDependencies": {

--- a/controller/src/relay.test.ts
+++ b/controller/src/relay.test.ts
@@ -9,6 +9,7 @@ import {
   RELAY_TIMEOUT_MS,
   browserRelayRoute,
   connectNodeRelay,
+  proxyBrowserRelay,
   relayTokenHash,
   relayNodeSocketId,
   validRelayNodeVersion,
@@ -115,6 +116,67 @@ test('browser relay parses supported Node paths before semantic authorization', 
     'https://controller.example/v1/nodes/node_test/relay/../capabilities',
     { method: 'POST' },
   )), null);
+});
+
+test('browser relay preserves a maximally escaped valid session message', async () => {
+  const message = '\0'.repeat(65_536);
+  const body = JSON.stringify({ message });
+  assert.ok(new TextEncoder().encode(body).byteLength > 96 * 1024);
+  let relayedBody = '';
+  const relay = {
+    idFromName: () => ({}) as DurableObjectId,
+    get: () => ({
+      fetch: async (request: Request) => {
+        const input = await request.json() as { body?: string };
+        relayedBody = input.body || '';
+        return new Response('{}', { status: 200 });
+      },
+    }) as unknown as DurableObjectStub,
+  } as unknown as DurableObjectNamespace;
+  const request = new Request(
+    'https://controller.example/v1/nodes/node_test/relay/sessions/session-1/messages',
+    { method: 'POST', body },
+  );
+  const route = browserRelayRoute(request);
+  assert.ok(route);
+
+  const response = await proxyBrowserRelay(
+    request,
+    { DB: {} as D1Database, NODE_RELAY: relay },
+    route,
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(relayedBody, body);
+  assert.equal(JSON.parse(relayedBody).message, message);
+});
+
+test('browser relay cancels an oversized streaming body without Content-Length', async () => {
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new Uint8Array(300 * 1024));
+      controller.enqueue(new Uint8Array(300 * 1024));
+    },
+    cancel() {
+      cancelled = true;
+    },
+  });
+  const request = new Request(
+    'https://controller.example/v1/nodes/node_test/relay/sessions/session-1/messages',
+    { method: 'POST', body: stream, duplex: 'half' } as RequestInit & { duplex: 'half' },
+  );
+  const route = browserRelayRoute(request);
+  assert.ok(route);
+
+  const response = await proxyBrowserRelay(
+    request,
+    { DB: {} as D1Database, NODE_RELAY: {} as DurableObjectNamespace },
+    route,
+  );
+
+  assert.equal(response.status, 413);
+  assert.equal(cancelled, true);
 });
 
 test('relay tokens use the same Direct bearer shape', () => {

--- a/controller/src/relay.test.ts
+++ b/controller/src/relay.test.ts
@@ -4,6 +4,9 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  MAX_PENDING_RELAY_REQUESTS,
+  NodeRelay,
+  RELAY_TIMEOUT_MS,
   browserRelayRoute,
   connectNodeRelay,
   relayTokenHash,
@@ -11,6 +14,69 @@ import {
   validRelayNodeVersion,
   validRelayToken,
 } from './relay.ts';
+import type { RelayEnv } from './relay.ts';
+
+test('relay waits longer than the Node provider acknowledgement window', () => {
+  assert.ok(RELAY_TIMEOUT_MS > 20_000);
+  assert.ok(RELAY_TIMEOUT_MS < 30_000);
+});
+
+test('relay pending work is capped per Node', () => {
+  assert.equal(MAX_PENDING_RELAY_REQUESTS, 64);
+});
+
+test('relay pending cap holds across concurrently parsed request bodies', async () => {
+  const originalPair = Object.getOwnPropertyDescriptor(globalThis, 'WebSocketRequestResponsePair');
+  Object.defineProperty(globalThis, 'WebSocketRequestResponsePair', {
+    configurable: true,
+    value: class WebSocketRequestResponsePairStub {},
+  });
+  const envelopes: Array<{ id: string }> = [];
+  const socket = {
+    readyState: WebSocket.OPEN,
+    send(message: string) {
+      envelopes.push(JSON.parse(message) as { id: string });
+    },
+  } as unknown as WebSocket;
+  const ctx = {
+    setWebSocketAutoResponse() {},
+    getWebSockets: () => [socket],
+  } as unknown as DurableObjectState;
+  const relay = new NodeRelay(ctx, {} as RelayEnv);
+
+  try {
+    const requests = Array.from({ length: MAX_PENDING_RELAY_REQUESTS + 1 }, () => relay.fetch(
+      new Request('https://relay.internal/request', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ method: 'GET', path: '/api/v1/overview' }),
+      }),
+    ));
+    for (let attempt = 0; attempt < 20 && envelopes.length < MAX_PENDING_RELAY_REQUESTS; attempt += 1) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    await new Promise((resolve) => setImmediate(resolve));
+
+    for (const envelope of envelopes) {
+      await relay.webSocketMessage(socket, JSON.stringify({
+        type: 'response', id: envelope.id, status: 200, body: '{}',
+      }));
+    }
+    const responses = await Promise.all(requests);
+    assert.equal(envelopes.length, MAX_PENDING_RELAY_REQUESTS);
+    assert.equal(responses.filter((response) => response.status === 200).length, MAX_PENDING_RELAY_REQUESTS);
+    assert.equal(responses.filter((response) => response.status === 429).length, 1);
+    assert.deepEqual(await responses.find((response) => response.status === 429)?.json(), {
+      error: 'relay_busy',
+    });
+  } finally {
+    if (originalPair) {
+      Object.defineProperty(globalThis, 'WebSocketRequestResponsePair', originalPair);
+    } else {
+      Reflect.deleteProperty(globalThis, 'WebSocketRequestResponsePair');
+    }
+  }
+});
 
 test('Node relay socket path accepts only stable Node IDs', () => {
   assert.equal(relayNodeSocketId('/v1/relay/nodes/node_0123abcdef'), 'node_0123abcdef');

--- a/controller/src/relay.ts
+++ b/controller/src/relay.ts
@@ -4,7 +4,8 @@
 const NODE_ID_PATTERN = /^node_[A-Za-z0-9_]{1,123}$/;
 const RELAY_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 const NODE_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
-const RELAY_TIMEOUT_MS = 12_000;
+export const RELAY_TIMEOUT_MS = 25_000;
+export const MAX_PENDING_RELAY_REQUESTS = 64;
 const MAX_BROWSER_BODY_BYTES = 96 * 1024;
 const MAX_RELAY_SUFFIX_BYTES = 4 * 1024;
 
@@ -230,6 +231,11 @@ export class NodeRelay {
       || typeof input.path !== 'string'
       || (input.body !== undefined && typeof input.body !== 'string')) {
       return json({ error: 'invalid_relay_request' }, 400);
+    }
+    // Durable Object requests can interleave at await points. Reserve the slot only
+    // after parsing, with no await between this check and pending.set below.
+    if (this.pending.size >= MAX_PENDING_RELAY_REQUESTS) {
+      return json({ error: 'relay_busy' }, 429);
     }
 
     const id = crypto.randomUUID();

--- a/controller/src/relay.ts
+++ b/controller/src/relay.ts
@@ -6,7 +6,9 @@ const RELAY_TOKEN_PATTERN = /^[A-Za-z0-9_-]{32,256}$/;
 const NODE_VERSION_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._+-]{0,63}$/;
 export const RELAY_TIMEOUT_MS = 25_000;
 export const MAX_PENDING_RELAY_REQUESTS = 64;
-const MAX_BROWSER_BODY_BYTES = 96 * 1024;
+// SessionMessageRequest permits 65,536 decoded bytes. JSON escaping can expand
+// control bytes to six source bytes, so relay the full public Node contract.
+const MAX_BROWSER_BODY_BYTES = 512 * 1024;
 const MAX_RELAY_SUFFIX_BYTES = 4 * 1024;
 
 export interface RelayEnv {
@@ -286,11 +288,27 @@ function bearerToken(request: Request): string | null {
 async function boundedBody(request: Request): Promise<string | Response> {
   const declared = Number(request.headers.get('Content-Length') || '0');
   if (declared > MAX_BROWSER_BODY_BYTES) return json({ error: 'request_too_large' }, 413);
-  const body = await request.text();
-  if (new TextEncoder().encode(body).byteLength > MAX_BROWSER_BODY_BYTES) {
-    return json({ error: 'request_too_large' }, 413);
+  if (!request.body) return '';
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  const chunks: string[] = [];
+  let received = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > MAX_BROWSER_BODY_BYTES) {
+        await reader.cancel('request too large');
+        return json({ error: 'request_too_large' }, 413);
+      }
+      chunks.push(decoder.decode(value, { stream: true }));
+    }
+    chunks.push(decoder.decode());
+    return chunks.join('');
+  } catch {
+    return json({ error: 'invalid_request_body' }, 400);
   }
-  return body;
 }
 
 export async function relayTokenHash(value: string): Promise<string> {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,6 +75,14 @@ it into public logs. Stop the foreground command after the browser completes
 binding; the key is stored in the user's platform config directory and is
 reused across Node restarts.
 
+When a browser sends a follow-up to a stopped Codex session, AgentSight reads
+the session's recorded `cli_version` and prefers that exact installed Codex
+standalone release. This avoids resuming a newer transcript with an older
+global `codex` from a background service's `PATH`. If that release is no longer
+installed, AgentSight falls back to `PATH`. Advanced installations can set
+`AGENTSIGHT_CODEX_BIN`, `AGENTSIGHT_CLAUDE_BIN`, or `AGENTSIGHT_GEMINI_BIN` to
+an explicit provider executable; these values are paths, not credentials.
+
 For a headless remote host, forward its loopback port to the workstation that
 runs the browser:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -224,6 +224,12 @@ Start-ScheduledTask -TaskName 'AgentSight Monitor'
 Start-ScheduledTask -TaskName 'AgentSight Bind'
 ```
 
+Keep the Bind task at `RunLevel Limited`. Session discovery and read-only views
+still work from an elevated process, but AgentSight deliberately refuses to
+resume or message an agent from an elevated Windows process because the selected
+provider executable is owned by the transcript user. Run Bind as that same
+non-administrator user to enable messaging.
+
 If this Windows machine has not been added to the hosted app, run
 `agentsight bind` once in an interactive terminal before relying on the
 background Bind task. Its binding URL also contains a secret bootstrap key.

--- a/docs/installation.zh-CN.md
+++ b/docs/installation.zh-CN.md
@@ -198,6 +198,10 @@ Start-ScheduledTask -TaskName 'AgentSight Monitor'
 Start-ScheduledTask -TaskName 'AgentSight Bind'
 ```
 
+请保持 Bind 任务使用 `RunLevel Limited`。提升权限的进程仍可进行会话发现和只读查看，
+但 AgentSight 会拒绝从提升权限的 Windows 进程恢复 agent 或发送消息，因为所选 Provider
+可执行文件属于 transcript 用户。要启用消息功能，请使用同一个非管理员用户运行 Bind。
+
 如果这台 Windows 机器还没有加入托管应用，请先在交互终端运行一次 `agentsight bind`，再依赖后台
 Bind 任务。与 Linux 相同，绑定 URL 包含秘密 bootstrap key。
 

--- a/ext/web/components/SessionConsole.tsx
+++ b/ext/web/components/SessionConsole.tsx
@@ -40,7 +40,7 @@ export function SessionConsole({
   client: NodeClient | null;
   loading: boolean;
   detailError: string;
-  onReload: () => void;
+  onReload: (quiet?: boolean) => Promise<SessionDetail | null>;
 }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState('');
@@ -49,6 +49,7 @@ export function SessionConsole({
   const [writeBlocked, setWriteBlocked] = useState('');
   const conversationRef = useRef<HTMLDivElement | null>(null);
   const stickToBottom = useRef(true);
+  const refreshGeneration = useRef(0);
   const conversation = messages(detail);
 
   useEffect(() => {
@@ -57,7 +58,9 @@ export function SessionConsole({
   }, [conversation.length, detail]);
 
   useEffect(() => {
+    refreshGeneration.current += 1;
     setMessage('');
+    setBusy(false);
     setError('');
     setWriteBlocked('');
     stickToBottom.current = true;
@@ -67,14 +70,23 @@ export function SessionConsole({
     event.preventDefault();
     const text = message.trim();
     if (!text || busy || !client || writeBlocked) return;
+    const generation = ++refreshGeneration.current;
+    const responseCount = detail?.events?.llm_responses?.length ?? 0;
     setBusy(true);
     setError('');
     try {
       await client.submitMessage(rawSessionId(session), text);
       setMessage('');
+      setBusy(false);
       stickToBottom.current = true;
-      window.setTimeout(onReload, 350);
+      for (const delay of [350, 650, 1_000, 1_500, 2_500, 4_000, 6_000, 8_000, 10_000, 12_000, 15_000]) {
+        await new Promise((resolve) => window.setTimeout(resolve, delay));
+        if (refreshGeneration.current !== generation) return;
+        const next = await onReload(true);
+        if ((next?.events?.llm_responses?.length ?? 0) > responseCount) break;
+      }
     } catch (cause) {
+      if (refreshGeneration.current !== generation) return;
       const reason = cause instanceof Error ? cause.message : 'Could not send message.';
       if (cause instanceof NodeRequestError
           && cause.status === 409
@@ -85,11 +97,11 @@ export function SessionConsole({
       }
       setError(reason);
     } finally {
-      setBusy(false);
+      if (refreshGeneration.current === generation) setBusy(false);
     }
   };
 
-  const canSend = !!client && !writeBlocked
+  const canSend = !!client && !!detail && !writeBlocked
     && ['claude', 'codex', 'gemini'].includes(session.agent_type);
 
   return (

--- a/ext/web/components/SessionWorkspace.tsx
+++ b/ext/web/components/SessionWorkspace.tsx
@@ -69,9 +69,9 @@ export function SessionWorkspace({
     [recordedCapture, session, snapshot],
   );
 
-  const loadDetail = useCallback(async (quiet = false) => {
+  const loadDetail = useCallback(async (quiet = false): Promise<SessionDetail | null> => {
     if (!client || recordedCapture) {
-      setDetail(recordedDetail ?? {
+      const next = recordedDetail ?? {
         session_id: sessionId,
         agent_type: session.agent_type,
         model: session.model,
@@ -82,11 +82,12 @@ export function SessionWorkspace({
             : [],
           plan: JSON.parse(recordedPlanKey) as CodingPlanStep[],
         },
-      });
+      };
+      setDetail(next);
       setDetailError('');
-      return;
+      return next;
     }
-    if (activeRequest.current !== 0) return;
+    if (activeRequest.current !== 0) return null;
     const request = ++nextRequest.current;
     activeRequest.current = request;
     if (!quiet) setLoading(true);
@@ -96,10 +97,12 @@ export function SessionWorkspace({
         setDetail(next);
         setDetailError('');
       }
+      return next;
     } catch (cause) {
       if (!quiet && activeRequest.current === request) {
         setDetailError(cause instanceof Error ? cause.message : t('sessions.loadFailed'));
       }
+      return null;
     } finally {
       if (activeRequest.current === request) {
         activeRequest.current = 0;
@@ -121,8 +124,8 @@ export function SessionWorkspace({
   }, [client, loadDetail, sessionId]);
 
   useEffect(() => {
-    if (client && running && document.visibilityState !== 'hidden') void loadDetail(true);
-  }, [client, liveVersion, loadDetail, running]);
+    if (client && document.visibilityState !== 'hidden') void loadDetail(true);
+  }, [client, liveVersion, loadDetail]);
 
   const scopedSnapshot = useMemo(
     () => sessionSnapshot(snapshot, session, live, detail, overview),
@@ -220,7 +223,7 @@ export function SessionWorkspace({
       <div id={`session-panel-${tab}`} role="tabpanel">
         {tab === 'conversation' ? (
           <SessionConsole session={session} detail={detail} client={recordedCapture ? null : client} loading={loading}
-            detailError={detailError} onReload={() => { void loadDetail(); }} />
+            detailError={detailError} onReload={loadDetail} />
         ) : tab === 'process' ? (
           <ProcessTreeView snapshot={scopedSnapshot} />
         ) : (

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -59,7 +59,7 @@ test('signed-in user opens a relay Node and sees machine value before session de
 });
 
 test('conversation, message send, process tree, timeline filters, and event detail work together', async ({ page }) => {
-  const state = await mockController(page, { signedIn: true });
+  const state = await mockController(page, { signedIn: true, responseDelayMs: 10_500 });
   await page.goto('/');
   await openLab(page);
   await openCodexSession(page);
@@ -70,6 +70,9 @@ test('conversation, message send, process tree, timeline filters, and event deta
   await expect.poll(() => state.messages.length).toBe(1);
   expect(state.messages[0]).toEqual({ message: 'Run the final browser regression suite.' });
   await expect(composer).toHaveValue('');
+  await expect(composer).toBeEnabled();
+  await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
+  await expect(page.getByText('Browser follow-up complete.')).toBeVisible({ timeout: 25_000 });
 
   await page.getByRole('tab', { name: 'Process tree & AI prompts' }).click();
   await expect(page.getByRole('heading', { name: 'Process Tree & AI Prompts' })).toBeVisible();

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -146,6 +146,7 @@ export const nodes = [
 
 export interface MockState {
   messages: unknown[];
+  messageAcceptedAt: number | null;
   nodeListRequests: number;
   deletedNodes: string[];
   signOuts: number;
@@ -172,9 +173,11 @@ export async function mockController(page: Page, options: {
   signedIn?: boolean;
   blockMessages?: boolean;
   nodeListDelayMs?: number;
+  responseDelayMs?: number;
 } = {}) {
   const state: MockState = {
     messages: [], nodeListRequests: 0, deletedNodes: [], signOuts: 0,
+    messageAcceptedAt: null,
     blockMessages: options.blockMessages ?? false, organizations: [], registrations: [], directRequests: [],
   };
   await mockEmbeddedProbe(page);
@@ -259,11 +262,32 @@ export async function mockController(page: Page, options: {
       if (suffix === '/snapshot') return json(route, snapshot);
       if (/^\/sessions\/[^/]+\/messages$/.test(suffix) && request.method() === 'POST') {
         state.messages.push(request.postDataJSON());
-        return state.blockMessages
-          ? json(route, { detail: 'This session is running outside AgentSight.' }, 409)
-          : json(route, { accepted: true }, 202);
+        if (state.blockMessages) {
+          return json(route, { detail: 'This session is running outside AgentSight.' }, 409);
+        }
+        state.messageAcceptedAt = Date.now();
+        return json(route, { accepted: true }, 202);
       }
-      if (/^\/sessions\/[^/]+$/.test(suffix)) return json(route, sessionDetail);
+      if (/^\/sessions\/[^/]+$/.test(suffix)) {
+        const completed = state.messageAcceptedAt !== null
+          && Date.now() - state.messageAcceptedAt >= (options.responseDelayMs ?? 700);
+        if (!completed) return json(route, sessionDetail);
+        const submitted = state.messages.at(-1) as { message?: string } | undefined;
+        return json(route, {
+          ...sessionDetail,
+          events: {
+            ...sessionDetail.events,
+            prompts: [
+              ...sessionDetail.events.prompts,
+              { ts_ms: started + 70_000, text: submitted?.message || 'Follow-up' },
+            ],
+            llm_responses: [
+              ...sessionDetail.events.llm_responses,
+              { ts_ms: started + 71_000, text: 'Browser follow-up complete.', model: 'gpt-5' },
+            ],
+          },
+        });
+      }
     }
     const deletion = path.match(/^\/v1\/nodes\/([^/]+)$/);
     if (deletion && request.method() === 'DELETE') {

--- a/frontend/src/lib/nodeClient.ts
+++ b/frontend/src/lib/nodeClient.ts
@@ -275,6 +275,7 @@ function nodeClient(nodeId: string, nodeName: string, transport: NodeTransport, 
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ message }),
+          signal: AbortSignal.timeout(SESSION_REQUEST_TIMEOUT_MS),
         },
       ), 'Message submit failed');
     },


### PR DESCRIPTION
## Summary

- resume Codex transcripts with their recorded standalone CLI version while preserving the existing `PATH` fallback
- propagate provider initialization, resume, JSON-RPC, timeout, transport-close, and immediate process-exit failures instead of reporting false acceptance
- keep one runtime lock per session, reject concurrent same-session submissions immediately, and never automatically resend an ambiguous delivery
- forward independent Controller requests concurrently with bounded Node memory, in-flight work, response bodies, and deadlines
- preserve the public 65,536-byte decoded message contract across Direct and relay with streaming 512 KiB JSON-body limits
- keep accepted-message refreshes running for slow providers without disabling Codex steer or blocking input for up to a minute
- separate production code deployment from operator-reviewed D1 migration; automatic production deploys are code-only

## Compatibility and safety

- missing, malformed, too-large, unavailable, non-executable, or wrong-platform Codex version metadata falls back to the global CLI lookup
- Codex 0.147 resumes with `excludeTurns: true`, explicitly rejects server requests, and handles bounded 16 MiB completion messages without leaving stale runtimes
- all provider start, pipe write, initialization, resume, and acknowledgement work shares one 20-second deadline; Node relay uses 24 seconds, Controller uses 25 seconds, and the browser uses 30 seconds
- Unix root execution drops UID, GID, and supplementary groups, clears the service environment, and restores only a minimal non-secret environment for the transcript owner
- Windows messaging runs only from a non-elevated current-user context and only for canonical transcripts beneath `HOME` or `USERPROFILE`; elevated capture and read-only views remain available, but provider execution fails closed
- Gemini sends the public message through stdin rather than the Windows-limited process command line
- Controller keeps at most 64 pending browser requests per Node; each Node forwards at most 8 local requests concurrently and caps each response while streaming
- no Controller D1 query, Wrangler binding, lockfile, schema, migration, or database file changed
- no production D1 read, write, migration, deployment, or data change was performed during validation

## Validation

- exact head: `8c3323d26b1494be7b6c667b0a1e4d092a6a988e`
- lab collector suite: 112 unit + 5 integration + 3 system tests passed; 4 credential-gated capture tests ignored
- lab `cargo clippy --manifest-path collector/Cargo.toml --all-targets -- -D warnings`
- lab root fixture: provider child UID, GID, supplementary groups, `HOME`, `USER`, and `LOGNAME` matched the transcript owner, and a parent secret sentinel was absent
- Controller: 24/24 tests passed, including 65 concurrent relay requests, maximally escaped valid messages, and an oversized streaming body without `Content-Length`; TypeScript strict check passed
- frontend tree is unchanged since its 28/28 logic tests, Next.js 15.5.23 production export, and 6/6 Playwright flows passed; exact-head CI reruns them
- isolated Direct message flow verified HTTP 202 acceptance, immediate HTTP 409 for a concurrent same-session submit, runtime reuse on a later message, prompt persistence, and assistant-response visibility
- real Codex 0.147 app-server resume accepted `excludeTurns: true` with no reconstructed turns; current lab model-response testing is externally blocked by Codex usage exhaustion, Gemini account/client ineligibility, and an unresponsive Claude auth status, so no real model-text pass is claimed

Exact-head Linux, Windows, macOS, Component, Cloudflare preview, and GitGuardian checks all passed; independent code review found no code blocker. Merge remains gated on Dashboard production build-command verification and the browser-to-lab click path after Chrome local-network permission is granted. The production Build command must remain deploy-only; D1 migrations are a separate explicit operator action.