### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ the `agentsight` package and is the library's primary consumer.
 
 ### Installation
 
+#### Homebrew on Linux
+
+```bash
+brew tap eunomia-bpf/tap
+brew install eunomia-bpf/tap/agentsight
+agentsight --version
+```
+
+The current Homebrew formula supports Linux x86-64.
+
 #### Cargo or Release Binary
 
 For local use, install with `cargo install agentsight` or download the latest

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,16 @@ commands remain Linux-only and have additional privilege requirements.
 
 ## Linux
 
+### Install with Homebrew
+
+On Linux x86-64:
+
+```bash
+brew tap eunomia-bpf/tap
+brew install eunomia-bpf/tap/agentsight
+agentsight --version
+```
+
 ### Install a release binary
 
 GitHub Releases publish Linux binaries for x86-64 and ARM64:


### PR DESCRIPTION
## Description

Adds the validated Homebrew installation method to the AgentSight README and Linux installation guide.

The documentation includes the official tap command, formula installation command, version check, and current Linux architecture support.

Part of #71.

Related formula update: eunomia-bpf/homebrew-tap#2

## Type of change

* [x] This change requires a documentation update

## How Has This Been Tested?

* [x] Installed AgentSight through the official Homebrew tap
* [x] Verified `agentsight --version`
* [x] Launched `agentsight top`
* [x] Checked the Markdown changes with `git diff --check`

**Test Configuration**:

* Operating system: Ubuntu 24.04.2 LTS
* Architecture: x86_64
* Homebrew: 6.0.18

## Checklist

* [x] My changes follow the style guidelines of this project
* [x] I have performed a self-review
* [x] I have made the corresponding documentation changes
* [x] My changes generate no new warnings
* [x] I have checked my changes and corrected any misspellings