### PR TITLE
Fix frontend fleet loading and mobile session usability

### DIFF
--- a/ext/web/components/ConnectionDialog.tsx
+++ b/ext/web/components/ConnectionDialog.tsx
@@ -41,7 +41,7 @@ export function ConnectionDialog({
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/55 px-4 py-8">
       <div role="dialog" aria-modal="true" aria-labelledby="connect-title"
-        className="relative w-full max-w-3xl rounded-2xl bg-white p-6 shadow-2xl sm:p-8">
+        className="relative max-h-[calc(100dvh-4rem)] w-full max-w-3xl overflow-y-auto rounded-2xl bg-white p-6 shadow-2xl sm:p-8">
         {canClose && onClose && (
           <button type="button" onClick={onClose} aria-label={t('connect.close')}
             className="absolute right-5 top-4 text-2xl text-slate-400 hover:text-slate-700">

--- a/ext/web/components/FleetOverview.tsx
+++ b/ext/web/components/FleetOverview.tsx
@@ -11,16 +11,9 @@ import {
   filterFleetNodes, fleetSubscriptions, fleetTotals, isRunningSession,
   type FleetNodeSample,
 } from '@/lib/fleetData';
-import { Subscription } from '@/components/NodeOverview';
+import { count, Stat, Subscription } from '@/components/NodeOverview';
 
 type Filter = 'all' | 'running' | 'idle' | 'unreachable';
-
-function count(value: number): string {
-  if (Math.abs(value) >= 1_000_000_000) return `${(value / 1_000_000_000).toFixed(1)}B`;
-  if (Math.abs(value) >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
-  if (Math.abs(value) >= 1_000) return `${(value / 1_000).toFixed(1)}k`;
-  return Math.round(value).toLocaleString();
-}
 
 function planTitle(value: string): string {
   return value.replace(/_/g, ' ').replace(/\b\w/g, (letter) => letter.toUpperCase());
@@ -189,16 +182,6 @@ function Status({ state }: { state: FleetNodeSample['state'] }) {
   const style = state === 'online' ? 'bg-emerald-50 text-emerald-700'
     : state === 'checking' ? 'bg-blue-50 text-blue-700' : 'bg-slate-100 text-slate-500';
   return <span className={`rounded-full px-2 py-1 text-[11px] font-medium ${style}`}>{t(`fleet.${state}`)}</span>;
-}
-
-function Stat({ label, value, hint }: { label: string; value: string; hint: string }) {
-  return (
-    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 shadow-sm">
-      <div className="text-xs font-medium text-slate-500">{label}</div>
-      <div className="mt-1 text-2xl font-semibold tabular-nums tracking-tight text-slate-950">{value}</div>
-      <div className="mt-0.5 truncate text-[11px] text-slate-400">{hint}</div>
-    </div>
-  );
 }
 
 function Metric({ label, value }: { label: string; value: string }) {

--- a/ext/web/components/FleetOverview.tsx
+++ b/ext/web/components/FleetOverview.tsx
@@ -56,7 +56,7 @@ export function FleetOverview({
 
   return (
     <div className="space-y-4">
-      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-6">
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
         <Stat label={t('fleet.machines')} value={`${totals.online}/${totals.machines}`}
           hint={t('fleet.onlineHint')} />
         <Stat label={t('overview.running')} value={String(totals.running)} hint={t('fleet.runningHint')} />

--- a/ext/web/components/NodeOverview.tsx
+++ b/ext/web/components/NodeOverview.tsx
@@ -24,7 +24,7 @@ import {
   sessionWorkspace,
 } from '@/utils/sessionData';
 
-function count(value: number | null | undefined): string {
+export function count(value: number | null | undefined): string {
   const number = value ?? 0;
   if (Math.abs(number) >= 1_000_000_000) return `${(number / 1_000_000_000).toFixed(1)}B`;
   if (Math.abs(number) >= 1_000_000) return `${(number / 1_000_000).toFixed(1)}M`;
@@ -308,7 +308,7 @@ export function NodeOverview({
   );
 }
 
-function Stat({ label, value, hint, tone = 'slate' }: {
+export function Stat({ label, value, hint, tone = 'slate' }: {
   label: string; value: string; hint: string; tone?: 'slate' | 'emerald';
 }) {
   return (
@@ -323,7 +323,7 @@ function Stat({ label, value, hint, tone = 'slate' }: {
   );
 }
 
-function State({ state }: { state: 'running' | 'recent' | 'stopped' }) {
+export function State({ state }: { state: 'running' | 'recent' | 'stopped' }) {
   const { t } = useTranslation();
   const running = state === 'running';
   const recent = state === 'recent';

--- a/ext/web/components/NodeOverview.tsx
+++ b/ext/web/components/NodeOverview.tsx
@@ -107,7 +107,7 @@ export function NodeOverview({
 
   return (
     <div className="space-y-4">
-      <section className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+      <section className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-5">
         <Stat label={t('overview.running')} value={liveAvailable ? String(running) : '—'}
           tone={liveAvailable ? 'emerald' : 'slate'}
           hint={liveAvailable ? t('overview.runningHint') : t('overview.liveUnavailable')} />
@@ -141,8 +141,8 @@ export function NodeOverview({
             <span className="text-xs tabular-nums text-slate-400">{sessions.length + unmatched.length}</span>
           </div>
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[820px] text-left text-sm">
-              <thead className="bg-slate-50 text-[11px] uppercase tracking-wide text-slate-500">
+            <table className="w-full text-left text-sm md:min-w-[820px] [&_td:nth-child(n+4)]:hidden md:[&_td:nth-child(n+4)]:table-cell">
+              <thead className="hidden bg-slate-50 text-[11px] uppercase tracking-wide text-slate-500 md:table-header-group">
                 <tr>
                   <th scope="col" className="px-5 py-2.5 font-medium">{t('overview.state')}</th>
                   <th scope="col" className="px-3 py-2.5 font-medium">{t('overview.agentProcess')}</th>
@@ -159,7 +159,7 @@ export function NodeOverview({
                   const state = sessionActivityState(session, live);
                   const runningSession = state === 'running';
                   return (
-                    <tr key={session.id} className="group hover:bg-blue-50/40">
+                    <tr key={session.id} className="group grid grid-cols-2 hover:bg-blue-50/40 md:table-row">
                       <td className="px-5 py-3">
                         {isRecordedCaptureSession(session)
                           ? <span className="text-xs font-medium text-slate-500">{t('sessionDetail.recordedCapture')}</span>
@@ -176,7 +176,7 @@ export function NodeOverview({
                             .filter(Boolean).join(' · ')}
                         </div>
                       </td>
-                      <td className="max-w-[420px] px-3 py-3">
+                      <td className="col-span-2 min-w-0 px-3 pb-3 md:max-w-[420px] md:py-3">
                         <button type="button" onClick={() => onOpenSession(session.id)}
                           className="block w-full truncate text-left font-medium text-slate-700 group-hover:text-slate-950">
                           {currentWork(session, live)}
@@ -211,10 +211,10 @@ export function NodeOverview({
                   );
                 })}
                 {unmatched.map((row) => (
-                  <tr key={`${row.pid}-${row.session}`} className="bg-slate-50/50">
+                  <tr key={`${row.pid}-${row.session}`} className="grid grid-cols-2 bg-slate-50/50 md:table-row">
                     <td className="px-5 py-3"><State state="running" /></td>
                     <td className="px-3 py-3 font-semibold capitalize text-slate-900">{row.agent}</td>
-                    <td className="max-w-[420px] px-3 py-3">
+                    <td className="col-span-2 min-w-0 px-3 pb-3 md:max-w-[420px] md:py-3">
                       <div className="truncate font-medium text-slate-700">{row.command}</div>
                       <div className="truncate text-[11px] text-slate-400">{row.workspace || `PID ${row.pid}`}</div>
                     </td>

--- a/ext/web/components/SessionConsole.tsx
+++ b/ext/web/components/SessionConsole.tsx
@@ -3,7 +3,7 @@
 
 'use client';
 
-import { FormEvent, useEffect, useRef, useState } from 'react';
+import { FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { NodeRequestError, type NodeClient, type SessionDetail } from '@/lib/nodeClient';
 import type { SnapshotSession } from '@/types/event';
 import { useTranslation } from '@/i18n';
@@ -50,21 +50,14 @@ export function SessionConsole({
   const conversationRef = useRef<HTMLDivElement | null>(null);
   const stickToBottom = useRef(true);
   const refreshGeneration = useRef(0);
-  const conversation = messages(detail);
+  const conversation = useMemo(() => messages(detail), [detail]);
 
   useEffect(() => {
     const element = conversationRef.current;
     if (element && stickToBottom.current) element.scrollTop = element.scrollHeight;
   }, [conversation.length, detail]);
 
-  useEffect(() => {
-    refreshGeneration.current += 1;
-    setMessage('');
-    setBusy(false);
-    setError('');
-    setWriteBlocked('');
-    stickToBottom.current = true;
-  }, [session.id]);
+  useEffect(() => () => { refreshGeneration.current += 1; }, []);
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
@@ -76,6 +69,7 @@ export function SessionConsole({
     setError('');
     try {
       await client.submitMessage(rawSessionId(session), text);
+      if (refreshGeneration.current !== generation) return;
       setMessage('');
       setBusy(false);
       stickToBottom.current = true;
@@ -111,7 +105,7 @@ export function SessionConsole({
           const element = event.currentTarget;
           stickToBottom.current = element.scrollHeight - element.scrollTop - element.clientHeight < 80;
         }}
-        className="max-h-[680px] min-h-[460px] space-y-3 overflow-y-auto p-5">
+        className="h-[45dvh] min-h-40 space-y-3 overflow-y-auto overscroll-contain p-3 sm:h-[60dvh] sm:max-h-[680px] sm:p-5">
         {loading && conversation.length === 0 && !detailError && (
           <p className="py-16 text-center text-sm text-slate-400">{t('sessions.loading')}</p>
         )}
@@ -125,7 +119,7 @@ export function SessionConsole({
         )}
         {conversation.map((item, index) => (
           <div key={`${item.ts}-${index}`} className={`flex ${item.kind === 'user' ? 'justify-end' : 'justify-start'}`}>
-            <div className={`max-w-[88%] whitespace-pre-wrap rounded-2xl px-4 py-3 text-sm leading-6 ${
+            <div className={`min-w-0 max-w-[88%] whitespace-pre-wrap [overflow-wrap:anywhere] rounded-2xl px-4 py-3 text-sm leading-6 ${
               item.kind === 'user'
                 ? 'rounded-br-md bg-slate-950 text-white'
                 : 'rounded-bl-md bg-slate-100 text-slate-800'
@@ -148,12 +142,13 @@ export function SessionConsole({
             placeholder={canSend ? t('sessions.followUp') : t('sessions.readOnly')}
             disabled={!canSend || busy}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey && canSend && !busy) {
+              if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing
+                  && event.keyCode !== 229 && canSend && !busy) {
                 event.preventDefault();
                 event.currentTarget.form?.requestSubmit();
               }
             }}
-            className="min-h-14 flex-1 resize-none rounded-xl border border-slate-300 px-3 py-2.5 text-sm outline-none focus:border-slate-500 disabled:bg-slate-50" />
+            className="min-h-14 min-w-0 flex-1 resize-none rounded-xl border border-slate-300 px-3 py-2.5 text-base sm:text-sm outline-none focus:border-slate-500 disabled:bg-slate-50" />
           <button type="submit" disabled={!canSend || !message.trim() || busy}
             className="self-end rounded-xl bg-slate-950 px-5 py-2.5 text-sm font-semibold text-white hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-40">
             {busy ? t('sessions.sending') : t('sessions.send')}

--- a/ext/web/components/SessionConsole.tsx
+++ b/ext/web/components/SessionConsole.tsx
@@ -13,18 +13,13 @@ type Message = { ts: number; kind: 'user' | 'assistant'; text: string };
 
 function messages(detail: SessionDetail | null): Message[] {
   if (!detail?.events) return [];
-  return [
-    ...(detail.events.prompts ?? []).map((item) => ({
+  return ([['user', detail.events.prompts], ['assistant', detail.events.llm_responses]] as const)
+    .flatMap(([kind, items]) => (items ?? []).map((item) => ({
       ts: item.ts_ms ?? 0,
-      kind: 'user' as const,
+      kind,
       text: item.text || item.preview || '',
-    })),
-    ...(detail.events.llm_responses ?? []).map((item) => ({
-      ts: item.ts_ms ?? 0,
-      kind: 'assistant' as const,
-      text: item.text || item.preview || '',
-    })),
-  ].filter((item) => item.text).sort((a, b) => a.ts - b.ts);
+    })))
+    .filter((item) => item.text).sort((a, b) => a.ts - b.ts);
 }
 
 export function SessionConsole({
@@ -106,11 +101,10 @@ export function SessionConsole({
           stickToBottom.current = element.scrollHeight - element.scrollTop - element.clientHeight < 80;
         }}
         className="h-[45dvh] min-h-40 space-y-3 overflow-y-auto overscroll-contain p-3 sm:h-[60dvh] sm:max-h-[680px] sm:p-5">
-        {loading && conversation.length === 0 && !detailError && (
-          <p className="py-16 text-center text-sm text-slate-400">{t('sessions.loading')}</p>
-        )}
-        {!loading && !detailError && conversation.length === 0 && (
-          <p className="py-16 text-center text-sm text-slate-400">{t('sessions.noConversation')}</p>
+        {!detailError && conversation.length === 0 && (
+          <p className="py-16 text-center text-sm text-slate-400">
+            {t(loading ? 'sessions.loading' : 'sessions.noConversation')}
+          </p>
         )}
         {detailError && (
           <div className="mx-auto max-w-xl rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">

--- a/ext/web/components/SessionWorkspace.tsx
+++ b/ext/web/components/SessionWorkspace.tsx
@@ -191,11 +191,11 @@ export function SessionWorkspace({
         </div>
 
         {plan.length > 0 && (
-          <div className="mt-5 border-t border-slate-100 pt-4">
-            <div className="mb-2 text-[11px] font-medium uppercase tracking-wide text-slate-400">
+          <details className="mt-3 border-t border-slate-100 pt-3">
+            <summary className="cursor-pointer text-[11px] font-medium uppercase tracking-wide text-slate-400">
               {t('sessionDetail.plan')}
-            </div>
-            <div className="flex flex-wrap gap-2">
+            </summary>
+            <div className="mt-2 flex flex-wrap gap-2">
               {plan.map((step, index) => (
                 <span key={`${step.step}-${index}`} className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1.5 text-xs ${
                   step.status === 'completed'
@@ -212,7 +212,7 @@ export function SessionWorkspace({
                 </span>
               ))}
             </div>
-          </div>
+          </details>
         )}
       </section>
 
@@ -221,7 +221,7 @@ export function SessionWorkspace({
         {(['conversation', 'process', 'analysis'] as SessionTab[]).map((item) => (
           <button key={item} type="button" role="tab" aria-selected={tab === item}
             aria-controls={`session-panel-${item}`} onClick={() => setTab(item)}
-            className={`whitespace-nowrap rounded-lg px-4 py-2 text-sm font-medium transition ${
+            className={`min-w-0 flex-1 rounded-lg px-2 py-2 text-xs font-medium transition sm:flex-none sm:whitespace-nowrap sm:px-4 sm:text-sm ${
               tab === item ? 'bg-slate-950 text-white' : 'text-slate-500 hover:bg-slate-100 hover:text-slate-950'
             }`}>
             {t(`sessionDetail.${item}`)}

--- a/ext/web/components/SessionWorkspace.tsx
+++ b/ext/web/components/SessionWorkspace.tsx
@@ -4,8 +4,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ProcessTreeView } from '@/components/ProcessTreeView';
-import { SessionAnalysis } from '@/components/SessionAnalysis';
+import dynamic from 'next/dynamic';
 import { SessionConsole } from '@/components/SessionConsole';
 import { type NodeClient, type SessionDetail } from '@/lib/nodeClient';
 import { useTranslation } from '@/i18n';
@@ -26,6 +25,8 @@ import {
 } from '@/utils/sessionData';
 
 type SessionTab = 'conversation' | 'process' | 'analysis';
+const ProcessTreeView = dynamic(() => import('@/components/ProcessTreeView').then((module) => module.ProcessTreeView));
+const SessionAnalysis = dynamic(() => import('@/components/SessionAnalysis').then((module) => module.SessionAnalysis));
 
 function compact(value: number | null | undefined): string {
   const number = value ?? 0;
@@ -127,14 +128,8 @@ export function SessionWorkspace({
     session.agent_type, session.model, session.start_timestamp_ms, sessionId, t]);
 
   useEffect(() => {
-    activeRequest.current = 0;
-    setDetail(null);
-    setDetailError('');
-    setTab('conversation');
-  }, [sessionId]);
-
-  useEffect(() => {
     void loadDetail();
+    return () => { activeRequest.current = 0; };
   }, [client, loadDetail, sessionId]);
 
   useEffect(() => {
@@ -145,7 +140,7 @@ export function SessionWorkspace({
     () => sessionSnapshot(snapshot, session, live, detail, overview),
     [detail, live, overview, session, snapshot],
   );
-  const events = useMemo(() => displayEventsFromSnapshot(scopedSnapshot), [scopedSnapshot]);
+  const events = useMemo(() => tab === 'analysis' ? displayEventsFromSnapshot(scopedSnapshot) : [], [scopedSnapshot, tab]);
   const plan = sessionPlan(session, detail, live);
   const currentPlan = plan.find((step) => step.status === 'in_progress');
   const peakCpu = (scopedSnapshot.resource_samples ?? [])
@@ -184,7 +179,7 @@ export function SessionWorkspace({
               {sessionWorkspace(session) || live?.workspace || rawSessionId(session)}
             </p>
           </div>
-          <div className="grid shrink-0 grid-cols-2 gap-2 sm:grid-cols-4">
+          <div className="grid shrink-0 grid-cols-4 gap-2">
             <Metric label={t('overview.tokens')} value={compact(session.total_tokens)} />
             <Metric label={running ? t('sessionDetail.cpuNow') : t('sessionDetail.cpuPeak')}
               value={running ? `${live!.cpu_percent.toFixed(1)}%` : peakCpu ? `${peakCpu.toFixed(1)}%` : '—'} />
@@ -250,9 +245,9 @@ export function SessionWorkspace({
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
-    <div className="min-w-24 rounded-lg bg-slate-50 px-3 py-2">
+    <div className="min-w-0 rounded-lg bg-slate-50 px-2 py-2 sm:min-w-24 sm:px-3">
       <div className="text-[10px] uppercase tracking-wide text-slate-400">{label}</div>
-      <div className="mt-0.5 font-semibold tabular-nums text-slate-900">{value}</div>
+      <div className="mt-0.5 break-words text-sm font-semibold tabular-nums text-slate-900">{value}</div>
     </div>
   );
 }

--- a/ext/web/components/SessionWorkspace.tsx
+++ b/ext/web/components/SessionWorkspace.tsx
@@ -6,6 +6,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { SessionConsole } from '@/components/SessionConsole';
+import { State } from '@/components/NodeOverview';
 import { type NodeClient, type SessionDetail } from '@/lib/nodeClient';
 import { useTranslation } from '@/i18n';
 import type { AgentSightSnapshot, CodingPlanStep, LiveOverview, SnapshotSession } from '@/types/event';
@@ -161,15 +162,7 @@ export function SessionWorkspace({
               <h1 className="text-xl font-semibold capitalize tracking-tight text-slate-950">
                 {session.agent_type}
               </h1>
-              <span className={`inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-[11px] font-medium ${
-                running ? 'bg-emerald-50 text-emerald-700'
-                  : activityState === 'recent' ? 'bg-amber-50 text-amber-700' : 'bg-slate-100 text-slate-500'
-              }`}>
-                <span className={`h-1.5 w-1.5 rounded-full ${
-                  running ? 'bg-emerald-500' : activityState === 'recent' ? 'bg-amber-500' : 'bg-slate-400'
-                }`} />
-                {t(`overview.${activityState}`)}
-              </span>
+              <State state={activityState} />
               {session.model && <span className="text-xs text-slate-400">{session.model}</span>}
             </div>
             <p className="mt-2 max-w-3xl truncate text-sm font-medium text-slate-700">

--- a/ext/web/page.tsx
+++ b/ext/web/page.tsx
@@ -661,34 +661,23 @@ export default function Home() {
   useEffect(() => {
     if (mode !== 'live' || !activeClient) return;
     let cancelled = false;
-    let overviewRefreshing = false;
-    let snapshotRefreshing = false;
-    const refreshOverview = async () => {
-      if (overviewRefreshing || document.visibilityState === 'hidden') return;
-      overviewRefreshing = true;
-      try {
-        const next = await activeClient.overview();
-        if (!cancelled) setOverview(next);
-      } catch {
-        // Retain the last good top sample; manual refresh reports Node errors.
-      } finally {
-        overviewRefreshing = false;
-      }
+    const poll = <T,>(read: () => Promise<T>, update: (value: T) => void, interval: number) => {
+      let refreshing = false;
+      return window.setInterval(async () => {
+        if (refreshing || document.visibilityState === 'hidden') return;
+        refreshing = true;
+        try {
+          const next = await read();
+          if (!cancelled) update(next);
+        } catch {
+          // Keep the last good sample; manual refresh reports Node errors.
+        } finally {
+          refreshing = false;
+        }
+      }, interval);
     };
-    const refreshSnapshot = async () => {
-      if (snapshotRefreshing || document.visibilityState === 'hidden') return;
-      snapshotRefreshing = true;
-      try {
-        const next = await activeClient.snapshot();
-        if (!cancelled) setSnapshot(next);
-      } catch {
-        // Keep the current session index until the next bounded refresh.
-      } finally {
-        snapshotRefreshing = false;
-      }
-    };
-    const overviewTimer = window.setInterval(() => { void refreshOverview(); }, 3_000);
-    const snapshotTimer = window.setInterval(() => { void refreshSnapshot(); }, 30_000);
+    const overviewTimer = poll(() => activeClient.overview(), setOverview, 3_000);
+    const snapshotTimer = poll(() => activeClient.snapshot(), setSnapshot, 30_000);
     return () => {
       cancelled = true;
       window.clearInterval(overviewTimer);
@@ -722,15 +711,10 @@ export default function Home() {
     return () => { window.removeEventListener('hashchange', handleLaunchFragment); };
   }, []);
 
-  const openSession = (sessionId: string) => {
+  const openSession = (sessionId: string | null) => {
     setSelectedSessionId(sessionId);
-    window.history.replaceState(null, '', `${basePath}/?session=${encodeURIComponent(sessionId)}`);
-    window.scrollTo(0, 0);
-  };
-
-  const closeSession = () => {
-    setSelectedSessionId(null);
-    window.history.replaceState(null, '', `${basePath}/`);
+    const query = sessionId === null ? '' : `?session=${encodeURIComponent(sessionId)}`;
+    window.history.replaceState(null, '', `${basePath}/${query}`);
     window.scrollTo(0, 0);
   };
 
@@ -898,7 +882,7 @@ export default function Home() {
             {snapshot ? (
               selectedSession ? (
                 <SessionWorkspace key={`${activeClient?.nodeId}:${selectedSession.id}`} snapshot={snapshot} overview={overview} session={selectedSession}
-                  client={activeClient} onBack={closeSession} />
+                  client={activeClient} onBack={() => openSession(null)} />
               ) : (
                 <NodeOverview snapshot={snapshot} overview={overview} organization={activeOrganization}
                   onOpenSession={openSession} />

--- a/ext/web/page.tsx
+++ b/ext/web/page.tsx
@@ -191,29 +191,9 @@ export default function Home() {
     }
   }, [activeClient]);
 
-  const refreshRelayStatuses = useCallback(async (nodes: CloudNode[], token: string, generation: number) => {
-    if (directoryGeneration.current !== generation) return;
-    setRelayStatus(Object.fromEntries(nodes.map((node) => [node.id, null])));
-    await Promise.all(nodes.map(async (node) => {
-      let online = false;
-      try {
-        online = await relayOnline(token, node.id);
-      } catch (cause) {
-        if (cause instanceof CloudSessionExpiredError
-            && directoryGeneration.current === generation) {
-          handleCloudError(cause, 'Could not check Node relay status.');
-          return;
-        }
-      }
-      if (directoryGeneration.current === generation) {
-        setRelayStatus((current) => ({ ...current, [node.id]: online }));
-      }
-    }));
-  }, [handleCloudError]);
-
   const loadCloudDirectory = useCallback(async (token: string): Promise<CloudOrganization | null> => {
-    const me = await fetchCloudIdentity(token);
-    let nextOrganizations = await fetchOrganizations(token);
+    const [me, fetchedOrganizations] = await Promise.all([fetchCloudIdentity(token), fetchOrganizations(token)]);
+    let nextOrganizations = fetchedOrganizations;
     let selected = preferredOrganization(nextOrganizations);
     const pendingInvite = window.localStorage.getItem(PENDING_INVITE_KEY);
     if (pendingInvite) {
@@ -241,7 +221,6 @@ export default function Home() {
       if (directoryGeneration.current !== generation) return 'stale';
       setCloudNodes(nodes);
       setNodeError('');
-      void refreshRelayStatuses(nodes, token, generation);
       return 'loaded';
     } catch (cause) {
       if (directoryGeneration.current === generation) {
@@ -252,7 +231,7 @@ export default function Home() {
     } finally {
       if (directoryGeneration.current === generation) setNodesLoading(false);
     }
-  }, [handleCloudError, refreshRelayStatuses]);
+  }, [handleCloudError]);
 
   const refreshFleet = useCallback(async () => {
     const organizationId = activeOrganizationId;
@@ -272,63 +251,39 @@ export default function Home() {
 
     try {
       const next = await Promise.all(cloudNodes.map(async (node): Promise<FleetNodeSample> => {
-        const loaded: { value: Pick<FleetNodeSample, 'overview' | 'transport' | 'updatedAt'> | null } = {
-          value: null,
-        };
-        const attempts = [];
+        let sample: FleetNodeSample = { node, state: 'unreachable', overview: null };
         const direct = directConnections[node.id];
-        if (direct) {
-          attempts.push({
-            transport: 'direct',
-            open: async () => {
-              const client = directNodeClient(direct);
-              const overview = await client.overview();
-              if (!overview) throw new Error('This Node does not expose a live overview.');
-              loaded.value = { overview, transport: client.transport, updatedAt: Date.now() };
-            },
+        const relayCheck = (token ? relayOnline(token, node.id) : Promise.resolve(false))
+          .catch((cause) => {
+            if (cause instanceof CloudSessionExpiredError && fleetGeneration.current === generation) {
+              handleCloudError(cause, 'Could not check Node relay status.');
+            }
+            return false;
+          }).then((online) => {
+            if (fleetGeneration.current === generation) {
+              setRelayStatus((current) => ({ ...current, [node.id]: online }));
+            }
+            return online;
           });
-        }
-        let relayAvailable = false;
-        try {
-          relayAvailable = token ? await relayOnline(token, node.id) : false;
-        } catch (cause) {
-          if (cause instanceof CloudSessionExpiredError) throw cause;
+        for (const client of [direct && directNodeClient(direct), token && relayNodeClient(node, token)]) {
+          if (!client || (client.transport === 'relay' && !await relayCheck)) continue;
+          try {
+            const overview = await client.overview();
+            if (!overview) throw new Error('This Node does not expose a live overview.');
+            sample = { node, state: 'online', overview, transport: client.transport, updatedAt: Date.now() };
+            break;
+          } catch (cause) {
+            sample.error = cause instanceof Error ? cause.message : 'No reachable transport.';
+          }
         }
         if (fleetGeneration.current === generation) {
-          setRelayStatus((current) => current[node.id] === relayAvailable
-            ? current : { ...current, [node.id]: relayAvailable });
+          setFleetSamples((current) => current.map((item) => item.node.id === node.id ? sample : item));
         }
-        if (token && relayAvailable) {
-          attempts.push({
-            transport: 'relay',
-            open: async () => {
-              const client = relayNodeClient(node, token);
-              const overview = await client.overview();
-              if (!overview) throw new Error('This Node does not expose a live overview.');
-              loaded.value = { overview, transport: client.transport, updatedAt: Date.now() };
-            },
-          });
-        }
-        if (attempts.length === 0) {
-          return {
-            node,
-            state: 'unreachable',
-            overview: null,
-          };
-        }
-        const result = await tryNodeTransports(attempts);
-        if (loaded.value && result.transport) return { node, state: 'online', ...loaded.value };
-        const cause = result.failures.at(-1)?.cause;
-        return {
-          node,
-          state: 'unreachable',
-          overview: null,
-          error: cause instanceof Error ? cause.message : 'No reachable transport.',
-        };
+        await relayCheck;
+        return sample;
       }));
 
       if (fleetGeneration.current === generation) {
-        setFleetSamples(next);
         const failed = next.filter((sample) => sample.state === 'unreachable').length;
         if (failed && failed === next.length) setFleetError('No machine overview is currently reachable.');
       }
@@ -742,7 +697,7 @@ export default function Home() {
   }, [activeClient, mode]);
 
   useEffect(() => {
-    if (mode !== 'directory' || !identity) return;
+    if ((mode !== 'directory' && !dialogOpen) || !identity) return;
     let cancelled = false;
     let timer: number | undefined;
     const refresh = async () => {
@@ -754,7 +709,7 @@ export default function Home() {
       cancelled = true;
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [identity, mode, refreshFleet]);
+  }, [dialogOpen, identity, mode, refreshFleet]);
 
   useEffect(() => {
     const handleLaunchFragment = () => {
@@ -770,11 +725,13 @@ export default function Home() {
   const openSession = (sessionId: string) => {
     setSelectedSessionId(sessionId);
     window.history.replaceState(null, '', `${basePath}/?session=${encodeURIComponent(sessionId)}`);
+    window.scrollTo(0, 0);
   };
 
   const closeSession = () => {
     setSelectedSessionId(null);
     window.history.replaceState(null, '', `${basePath}/`);
+    window.scrollTo(0, 0);
   };
 
   const showFleet = () => {
@@ -799,6 +756,7 @@ export default function Home() {
 
   const nodeManager = identity ? (
     <NodeManager nodes={cloudNodes} connections={directConnections}
+      modal={dialogOpen} onClose={() => setDialogOpen(false)}
       relayStatus={relayStatus} activeNodeId={activeClient?.nodeId} activeTransport={activeTransport}
       loadingNodeId={loadingNodeId} loading={syncing || nodesLoading} error={nodeError}
       onOpenNode={(nodeId) => { void openNode(nodeId); }} onConnectDirect={connectDirect}
@@ -816,17 +774,7 @@ export default function Home() {
           onDemo={() => { void enterDemo(); }} />
       )}
 
-      {identity && dialogOpen && (
-        <NodeManager nodes={cloudNodes} connections={directConnections}
-          relayStatus={relayStatus} activeNodeId={activeClient?.nodeId} activeTransport={activeTransport}
-          loadingNodeId={loadingNodeId} loading={syncing || nodesLoading} error={nodeError} modal
-          onClose={() => setDialogOpen(false)}
-          onOpenNode={(nodeId) => { void openNode(nodeId); }} onConnectDirect={connectDirect}
-          onRefresh={() => { void refreshCloudNodes(loadCloudSession(), activeOrganizationId); }}
-          onForgetNode={(nodeId) => { void forgetNode(nodeId); }} onForgetDirect={forgetDirect}
-          onForgetCloudDirect={(nodeId) => { void forgetCloudDirect(nodeId); }}
-          onDemo={() => { void enterDemo(); }} onSignOut={signOut} />
-      )}
+      {dialogOpen && nodeManager}
 
       {identity && organizationDialogOpen && (
         <div className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-950/60 px-4">
@@ -870,7 +818,7 @@ export default function Home() {
                   ))}
                 </select>
                 <button type="button" onClick={() => setOrganizationDialogOpen(true)}
-                  className="hidden text-xs font-medium text-slate-500 hover:text-slate-900 sm:inline">
+                  className="text-xs font-medium text-slate-500 hover:text-slate-900">
                   {t('app.addOrganization')}
                 </button>
               </div>
@@ -949,7 +897,7 @@ export default function Home() {
 
             {snapshot ? (
               selectedSession ? (
-                <SessionWorkspace snapshot={snapshot} overview={overview} session={selectedSession}
+                <SessionWorkspace key={`${activeClient?.nodeId}:${selectedSession.id}`} snapshot={snapshot} overview={overview} session={selectedSession}
                   client={activeClient} onBack={closeSession} />
               ) : (
                 <NodeOverview snapshot={snapshot} overview={overview} organization={activeOrganization}

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -81,7 +81,6 @@ test('conversation, message send, process tree, timeline filters, and event deta
   expect(state.messages[0]).toEqual({ message });
   await expect(composer).toHaveValue('');
   await expect(composer).toBeEnabled();
-  await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
   await expect(page.getByText('Browser follow-up complete.')).toBeVisible({ timeout: 25_000 });
   await expect.poll(() => page.getByText(message).evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
   await composer.fill('A draft for the next message');
@@ -153,6 +152,7 @@ test('leaving a pending send preserves a new conversation draft', async ({ page 
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(composer).toBeDisabled();
   await page.getByRole('tab', { name: 'Analysis', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Token usage' })).toBeVisible();
   await page.getByRole('tab', { name: 'Conversation', exact: true }).click();
   await composer.fill('New draft');
   const response = page.waitForResponse('**/sessions/*/messages');

--- a/frontend/e2e/app.spec.ts
+++ b/frontend/e2e/app.spec.ts
@@ -18,6 +18,7 @@ async function openCodexSession(page: Page) {
 }
 
 test('anonymous entry offers both sign-in providers, language switching, and the recorded demo', async ({ page }) => {
+  await page.setViewportSize({ width: 320, height: 568 });
   await mockController(page);
   await page.addInitScript(() => window.localStorage.setItem('agentsight-locale', 'zh'));
   await page.goto('/');
@@ -27,6 +28,7 @@ test('anonymous entry offers both sign-in providers, language switching, and the
   await expect(page.getByRole('button', { name: '使用 GitHub 继续' })).toBeVisible();
   await expect(page.getByRole('button', { name: '使用 Google 继续' })).toBeVisible();
   const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeInViewport({ ratio: 1 });
   await dialog.getByRole('button', { name: 'EN', exact: true }).click();
   await expect(dialog.getByRole('heading', { name: 'Open your AgentSight data' })).toBeVisible();
   await dialog.getByRole('button', { name: 'Enter demo' }).click();
@@ -63,19 +65,28 @@ test('signed-in user opens a relay Node and sees machine value before session de
 
 test('conversation, message send, process tree, timeline filters, and event detail work together', async ({ page }) => {
   const state = await mockController(page, { signedIn: true, responseDelayMs: 10_500 });
+  await page.setViewportSize({ width: 390, height: 844 });
   await page.goto('/');
   await openLab(page);
   await openCodexSession(page);
 
   const composer = page.getByPlaceholder('Send a follow-up to this session…');
-  await composer.fill('Run the final browser regression suite.');
+  const message = `Mobile regression ${'long-path/'.repeat(40)}`;
+  await composer.fill(message);
+  await composer.dispatchEvent('keydown', { key: 'Enter', code: 'Enter', isComposing: true });
+  await expect(composer).toHaveValue(message);
+  expect(state.messages).toHaveLength(0);
   await page.getByRole('button', { name: 'Send' }).click();
   await expect.poll(() => state.messages.length).toBe(1);
-  expect(state.messages[0]).toEqual({ message: 'Run the final browser regression suite.' });
+  expect(state.messages[0]).toEqual({ message });
   await expect(composer).toHaveValue('');
   await expect(composer).toBeEnabled();
   await expect(page.getByRole('button', { name: 'Send' })).toBeVisible();
   await expect(page.getByText('Browser follow-up complete.')).toBeVisible({ timeout: 25_000 });
+  await expect.poll(() => page.getByText(message).evaluate((element) => element.scrollWidth <= element.clientWidth)).toBe(true);
+  await composer.fill('A draft for the next message');
+  await expect(composer).toBeInViewport({ ratio: 1 });
+  await expect(page.getByRole('button', { name: 'Send' })).toBeInViewport({ ratio: 1 });
 
   await page.getByRole('tab', { name: 'Process tree & AI prompts' }).click();
   await expect(page.getByRole('heading', { name: 'Process Tree & AI Prompts' })).toBeVisible();
@@ -92,7 +103,6 @@ test('conversation, message send, process tree, timeline filters, and event deta
   await expect(page.getByRole('heading', { name: 'Timeline Event Details' })).toBeVisible();
   await expect(page.getByText('file-1', { exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Raw Data' })).toBeVisible();
-  await page.setViewportSize({ width: 390, height: 844 });
   await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
 });
 
@@ -107,6 +117,48 @@ test('unsafe message resume is blocked and disables further sends', async ({ pag
   await page.getByRole('button', { name: 'Send' }).click();
   await expect(page.getByText(/already running in another agent process/)).toBeVisible();
   await expect(page.getByPlaceholder('This session is read-only.')).toBeDisabled();
+});
+
+test('a slow relay check leaves fast machines usable and stale results stay signed out', async ({ page }) => {
+  await mockController(page, { signedIn: true });
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  await page.route('**/node-studio/relay/status', async (route) => {
+    await pending;
+    await route.fulfill({ json: { online: true } });
+  });
+  await page.goto('/');
+  await expect(page.getByRole('button', { name: /Checking Studio workstation/ })).toBeVisible();
+  await openLab(page);
+  await page.getByRole('button', { name: 'Nodes' }).click();
+  await page.getByRole('button', { name: 'Sign out' }).click();
+  release();
+  await expect(page.getByRole('heading', { name: 'Open your AgentSight data' })).toBeVisible();
+  await expect(page.getByLabel('Machine view')).toHaveCount(0);
+});
+
+test('leaving a pending send preserves a new conversation draft', async ({ page }) => {
+  await mockController(page, { signedIn: true });
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  await page.route('**/sessions/*/messages', async (route) => {
+    await pending;
+    await route.fulfill({ status: 202, json: { accepted: true } });
+  });
+  await page.goto('/');
+  await openLab(page);
+  await openCodexSession(page);
+  const composer = page.getByPlaceholder('Send a follow-up to this session…');
+  await composer.fill('First message');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(composer).toBeDisabled();
+  await page.getByRole('tab', { name: 'Analysis', exact: true }).click();
+  await page.getByRole('tab', { name: 'Conversation', exact: true }).click();
+  await composer.fill('New draft');
+  const response = page.waitForResponse('**/sessions/*/messages');
+  release();
+  await response;
+  await expect(composer).toHaveValue('New draft');
 });
 
 test('sign-out during initial Node loading returns to the anonymous entry', async ({ page }) => {
@@ -131,7 +183,7 @@ test('Node management refresh, Direct setup, organization creation, sign-out, an
 
   const offline = manager.getByRole('article').filter({ hasText: 'Offline laptop' });
   await offline.getByRole('button', { name: 'Connect Direct' }).click();
-  await page.getByLabel('Direct URL or IP').fill('http://node-direct.test:7395');
+  await page.getByLabel('Direct URL or IP').fill('https://node-direct.test:7395');
   await page.getByLabel('Node bootstrap key').fill('a'.repeat(40));
   await manager.getByRole('button', { name: 'Pair and connect' }).click();
   await expect(page.getByRole('heading', { name: 'Agents on this machine' })).toBeVisible();
@@ -141,6 +193,13 @@ test('Node management refresh, Direct setup, organization creation, sign-out, an
   ]);
   await expect.poll(() => state.registrations.length).toBe(1);
   expect(state.registrations[0]).toMatchObject({ id: 'node-offline', organization_id: 'org-personal' });
+  await openCodexSession(page);
+  const composer = page.getByPlaceholder('Send a follow-up to this session…');
+  await composer.fill('Delivery check');
+  await page.getByRole('button', { name: 'Send' }).click();
+  await expect(page.getByText('Failed to fetch', { exact: true })).toBeVisible();
+  await expect(composer).toHaveValue('Delivery check');
+  expect(state.directRequests.filter((request) => request.endsWith('/messages'))).toHaveLength(1);
   await page.getByLabel('Machine view').selectOption('all');
   await expect(page.getByRole('heading', { name: 'Machine fleet' })).toBeVisible();
 
@@ -156,7 +215,6 @@ test('Node management refresh, Direct setup, organization creation, sign-out, an
   await expect.poll(() => state.deletedNodes).toContain('node-offline');
 
   await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)).toBe(true);
-  await page.setViewportSize({ width: 1280, height: 900 });
   await refreshedManager.getByRole('button', { name: 'Close Node manager' }).click();
   await page.getByRole('button', { name: '+ Organization' }).click();
   await page.getByLabel('Organization name').fill('Browser Test Team');

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -187,7 +187,7 @@ export async function mockController(page: Page, options: {
       window.localStorage.setItem('agentsight-locale', 'en');
     });
   }
-  await page.route('http://node-direct.test:7395/**', async (route) => {
+  await page.route(/^https?:\/\/node-direct\.test:7395\//, async (route) => {
     const request = route.request();
     const path = new URL(request.url()).pathname;
     state.directRequests.push(`${request.method()} ${path}`);
@@ -200,6 +200,8 @@ export async function mockController(page: Page, options: {
     if (path === '/api/v1/capabilities') return json(route, { access_token: 'b'.repeat(40) });
     if (path === '/api/v1/snapshot') return json(route, snapshot);
     if (path === '/api/v1/overview') return json(route, overview);
+    if (path.endsWith('/messages')) return route.abort('failed');
+    if (path.startsWith('/api/v1/sessions/')) return json(route, sessionDetail);
     return json(route, { error: `Unhandled Direct route: ${request.method()} ${path}` }, 500);
   });
   await page.route('https://control.agentsight.us/**', async (route) => {

--- a/frontend/src/lib/nodeClient.ts
+++ b/frontend/src/lib/nodeClient.ts
@@ -133,7 +133,8 @@ async function directFetch(input: string, init: RequestInit = {}): Promise<Respo
     try {
       return await fetch(input, options);
     } catch (error) {
-      if (init.signal?.aborted) throw error;
+      // A failed response can follow an accepted write; only replay reads.
+      if (options.signal?.aborted || !['GET', 'HEAD'].includes(init.method || 'GET')) throw error;
     }
   }
   const localOptions: LocalFetchInit = { ...options, targetAddressSpace: expectedNodeAddressSpace(endpoint) };


### PR DESCRIPTION
## Summary

- Show fast machine overviews as each node completes; overlap identity and organization reads and remove duplicate relay status probes.
- Load process/analysis views on demand, fit fleet/session layouts to narrow screens, collapse optional plan details, and keep tabs and login dialogs reachable on short screens.
- Wrap long chat messages, preserve IME composition, isolate async sends from replaced views, and avoid replaying HTTPS writes after an ambiguous network error.
- Reuse Node manager rendering and session lifecycle: production -107 lines; tests/fixtures +60; total -47 lines (+171/-218). No dependency or configuration additions.

## Validation at f84ab1a4cd3472156a85611c8f998051866e8493

- Lint and production build passed; initial route 138 kB First Load JS.
- Worker tests: 28 passed. Browser suite with 4 workers: 9 passed, covering 320px entry, 390px chat/management, long messages, IME Enter, delayed replies, pending-send unmount, slow node, sign-out, and single-attempt failed HTTPS writes.
- Final-head Linux Build and Test, Windows native, macOS Top Smoke, session-component, GitGuardian and Workers preview all passed. Release-only jobs were skipped as expected. Linux run: https://github.com/eunomia-bpf/agentsight/actions/runs/33437327770
- Two independent exact-head reviews completed with zero blockers; see review comments below. No unresolved review threads or Copilot comments at final audit.
- At the prior 6cc6b51d head, compared identical gzip compression of initial referenced scripts: current production 188317 bytes; final local build 177938 bytes, a 5.5% reduction. This measures asset size, not physical-device load time.

## Visible-browser acceptance

- Opened the local build and deployed preview in real Chrome at a 390px viewport: all three tabs, wrapped messages, and composer fit without page-level horizontal overflow.
- Separately sent a harmless follow-up through the production browser UI in an isolated read-only test session using the existing Relay capability. HTTP 202 and the new user message in history were verified; the existing node completed with last_agent_message null, so a model response remains unverified.
- A Direct send against an older historical session returned gateway 502 without CORS headers; the old frontend retried the write. This PR removes automatic HTTPS write replay and covers draft preservation.
- Tab-scoped network overrides used to exercise Relay were cleared after testing. No credentials, permissions, or backend/provider configuration changed.

Preview: https://agentsight-preview.yunwei356.workers.dev/

No authentication, capability, organization or backend policy changes. Production has not been deployed or merged.

## Follow-up reduction

Reused existing statistic cards, session state badges and compact counts; consolidated independently guarded polling, session navigation and conversation mapping/empty states. Follow-up commit: five existing production files, +35/-81, net -46; regression tests untouched. Lint, build, 28 worker tests and 9 browser tests passed again. Two independent final-head reviews passed with zero blockers (see latest review comments). Local visible-browser demo checks confirmed statistics, session messages and return navigation.


