### PR TITLE
Fix cross-platform collector tests and Codex token usage parsing

### DIFF
--- a/agentsight-capture/src/time.rs
+++ b/agentsight-capture/src/time.rs
@@ -12,6 +12,34 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Cached boot time in seconds since UNIX epoch
 static BOOT_TIME_SECS: OnceLock<i64> = OnceLock::new();
 
+/// Earliest plausible boot timestamp accepted by the conversion helpers.
+const MIN_BOOT_TIME_SECS: i64 = 1_577_836_800; // 2020-01-01 00:00:00 UTC
+
+fn is_plausible_boot_time(candidate: i64, now_secs: i64) -> bool {
+    candidate > MIN_BOOT_TIME_SECS && candidate < now_secs
+}
+
+fn select_boot_time_secs(
+    reported_boot_time_secs: Option<i64>,
+    uptime_secs: Option<i64>,
+    now_secs: i64,
+) -> i64 {
+    if let Some(boot_time) = reported_boot_time_secs
+        && is_plausible_boot_time(boot_time, now_secs)
+    {
+        return boot_time;
+    }
+
+    if let Some(uptime) = uptime_secs.filter(|uptime| *uptime > 0 && *uptime < now_secs) {
+        let derived_boot_time = now_secs.saturating_sub(uptime);
+        if is_plausible_boot_time(derived_boot_time, now_secs) {
+            return derived_boot_time;
+        }
+    }
+
+    now_secs.saturating_sub(1)
+}
+
 /// Get the system boot time in seconds since UNIX epoch
 ///
 /// This uses the platform process backend and caches the result.
@@ -22,18 +50,9 @@ pub fn get_boot_time_secs() -> i64 {
             .unwrap()
             .as_secs() as i64;
 
-        if let Ok(boot_time) = i64::try_from(sysinfo::System::boot_time())
-            && boot_time > 946684800
-            && boot_time < now_secs
-        {
-            return boot_time;
-        }
-
-        let uptime_secs = i64::try_from(sysinfo::System::uptime())
-            .ok()
-            .filter(|uptime| *uptime > 0 && *uptime < now_secs)
-            .unwrap_or(1);
-        now_secs.saturating_sub(uptime_secs)
+        let reported_boot_time_secs = i64::try_from(sysinfo::System::boot_time()).ok();
+        let uptime_secs = i64::try_from(sysinfo::System::uptime()).ok();
+        select_boot_time_secs(reported_boot_time_secs, uptime_secs, now_secs)
     })
 }
 
@@ -67,7 +86,38 @@ mod tests {
             .as_secs() as i64;
         assert!(boot_time < now);
         // Boot time should be reasonable (after year 2020)
-        assert!(boot_time > 1577836800); // 2020-01-01
+        assert!(boot_time > MIN_BOOT_TIME_SECS);
+    }
+
+    #[test]
+    fn select_boot_time_rejects_invalid_positive_reported_time() {
+        let now = 1_800_000_000;
+        let invalid_boot_time = 1;
+
+        let boot_time = select_boot_time_secs(Some(invalid_boot_time), None, now);
+
+        assert_eq!(boot_time, now - 1);
+    }
+
+    #[test]
+    fn select_boot_time_rejects_future_reported_time() {
+        let now = 1_800_000_000;
+        let valid_uptime = 600;
+
+        let boot_time = select_boot_time_secs(Some(now + 60), Some(valid_uptime), now);
+
+        assert_eq!(boot_time, now - valid_uptime);
+    }
+
+    #[test]
+    fn select_boot_time_rejects_derived_invalid_reported_time() {
+        let now = 1_800_000_000;
+        let invalid_boot_time = 1;
+        let circular_uptime = now - invalid_boot_time;
+
+        let boot_time = select_boot_time_secs(Some(invalid_boot_time), Some(circular_uptime), now);
+
+        assert_eq!(boot_time, now - 1);
     }
 
     #[test]

--- a/agentsight-capture/src/time.rs
+++ b/agentsight-capture/src/time.rs
@@ -17,19 +17,21 @@ static BOOT_TIME_SECS: OnceLock<i64> = OnceLock::new();
 /// This uses the platform process backend and caches the result.
 pub fn get_boot_time_secs() -> i64 {
     *BOOT_TIME_SECS.get_or_init(|| {
-        if let Ok(boot_time) = i64::try_from(sysinfo::System::boot_time())
-            && boot_time > 0
-        {
-            return boot_time;
-        }
-
         let now_secs = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_secs() as i64;
+
+        if let Ok(boot_time) = i64::try_from(sysinfo::System::boot_time())
+            && boot_time > 946684800
+            && boot_time < now_secs
+        {
+            return boot_time;
+        }
+
         let uptime_secs = i64::try_from(sysinfo::System::uptime())
             .ok()
-            .filter(|uptime| *uptime > 0)
+            .filter(|uptime| *uptime > 0 && *uptime < now_secs)
             .unwrap_or(1);
         now_secs.saturating_sub(uptime_secs)
     })

--- a/ext/analysis/src/sources/agent_native.rs
+++ b/ext/analysis/src/sources/agent_native.rs
@@ -1508,6 +1508,56 @@ mod tests {
     }
 
     #[test]
+    fn codex_state_db_falls_back_to_tokens_used_for_invalid_rollout() {
+        let temp = tempfile::tempdir().unwrap();
+        let codex_dir = temp.path().join(".codex");
+        fs::create_dir_all(&codex_dir).unwrap();
+        let rollout = codex_dir.join("rollout.jsonl");
+        fs::write(
+            &rollout,
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":"corrupt","turn_token_usage":null,"usage":null}}"#,
+        )
+        .unwrap();
+        let conn = rusqlite::Connection::open(codex_dir.join("state_5.sqlite")).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE threads (
+                id TEXT PRIMARY KEY,
+                rollout_path TEXT,
+                model TEXT,
+                tokens_used INTEGER NOT NULL DEFAULT 0,
+                preview TEXT,
+                cwd TEXT,
+                created_at_ms INTEGER,
+                updated_at_ms INTEGER
+            );",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO threads
+            (id, rollout_path, model, tokens_used, preview, cwd, created_at_ms, updated_at_ms)
+            VALUES
+            ('019f49ca-54e7-7a91-82e7-a52b53cfd456', ?1, 'gpt-web-ci', 33, 'db fallback prompt', '/work/repo', 1800000, 1900000)",
+            [rollout.to_string_lossy().as_ref()],
+        )
+        .unwrap();
+
+        let sessions = codex_state_sessions_in_home(temp.path(), 5);
+
+        assert_eq!(sessions.len(), 1);
+        assert_eq!(sessions[0].usage.total_tokens, 33);
+        assert_eq!(sessions[0].usage.input_tokens, 0);
+        assert_eq!(sessions[0].usage.output_tokens, 0);
+        assert_eq!(
+            sessions[0]
+                .model_usage
+                .get("gpt-web-ci")
+                .unwrap()
+                .total_tokens,
+            33
+        );
+    }
+
+    #[test]
     fn codex_rollout_summary_cache_tracks_file_metadata() {
         let temp = tempfile::tempdir().unwrap();
         let rollout = temp.path().join("rollout.jsonl");

--- a/ext/session/src/parser.rs
+++ b/ext/session/src/parser.rs
@@ -950,6 +950,38 @@ fn parse_jsonl(
                     }
                 }
             }
+            (AGENT_CODEX, "token_usage_record") => {
+                let payload = obj.get("payload").unwrap_or(&Value::Null);
+                let token_usage = payload
+                    .get("thread_token_usage")
+                    .or_else(|| payload.get("turn_token_usage"))
+                    .or_else(|| payload.get("usage"))
+                    .unwrap_or(payload);
+                let usage = codex_token_usage(token_usage);
+                if usage.total_tokens > 0 {
+                    let name = if codex_model.is_empty() {
+                        "unknown"
+                    } else {
+                        &codex_model
+                    };
+                    acc.set_usage(
+                        name,
+                        usage.input_tokens,
+                        usage.output_tokens,
+                        0,
+                        usage.cache_read_tokens,
+                        usage.total_tokens,
+                    );
+                    if let Some(last) = events.llm_responses.last_mut()
+                        && last.total_tokens == 0
+                    {
+                        last.input_tokens = usage.input_tokens as u64;
+                        last.output_tokens = usage.output_tokens as u64;
+                        last.cache_tokens = usage.cache_read_tokens as u64;
+                        last.total_tokens = usage.total_tokens as u64;
+                    }
+                }
+            }
             (AGENT_CODEX, "response_item")
                 if obj.pointer("/payload/type").and_then(Value::as_str)
                     == Some("custom_tool_call") =>
@@ -4476,6 +4508,30 @@ mod tests {
                 .max(usage.input_tokens + usage.output_tokens + usage.cache_tokens);
             assert_eq!(total, tokens);
         }
+    }
+
+    #[test]
+    fn codex_token_usage_record_updates_session_totals() {
+        let codex = concat!(
+            r#"{"type":"turn_context","payload":{"model":"gpt-agentsight-mock","cwd":"/repo"}}"#,
+            "\n",
+            r#"{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"agentsight macos live token check"}]}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"usage":{"input_tokens":11,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":15},"turn_token_usage":{"input_tokens":11,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":15},"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":15}}}"#,
+        );
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.model.as_deref(), Some("gpt-agentsight-mock"));
+        assert_eq!(session.usage.input_tokens, 11);
+        assert_eq!(session.usage.output_tokens, 4);
+        assert_eq!(session.usage.total_tokens, 15);
     }
 
     #[test]

--- a/ext/session/src/parser.rs
+++ b/ext/session/src/parser.rs
@@ -860,14 +860,14 @@ fn parse_jsonl(
                 let payload = obj.get("payload").unwrap_or(&Value::Null);
                 let ptype = payload.get("type").and_then(Value::as_str).unwrap_or("");
                 if ptype == "token_count"
-                    && let Some(usage) = payload.pointer("/info/total_token_usage")
+                    && let Some(usage_value) = payload.pointer("/info/total_token_usage")
+                    && let Some(usage) = codex_token_usage(usage_value)
                 {
                     let name = if codex_model.is_empty() {
                         "unknown"
                     } else {
                         &codex_model
                     };
-                    let usage = codex_token_usage(usage);
                     acc.set_usage(
                         name,
                         usage.input_tokens,
@@ -952,10 +952,9 @@ fn parse_jsonl(
             }
             (AGENT_CODEX, "token_usage_record") => {
                 let payload = obj.get("payload").unwrap_or(&Value::Null);
-                let Some(usage_value) = codex_token_usage_candidate(payload) else {
+                let Some(usage) = codex_token_usage_candidate(payload) else {
                     continue;
                 };
-                let usage = codex_token_usage(usage_value);
                 let name = if codex_model.is_empty() {
                     "unknown"
                 } else {
@@ -2652,28 +2651,40 @@ fn shell_segments(command: &str) -> Vec<Vec<String>> {
     segments
 }
 
-fn codex_token_usage(value: &Value) -> TokenUsage {
-    let input = json_i64(value, "input_tokens").max(0);
-    let output = json_i64(value, "output_tokens").max(0);
-    let cache = json_i64(value, "cached_input_tokens").max(0);
+fn codex_token_usage(value: &Value) -> Option<TokenUsage> {
+    let fields = value.as_object()?;
+    let mut input = 0_i64;
+    let mut output = 0_i64;
+    let mut cache = 0_i64;
+    for (key, target) in [
+        ("input_tokens", &mut input),
+        ("output_tokens", &mut output),
+        ("cached_input_tokens", &mut cache),
+    ] {
+        let Some(raw) = fields.get(key) else {
+            continue;
+        };
+        let parsed = raw.as_i64().filter(|value| *value >= 0)?;
+        *target = parsed;
+    }
     let input = input.saturating_sub(cache);
-    TokenUsage {
+    let total = input + output + cache;
+    (total > 0).then_some(TokenUsage {
         input_tokens: input,
         output_tokens: output,
         cache_creation_tokens: 0,
         cache_read_tokens: cache,
-        total_tokens: input + output + cache,
-    }
+        total_tokens: total,
+    })
 }
 
-fn codex_token_usage_candidate(payload: &Value) -> Option<&Value> {
-    ["thread_token_usage", "turn_token_usage", "usage"]
-        .into_iter()
-        .find_map(|key| {
-            payload
-                .get(key)
-                .filter(|value| value.is_object() && codex_token_usage(value).total_tokens > 0)
-        })
+fn codex_token_usage_candidate(payload: &Value) -> Option<TokenUsage> {
+    for key in ["thread_token_usage", "turn_token_usage", "usage"] {
+        if let Some(usage) = payload.get(key).and_then(codex_token_usage) {
+            return Some(usage);
+        }
+    }
+    codex_token_usage(payload)
 }
 
 pub fn codex_total_token_usage(content: &str) -> Option<TokenUsage> {
@@ -2681,14 +2692,14 @@ pub fn codex_total_token_usage(content: &str) -> Option<TokenUsage> {
         let obj: Value = serde_json::from_str(line).ok()?;
         let payload = obj.get("payload")?;
         if obj.get("type").and_then(Value::as_str) == Some("token_usage_record") {
-            return codex_token_usage_candidate(payload).map(codex_token_usage);
+            return codex_token_usage_candidate(payload);
         }
         if payload.get("type").and_then(Value::as_str) != Some("token_count") {
             return None;
         }
         payload
             .pointer("/info/total_token_usage")
-            .map(codex_token_usage)
+            .and_then(codex_token_usage)
     })
 }
 
@@ -5223,9 +5234,9 @@ mod tests {
     #[test]
     fn codex_total_token_usage_invalid_newest_record_falls_back_to_older() {
         let zero_newest = concat!(
-            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"turn_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0}}}"#,
-            "\n",
             r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":19184,"cached_input_tokens":0,"output_tokens":11,"total_tokens":19195}}}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"turn_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0}}}"#,
         );
         assert_eq!(
             codex_total_token_usage(zero_newest).map(|usage| usage.total_tokens),
@@ -5233,9 +5244,9 @@ mod tests {
         );
 
         let malformed_newest = concat!(
-            r#"{"type":"token_usage_record","payload":{"thread_token_usage":"corrupt","turn_token_usage":{"total_tokens":"not-a-number"},"usage":null}}"#,
-            "\n",
             r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":"corrupt","turn_token_usage":{"total_tokens":"not-a-number"},"usage":null}}"#,
         );
         assert_eq!(
             codex_total_token_usage(malformed_newest).map(|usage| usage.total_tokens),
@@ -5310,6 +5321,89 @@ mod tests {
         assert_eq!(session.usage.output_tokens, 10);
         assert_eq!(session.usage.cache_read_tokens, 40);
         assert_eq!(session.usage.total_tokens, 110);
+    }
+
+    #[test]
+    fn codex_total_token_usage_reads_payload_level_fields() {
+        let content = r#"{"type":"token_usage_record","payload":{"thread_token_usage":null,"turn_token_usage":null,"usage":null,"input_tokens":7,"cached_input_tokens":0,"output_tokens":3,"total_tokens":10}}"#;
+
+        let usage = codex_total_token_usage(content).expect("usage");
+
+        assert_eq!(usage.input_tokens, 7);
+        assert_eq!(usage.output_tokens, 3);
+        assert_eq!(usage.total_tokens, 10);
+    }
+
+    #[test]
+    fn codex_total_token_usage_rejects_invalid_legacy_records() {
+        let zero = r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0}}}}"#;
+        assert_eq!(codex_total_token_usage(zero), None);
+
+        let malformed = r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":"corrupt","cached_input_tokens":0,"output_tokens":4}}}}"#;
+        assert_eq!(codex_total_token_usage(malformed), None);
+    }
+
+    #[test]
+    fn codex_token_usage_record_falls_back_to_payload_fields() {
+        let codex = [
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#,
+            r#"{"type":"token_usage_record","payload":{"input_tokens":7,"cached_input_tokens":0,"output_tokens":3,"total_tokens":10}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.usage.input_tokens, 7);
+        assert_eq!(session.usage.output_tokens, 3);
+        assert_eq!(session.usage.total_tokens, 10);
+    }
+
+    #[test]
+    fn codex_token_usage_record_corrupt_thread_falls_back_to_turn() {
+        let codex = [
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#,
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":"corrupt","turn_token_usage":{"input_tokens":7,"cached_input_tokens":0,"output_tokens":3,"total_tokens":10}}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.usage.input_tokens, 7);
+        assert_eq!(session.usage.output_tokens, 3);
+        assert_eq!(session.usage.total_tokens, 10);
+    }
+
+    #[test]
+    fn codex_token_count_invalid_legacy_usage_keeps_prior_totals() {
+        let codex = [
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+            r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":"corrupt","cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.usage.input_tokens, 11);
+        assert_eq!(session.usage.output_tokens, 4);
+        assert_eq!(session.usage.total_tokens, 15);
     }
 
     #[test]

--- a/ext/session/src/parser.rs
+++ b/ext/session/src/parser.rs
@@ -2667,8 +2667,8 @@ fn codex_token_usage(value: &Value) -> Option<TokenUsage> {
         let parsed = raw.as_i64().filter(|value| *value >= 0)?;
         *target = parsed;
     }
-    let input = input.saturating_sub(cache);
-    let total = input + output + cache;
+    let input = input.checked_sub(cache).filter(|value| *value >= 0)?;
+    let total = input.checked_add(output)?.checked_add(cache)?;
     (total > 0).then_some(TokenUsage {
         input_tokens: input,
         output_tokens: output,
@@ -5255,6 +5255,44 @@ mod tests {
 
         let only_invalid = r#"{"type":"token_usage_record","payload":{"thread_token_usage":null,"turn_token_usage":null,"usage":null}}"#;
         assert_eq!(codex_total_token_usage(only_invalid), None);
+    }
+
+    #[test]
+    fn codex_total_token_usage_rejects_cache_exceeding_input_newest_falls_back() {
+        let content = concat!(
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":10,"cached_input_tokens":40,"output_tokens":4,"total_tokens":54}}}"#,
+        );
+        assert_eq!(
+            codex_total_token_usage(content).map(|usage| usage.total_tokens),
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn codex_total_token_usage_rejects_total_overflow_newest_falls_back() {
+        let content = concat!(
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":9223372036854775807,"cached_input_tokens":0,"output_tokens":1,"total_tokens":9223372036854775808}}}"#,
+        );
+        assert_eq!(
+            codex_total_token_usage(content).map(|usage| usage.total_tokens),
+            Some(15)
+        );
+    }
+
+    #[test]
+    fn codex_total_token_usage_rejects_non_object_negative_and_empty() {
+        let non_object = r#"{"type":"token_usage_record","payload":{"thread_token_usage":"corrupt","turn_token_usage":null,"usage":null}}"#;
+        assert_eq!(codex_total_token_usage(non_object), None);
+
+        let negative = r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":-1,"cached_input_tokens":0,"output_tokens":4,"total_tokens":3}}}"#;
+        assert_eq!(codex_total_token_usage(negative), None);
+
+        let empty = r#"{"type":"token_usage_record","payload":{"thread_token_usage":{},"turn_token_usage":{},"usage":{}}}"#;
+        assert_eq!(codex_total_token_usage(empty), None);
     }
 
     #[test]

--- a/ext/session/src/parser.rs
+++ b/ext/session/src/parser.rs
@@ -2674,6 +2674,13 @@ pub fn codex_total_token_usage(content: &str) -> Option<TokenUsage> {
     content.lines().rev().find_map(|line| {
         let obj: Value = serde_json::from_str(line).ok()?;
         let payload = obj.get("payload")?;
+        if obj.get("type").and_then(Value::as_str) == Some("token_usage_record") {
+            let usage = payload
+                .get("thread_token_usage")
+                .or_else(|| payload.get("turn_token_usage"))
+                .or_else(|| payload.get("usage"))?;
+            return Some(codex_token_usage(usage));
+        }
         if payload.get("type").and_then(Value::as_str) != Some("token_count") {
             return None;
         }
@@ -5164,6 +5171,40 @@ mod tests {
         assert_eq!(session.usage.cache_read_tokens, 9_984);
         assert_eq!(session.usage.output_tokens, 11);
         assert_eq!(session.usage.total_tokens, 19_195);
+    }
+
+    #[test]
+    fn codex_total_token_usage_reads_mid_turn_token_usage_record() {
+        let content = r#"{"type":"token_usage_record","payload":{"usage":{"input_tokens":11,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":15},"turn_token_usage":{"input_tokens":11,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":15},"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"cache_write_input_tokens":0,"output_tokens":4,"reasoning_output_tokens":0,"total_tokens":15}}}"#;
+
+        let usage = codex_total_token_usage(content).expect("usage");
+
+        assert_eq!(usage.input_tokens, 11);
+        assert_eq!(usage.output_tokens, 4);
+        assert_eq!(usage.total_tokens, 15);
+    }
+
+    #[test]
+    fn codex_total_token_usage_newest_record_wins() {
+        let legacy_first = concat!(
+            r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":19184,"cached_input_tokens":0,"output_tokens":11,"total_tokens":19195}}}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+        );
+        let record_first = concat!(
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+            "\n",
+            r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":19184,"cached_input_tokens":0,"output_tokens":11,"total_tokens":19195}}}}"#,
+        );
+
+        assert_eq!(
+            codex_total_token_usage(legacy_first).map(|usage| usage.total_tokens),
+            Some(15)
+        );
+        assert_eq!(
+            codex_total_token_usage(record_first).map(|usage| usage.total_tokens),
+            Some(19_195)
+        );
     }
 
     #[test]

--- a/ext/session/src/parser.rs
+++ b/ext/session/src/parser.rs
@@ -952,34 +952,30 @@ fn parse_jsonl(
             }
             (AGENT_CODEX, "token_usage_record") => {
                 let payload = obj.get("payload").unwrap_or(&Value::Null);
-                let token_usage = payload
-                    .get("thread_token_usage")
-                    .or_else(|| payload.get("turn_token_usage"))
-                    .or_else(|| payload.get("usage"))
-                    .unwrap_or(payload);
-                let usage = codex_token_usage(token_usage);
-                if usage.total_tokens > 0 {
-                    let name = if codex_model.is_empty() {
-                        "unknown"
-                    } else {
-                        &codex_model
-                    };
-                    acc.set_usage(
-                        name,
-                        usage.input_tokens,
-                        usage.output_tokens,
-                        0,
-                        usage.cache_read_tokens,
-                        usage.total_tokens,
-                    );
-                    if let Some(last) = events.llm_responses.last_mut()
-                        && last.total_tokens == 0
-                    {
-                        last.input_tokens = usage.input_tokens as u64;
-                        last.output_tokens = usage.output_tokens as u64;
-                        last.cache_tokens = usage.cache_read_tokens as u64;
-                        last.total_tokens = usage.total_tokens as u64;
-                    }
+                let Some(usage_value) = codex_token_usage_candidate(payload) else {
+                    continue;
+                };
+                let usage = codex_token_usage(usage_value);
+                let name = if codex_model.is_empty() {
+                    "unknown"
+                } else {
+                    &codex_model
+                };
+                acc.set_usage(
+                    name,
+                    usage.input_tokens,
+                    usage.output_tokens,
+                    0,
+                    usage.cache_read_tokens,
+                    usage.total_tokens,
+                );
+                if let Some(last) = events.llm_responses.last_mut()
+                    && last.total_tokens == 0
+                {
+                    last.input_tokens = usage.input_tokens as u64;
+                    last.output_tokens = usage.output_tokens as u64;
+                    last.cache_tokens = usage.cache_read_tokens as u64;
+                    last.total_tokens = usage.total_tokens as u64;
                 }
             }
             (AGENT_CODEX, "response_item")
@@ -2670,16 +2666,22 @@ fn codex_token_usage(value: &Value) -> TokenUsage {
     }
 }
 
+fn codex_token_usage_candidate(payload: &Value) -> Option<&Value> {
+    ["thread_token_usage", "turn_token_usage", "usage"]
+        .into_iter()
+        .find_map(|key| {
+            payload
+                .get(key)
+                .filter(|value| value.is_object() && codex_token_usage(value).total_tokens > 0)
+        })
+}
+
 pub fn codex_total_token_usage(content: &str) -> Option<TokenUsage> {
     content.lines().rev().find_map(|line| {
         let obj: Value = serde_json::from_str(line).ok()?;
         let payload = obj.get("payload")?;
         if obj.get("type").and_then(Value::as_str) == Some("token_usage_record") {
-            let usage = payload
-                .get("thread_token_usage")
-                .or_else(|| payload.get("turn_token_usage"))
-                .or_else(|| payload.get("usage"))?;
-            return Some(codex_token_usage(usage));
+            return codex_token_usage_candidate(payload).map(codex_token_usage);
         }
         if payload.get("type").and_then(Value::as_str) != Some("token_count") {
             return None;
@@ -5205,6 +5207,109 @@ mod tests {
             codex_total_token_usage(record_first).map(|usage| usage.total_tokens),
             Some(19_195)
         );
+    }
+
+    #[test]
+    fn codex_total_token_usage_prefers_first_valid_candidate() {
+        let content = r#"{"type":"token_usage_record","payload":{"thread_token_usage":null,"turn_token_usage":{"input_tokens":7,"cached_input_tokens":0,"output_tokens":3,"total_tokens":10},"usage":{"input_tokens":1,"cached_input_tokens":0,"output_tokens":1,"total_tokens":2}}}"#;
+
+        let usage = codex_total_token_usage(content).expect("usage");
+
+        assert_eq!(usage.input_tokens, 7);
+        assert_eq!(usage.output_tokens, 3);
+        assert_eq!(usage.total_tokens, 10);
+    }
+
+    #[test]
+    fn codex_total_token_usage_invalid_newest_record_falls_back_to_older() {
+        let zero_newest = concat!(
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"turn_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0}}}"#,
+            "\n",
+            r#"{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":19184,"cached_input_tokens":0,"output_tokens":11,"total_tokens":19195}}}}"#,
+        );
+        assert_eq!(
+            codex_total_token_usage(zero_newest).map(|usage| usage.total_tokens),
+            Some(19_195)
+        );
+
+        let malformed_newest = concat!(
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":"corrupt","turn_token_usage":{"total_tokens":"not-a-number"},"usage":null}}"#,
+            "\n",
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+        );
+        assert_eq!(
+            codex_total_token_usage(malformed_newest).map(|usage| usage.total_tokens),
+            Some(15)
+        );
+
+        let only_invalid = r#"{"type":"token_usage_record","payload":{"thread_token_usage":null,"turn_token_usage":null,"usage":null}}"#;
+        assert_eq!(codex_total_token_usage(only_invalid), None);
+    }
+
+    #[test]
+    fn codex_token_usage_record_skips_null_thread_usage() {
+        let codex = [
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#,
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":null,"turn_token_usage":{"input_tokens":7,"cached_input_tokens":0,"output_tokens":3,"total_tokens":10}}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.usage.input_tokens, 7);
+        assert_eq!(session.usage.output_tokens, 3);
+        assert_eq!(session.usage.cache_read_tokens, 0);
+        assert_eq!(session.usage.total_tokens, 10);
+    }
+
+    #[test]
+    fn codex_token_usage_record_invalid_newest_keeps_older_totals() {
+        let codex = [
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#,
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":11,"cached_input_tokens":0,"output_tokens":4,"total_tokens":15}}}"#,
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"total_tokens":0},"turn_token_usage":null,"usage":{"total_tokens":"oops"}}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.usage.input_tokens, 11);
+        assert_eq!(session.usage.output_tokens, 4);
+        assert_eq!(session.usage.total_tokens, 15);
+    }
+
+    #[test]
+    fn codex_token_usage_record_keeps_cached_input_arithmetic() {
+        let codex = [
+            r#"{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"done"}]}}"#,
+            r#"{"type":"token_usage_record","payload":{"thread_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":150}}}"#,
+        ]
+        .join("\n");
+
+        let session = parse_session_content(
+            AGENT_CODEX,
+            &PathBuf::from("/tmp/session.jsonl"),
+            UNIX_EPOCH,
+            &codex,
+        )
+        .expect("session");
+
+        assert_eq!(session.usage.input_tokens, 60);
+        assert_eq!(session.usage.output_tokens, 10);
+        assert_eq!(session.usage.cache_read_tokens, 40);
+        assert_eq!(session.usage.total_tokens, 110);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- treat invalid sysinfo boot-time values as unusable before falling back to uptime-based boot time
- keep /proc-specific integration tests Linux-only
- keep /proc/self/root canonicalization coverage Linux-only while preserving missing-path fallback coverage everywhere

## Repro
On macOS, the collector suite previously failed in timestamp_normalizer, time::test_boot_time_is_reasonable, and system_runner_test because they assumed Linux /proc or valid Linux boot-time behavior.

## Test
- cargo test -q --manifest-path collector/Cargo.toml
- Result: passed